### PR TITLE
Stream parse

### DIFF
--- a/docs/reference/submit_transaction.md
+++ b/docs/reference/submit_transaction.md
@@ -4,13 +4,13 @@ title: submitTransaction()
 
 ## Overview
 
-You can build a transaction locally (see [this example](../readme.md#building-transactions)), but after you build it you have to submit it to the Stellar network.  js-stellar-sdk has a function `submitTransaction()` that sends your transaction to the Horizon server to be broadcast to the Stellar network.
+You can build a transaction locally (see [this example](../readme.md#building-transactions)), but after you build it you have to submit it to the Stellar network.  js-stellar-sdk has a function `submitTransaction()` that sends your transaction to the Horizon server (via the [`transactions_create`](https://stellar.org/developers/horizon/reference/transactions-create.html) endpoint) to be broadcast to the Stellar network.
 
-## Parameters
+## Methods
 
-| Parameter | Type | Description |
-| --- | --- | --- |
-| `transaction` | [`Transaction`](https://github.com/stellar/js-stellar-base/blob/master/src/transaction.js) | Transaction you want to submit to the network.|
+| Method | Horizon Endpoint | Param Type | Description |
+| --- | --- | --- | --- |
+| `submitTransaction(Transaction)` | [`transactions_create`](https://stellar.org/developers/horizon/reference/transactions-create.html) |  [`Transaction`](https://github.com/stellar/js-stellar-base/blob/master/src/transaction.js) | Submits a transaction to the network.
 
 ## Example
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "karma-sinon": "^1.0.4",
     "karma-sinon-chai": "^0.3.0",
     "karma-webpack": "^1.7.0",
+    "lodash": "^3.10.1",
     "mocha": "~1.17.1",
     "run-sequence": "^1.0.2",
     "sinon": "^1.14.1",

--- a/src/call_builder.js
+++ b/src/call_builder.js
@@ -47,8 +47,8 @@ export class CallBuilder {
     stream(options) {
         this.checkFilter();
         var es = new EventSource(this.url.toString());
-        es.onmessage = function (message) {
-            var result = message.data ? JSON.parse(message.data) : message;
+        es.onmessage = (message) => {
+            var result = message.data ? this._parseRecord(JSON.parse(message.data)) : message;
             options.onmessage(result);
         };
         es.onerror = options.onerror;
@@ -138,8 +138,8 @@ export class CallBuilder {
         }
     }
 
-    after(token) {
-        this.url.addQuery("after", token);
+    cursor(token) {
+        this.url.addQuery("cursor", token);
         return this;
     }
 

--- a/src/call_builder.js
+++ b/src/call_builder.js
@@ -80,7 +80,7 @@ export class CallBuilder {
     if (!json._links) {
       return json;
     }
-    _.mapKeys(json._links, (val, key) => {json[key] = this._requestFnForLink(val);});
+    _.forEach(json._links, (n, key) => {json[key] = this._requestFnForLink(n);});
     return json;
   }
   

--- a/src/call_builder.js
+++ b/src/call_builder.js
@@ -6,152 +6,150 @@ let URITemplate = require("URIjs").URITemplate;
 let axios = require("axios");
 var EventSource = (typeof window === 'undefined') ? require('eventsource') : window.EventSource;
 let toBluebird = require("bluebird").resolve;
+let _ = require('lodash');
 
 /**
 * @class Builder
 */
 export class CallBuilder {
 
-    /*
-    * @constructor
-    */
-    constructor(url) {
-        this.url = url;
-        this.filter = [];
-    }
+  /*
+  * @constructor
+  */
+  constructor(url) {
+    this.url = url;
+    this.filter = [];
+  }
 
-    checkFilter() {
-        if (this.filter.length >= 2) {
-            throw new BadRequestError("Too many filters specified", this.filter);
-        } 
-        if (this.filter.length === 1) {
-            this.url.segment(this.filter[0]);
-        }        
-    }
+  checkFilter() {
+    if (this.filter.length >= 2) {
+      throw new BadRequestError("Too many filters specified", this.filter);
+    } 
+    if (this.filter.length === 1) {
+      this.url.segment(this.filter[0]);
+    }        
+  }
 
-    /*
-    * Triggers a HTTP request using this builder's current configuration.
-    * Returns a Promise that resolves to the server's response.
-    */
-    call() {
-        this.checkFilter();
-        var promise = this._sendNormalRequest(this.url)
-            .then(r => this._parseResponse(r));
-        return promise;
-    }
+  /*
+  * Triggers a HTTP request using this builder's current configuration.
+  * Returns a Promise that resolves to the server's response.
+  */
+  call() {
+    this.checkFilter();
+    var promise = this._sendNormalRequest(this.url)
+      .then(r => this._parseResponse(r));
+    return promise;
+  }
 
-    /*
-    * Creates an Eventsource that listens for incoming messages from the server.
-    * URL based on builder's current configuration.
-    */
-    stream(options) {
-        this.checkFilter();
-        var es = new EventSource(this.url.toString());
-        es.onmessage = (message) => {
-            var result = message.data ? this._parseRecord(JSON.parse(message.data)) : message;
-            options.onmessage(result);
-        };
-        es.onerror = options.onerror;
-        return es;
-    }
+  /*
+  * Creates an Eventsource that listens for incoming messages from the server.
+  * URL based on builder's current configuration.
+  */
+  stream(options) {
+    this.checkFilter();
+    var es = new EventSource(this.url.toString());
+    es.onmessage = (message) => {
+      var result = message.data ? this._parseRecord(JSON.parse(message.data)) : message;
+      options.onmessage(result);
+    };
+    es.onerror = options.onerror;
+    return es;
+  }
 
-    /**
-    * Convert each link into a function on the response object.
-    */
-    _parseRecord(json) {
-        if (!json._links) {
-            return json;
-        }
-        var self = this;
-        var linkFn = function (link) {
-            return function (opts) {
-                if (link.template) {
-                    let template = URITemplate(link.href);
-                    return self._sendNormalRequest(URI(template.expand(opts))
-                        .authority(self.url.authority())
-                        .protocol(self.url.protocol())
-                        );
-                } else {
-                    return self._sendNormalRequest(URI(link.href)
-                        .authority(self.url.authority())
-                        .protocol(self.url.protocol())
-                        );
-                }
-            };
-        };
-        Object.keys(json._links).map(function(value, index) {
-            var link = json._links[value];
-            json[value] = linkFn(link);
-        });
-        return json;
-    }
-    
-    _sendNormalRequest(url) {
-        url.addQuery('c', Math.random());
-        var promise = axios.get(url.toString())
-            .then(response => response.data)
-            .catch(this._handleNetworkError);
-        return toBluebird(promise);
-    }
+  _requestFnForLink(link) {
+    return opts => {
+      if (link.template) {
+        let template = URITemplate(link.href);
+        return self._sendNormalRequest(URI(template.expand(opts))
+          .authority(self.url.authority())
+          .protocol(self.url.protocol())
+          );
+      } else {
+        return self._sendNormalRequest(URI(link.href)
+          .authority(self.url.authority())
+          .protocol(self.url.protocol())
+          );
+      }
+    };
+  } 
 
-    _parseResponse(json) {
-        if (json._embedded && json._embedded.records) {
-            return this._toCollectionPage(json);
-        } else {
-            return this._parseRecord(json);
-        }
+  /**
+  * Convert each link into a function on the response object.
+  */
+  _parseRecord(json) {
+    if (!json._links) {
+      return json;
     }
+    _.mapKeys(json._links, (val, key) => {json[key] = this._requestFnForLink(val);});
+    return json;
+  }
+  
+  _sendNormalRequest(url) {
+    url.addQuery('c', Math.random());
+    var promise = axios.get(url.toString())
+      .then(response => response.data)
+      .catch(this._handleNetworkError);
+    return toBluebird(promise);
+  }
 
-    _toCollectionPage(json) {
-        for (var i = 0; i < json._embedded.records.length; i++) {
-            json._embedded.records[i] = this._parseRecord(json._embedded.records[i]);
-        }
-        return {
-            records: json._embedded.records,
-            next: () => {
-                return this._sendNormalRequest(URI(json._links.next.href)
-                    .authority(this.url.authority())
-                    .protocol(this.url.protocol())
-                    )
-                    .then(r => this._toCollectionPage(r));
-            },
-            prev: () => {
-                return this._sendNormalRequest(URI(json._links.prev.href)
-                    .authority(this.url.authority())
-                    .protocol(this.url.protocol())
-                    )
-                    .then(r => this._toCollectionPage(r));
-            }
-        };
+  _parseResponse(json) {
+    if (json._embedded && json._embedded.records) {
+      return this._toCollectionPage(json);
+    } else {
+      return this._parseRecord(json);
     }
+  }
 
-    _handleNetworkError(response) {
-        if (response instanceof Error) {
-            return Promise.reject(response);
-        } else {
-            switch (response.status) {
-                case 404:
-                    return Promise.reject(new NotFoundError(response.data, response));
-                default:
-                    return Promise.reject(new NetworkError(response.status, response));
-            }
-        }
+  _toCollectionPage(json) {
+    for (var i = 0; i < json._embedded.records.length; i++) {
+      json._embedded.records[i] = this._parseRecord(json._embedded.records[i]);
     }
+    return {
+      records: json._embedded.records,
+      next: () => {
+        return this._sendNormalRequest(URI(json._links.next.href)
+          .authority(this.url.authority())
+          .protocol(this.url.protocol())
+          )
+          .then(r => this._toCollectionPage(r));
+      },
+      prev: () => {
+        return this._sendNormalRequest(URI(json._links.prev.href)
+          .authority(this.url.authority())
+          .protocol(this.url.protocol())
+          )
+          .then(r => this._toCollectionPage(r));
+      }
+    };
+  }
 
-    cursor(token) {
-        this.url.addQuery("cursor", token);
-        return this;
+  _handleNetworkError(response) {
+    if (response instanceof Error) {
+      return Promise.reject(response);
+    } else {
+      switch (response.status) {
+        case 404:
+          return Promise.reject(new NotFoundError(response.data, response));
+        default:
+          return Promise.reject(new NetworkError(response.status, response));
+      }
     }
+  }
 
-    limit(number) {
-        this.url.addQuery("limit", number);
-        return this;
-    }
+  cursor(token) {
+    this.url.addQuery("cursor", token);
+    return this;
+  }
 
-    order(direction) {
-        this.url.addQuery("order", direction);
-        return this;
-    }
+  limit(number) {
+    this.url.addQuery("limit", number);
+    return this;
+  }
+
+  order(direction) {
+    this.url.addQuery("order", direction);
+    return this;
+  }
 
 
 

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -79,14 +79,14 @@ describe("server.js tests", function () {
       describe("with options", function () {
         beforeEach(function() {
           this.axiosMock.expects('get')
-            .withArgs(sinon.match('https://horizon-live.stellar.org:1337/ledgers?limit=1&after=b&order=asc'))
+            .withArgs(sinon.match('https://horizon-live.stellar.org:1337/ledgers?limit=1&cursor=b&order=asc'))
             .returns(Promise.resolve({data: ledgersResponse}));
         });
 
         it("requests the correct endpoint", function (done) {
           this.server.ledgers()
             .limit("1")
-            .after("b")
+            .cursor("b")
             .order("asc")
             .call()
             .then(response => {
@@ -105,7 +105,7 @@ describe("server.js tests", function () {
           this.server
             .ledgers()
             .limit("1")
-            .after("b")
+            .cursor("b")
             .order("asc")
             .call()
             .then(function(page) {
@@ -205,13 +205,13 @@ describe("server.js tests", function () {
       describe("with options", function () {
         it("requests the correct endpoint", function (done) {
           this.axiosMock.expects('get')
-            .withArgs(sinon.match('https://horizon-live.stellar.org:1337/ledgers/1?limit=1&after=b&order=asc'))
+            .withArgs(sinon.match('https://horizon-live.stellar.org:1337/ledgers/1?limit=1&cursor=b&order=asc'))
             .returns(Promise.resolve({data: singleLedgerResponse}));
 
           this.server.ledgers()
             .ledger("1")
             .limit("1")
-            .after("b")
+            .cursor("b")
             .order("asc")
             .call()
             .then(function (response) {
@@ -309,12 +309,12 @@ describe("server.js tests", function () {
       describe("with options", function () {
         it("requests the correct endpoint", function (done) {
           this.axiosMock.expects('get')
-            .withArgs(sinon.match('https://horizon-live.stellar.org:1337/ledgers/1/transactions?after=b&limit=1&order=asc'))
+            .withArgs(sinon.match('https://horizon-live.stellar.org:1337/ledgers/1/transactions?cursor=b&limit=1&order=asc'))
             .returns(Promise.resolve({data: transactionsResponse}));
 
           this.server.transactions()
             .forLedger("1")
-            .after("b")
+            .cursor("b")
             .limit("1")
             .order("asc")
             .call()
@@ -576,11 +576,11 @@ describe("server.js tests", function () {
 
       it("requests the correct endpoint", function (done) {
         this.axiosMock.expects('get')
-          .withArgs(sinon.match('https://horizon-live.stellar.org:1337/effects?after=b'))
+          .withArgs(sinon.match('https://horizon-live.stellar.org:1337/effects?cursor=b'))
           .returns(Promise.resolve({data: effectsResponse}));
 
         this.server.effects()
-          .after("b")
+          .cursor("b")
           .call()
           .then(function (response) {
             expect(response.records).to.be.deep.equal(effectsResponse._embedded.records);


### PR DESCRIPTION
1) Changed "after" to "cursor" to reflect changes in Horizon
2) Refactored _parseRecord as in #29 
3) Fixed stream() so it parses messages and their links (e.g., so you can follow the transactions() link)
4) Explained that submitTransactions() hits the create_transactions endpoint.