### PR TITLE
Disallow insecure servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ As this project is pre 1.0, breaking changes may happen for minor version bumps.
 
 * **Breaking change** `Server` and `FederationServer` constructors no longer accept object as `serverUrl` parameter.
 * **Breaking change** Removed `AccountCallBuilder.address` method. Use `AccountCallBuilder.accountId` instead.
+* **Breaking change** It's no longer possible to connect to insecure server in `Server` or `FederationServer` unless `allowHttp` flag in `opts` is set.
 
-## next patch - unreleased
+## Unreleased
 
 * Added tests.
 * Added `CHANGELOG.md` file.

--- a/src/federation_server.js
+++ b/src/federation_server.js
@@ -13,11 +13,17 @@ export class FederationServer {
    * @constructor
    * @param {string} serverURL The federation server URL (ex. `https://acme.com/federation`).
    * @param {string} domain Domain this server represents
+   * @param {object} [opts]
+   * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments!
    */
-  constructor(serverURL, domain) {
+  constructor(serverURL, domain, opts = {}) {
     // TODO `domain` regexp
     this.serverURL = URI(serverURL);
     this.domain = domain;
+
+    if (this.serverURL.protocol() != 'https' && !opts.allowHttp) {
+      throw new Error('Cannot connect to insecure federation server');
+    }
   }
 
   /**

--- a/src/server.js
+++ b/src/server.js
@@ -27,9 +27,15 @@ export class Server {
      * instance and exposes an interface for requests to that instance.
      * @constructor
      * @param {string} serverURL Horizon Server URL (ex. `https://horizon-testnet.stellar.org`).
+     * @param {object} [opts]
+     * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments!
      */
-    constructor(serverURL) {
+    constructor(serverURL, opts = {}) {
         this.serverURL = URI(serverURL);
+
+        if (this.serverURL.protocol() != 'https' && !opts.allowHttp) {
+            throw new Error('Cannot connect to insecure horizon server');
+        }
     }
 
     /**

--- a/test/integration/server_test.js
+++ b/test/integration/server_test.js
@@ -5,8 +5,8 @@ describe("integration tests", function () {
   this.slow(TIMEOUT/2);
 
   // Docker
-  let server = new StellarSdk.Server('http://127.0.0.1:8000');
-  //let server = new StellarSdk.Server('http://192.168.59.103:32773');
+  let server = new StellarSdk.Server('http://127.0.0.1:8000', {allowHttp: true});
+  //let server = new StellarSdk.Server('http://192.168.59.103:32773', {allowHttp: true});
   let master = StellarSdk.Keypair.master();
 
   before(function(done) {

--- a/test/unit/federation_server_test.js
+++ b/test/unit/federation_server_test.js
@@ -9,6 +9,16 @@ describe("federation-server.js tests", function () {
     this.axiosMock.restore();
   });
 
+  describe('FederationServer.constructor', function () {
+    it("throws error for insecure server", function () {
+      expect(() => new StellarSdk.FederationServer('http://acme.com:1337/federation', 'stellar.org')).to.throw(/Cannot connect to insecure federation server/);
+    });
+
+    it("allow insecure server when opts.allowHttp flag is set", function () {
+      expect(() => new StellarSdk.FederationServer('http://acme.com:1337/federation', 'stellar.org', {allowHttp: true})).to.not.throw();
+    });
+  });
+
   describe('FederationServer.resolveAddress', function () {
     beforeEach(function () {
       this.axiosMock.expects('get')

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -9,6 +9,16 @@ describe("server.js tests", function () {
     this.axiosMock.restore();
   });
 
+  describe('Server.constructor', function () {
+    it("throws error for insecure server", function () {
+      expect(() => new StellarSdk.Server('http://horizon-live.stellar.org:1337')).to.throw(/Cannot connect to insecure horizon server/);
+    });
+
+    it("allow insecure server when opts.allowHttp flag is set", function () {
+      expect(() => new StellarSdk.Server('http://horizon-live.stellar.org:1337', {allowHttp: true})).to.not.throw();
+    });
+  });
+
   describe('Server._sendResourceRequest', function () {
 
     describe("requests all ledgers", function () {


### PR DESCRIPTION
Disallow insecure servers in `Server` and `FederationServer` unless `allowHttp` flag in `opts` is set.

This is a breaking change so the target branch is next minor (0.5.0).