### PR TITLE
Server.loadAccount account changes

### DIFF
--- a/src/account_call_builder.js
+++ b/src/account_call_builder.js
@@ -27,6 +27,4 @@ export class AccountCallBuilder extends CallBuilder {
       this.filter.push(['accounts', id]);
       return this;
     }
-
-
 }

--- a/src/account_response.js
+++ b/src/account_response.js
@@ -1,0 +1,46 @@
+import {Account as BaseAccount} from "stellar-base";
+import forIn from "lodash/forIn";
+
+export class AccountResponse {
+    /**
+     * Do not create this object directly, use {@link Server#loadAccount}.
+     *
+     * Returns information and links relating to a single account.
+     * The balances section in the returned JSON will also list all the trust lines this account has set up.
+     * It also contains {@link Account} object and exposes it's methods so can be used in {@link TransactionBuilder}.
+     *
+     * @see [Account Details](https://www.stellar.org/developers/horizon/reference/accounts-single.html)
+     * @param {string} response Response from horizon account endpoint.
+     * @returns {AccountResponse}
+     */
+	constructor(response) {
+		this._baseAccount = new BaseAccount(response.account_id, response.sequence);
+        // Extract response fields
+        forIn(response, (value, key) => {
+            this[key] = value;
+        });
+	}
+
+	/**
+     * Returns Stellar account ID, ex. `GB3KJPLFUYN5VL6R3GU3EGCGVCKFDSD7BEDX42HWG5BWFKB3KQGJJRMA`
+     * @returns {string}
+     */
+    accountId() {
+        return this._baseAccount.accountId();
+    }
+
+    /**
+     * @returns {string}
+     */
+    sequenceNumber() {
+        return this._baseAccount.sequenceNumber();
+    }
+
+    /**
+     * Increments sequence number in this object by one.
+     */
+    incrementSequenceNumber() {
+        this._baseAccount.incrementSequenceNumber();
+        this.sequence = this._baseAccount.sequenceNumber();
+    }
+}

--- a/src/account_response.js
+++ b/src/account_response.js
@@ -13,15 +13,15 @@ export class AccountResponse {
      * @param {string} response Response from horizon account endpoint.
      * @returns {AccountResponse}
      */
-	constructor(response) {
-		this._baseAccount = new BaseAccount(response.account_id, response.sequence);
+    constructor(response) {
+        this._baseAccount = new BaseAccount(response.account_id, response.sequence);
         // Extract response fields
         forIn(response, (value, key) => {
             this[key] = value;
         });
-	}
+    }
 
-	/**
+    /**
      * Returns Stellar account ID, ex. `GB3KJPLFUYN5VL6R3GU3EGCGVCKFDSD7BEDX42HWG5BWFKB3KQGJJRMA`
      * @returns {string}
      */

--- a/src/call_builder.js
+++ b/src/call_builder.js
@@ -193,7 +193,4 @@ export class CallBuilder {
     this.url.addQuery("order", direction);
     return this;
   }
-
-
-
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 import {NotFoundError, NetworkError, BadRequestError} from "./errors";
 
 import {AccountCallBuilder} from "./account_call_builder";
+import {AccountResponse} from "./account_response";
 import {LedgerCallBuilder} from "./ledger_call_builder";
 import {TransactionCallBuilder} from "./transaction_call_builder";
 import {OperationCallBuilder} from "./operation_call_builder";
@@ -10,9 +11,8 @@ import {PathCallBuilder} from "./path_call_builder";
 import {PaymentCallBuilder} from "./payment_call_builder";
 import {EffectCallBuilder} from "./effect_call_builder";
 import {FriendbotBuilder} from "./friendbot_builder";
-import {xdr, Account} from "stellar-base";
-
-import {isString} from "lodash";
+import {xdr} from "stellar-base";
+import isString from "lodash/isString";
 
 let axios = require("axios");
 let toBluebird = require("bluebird").resolve;
@@ -178,17 +178,14 @@ export class Server {
     /**
     * Fetches an account's most current state in the ledger and then creates and returns an {@link Account} object.
     * @param {string} accountId - The account to load.
-    * @returns {Promise} Returns a promise to the {@link Account} object with populated sequence number.
+    * @returns {Promise} Returns a promise to the {@link AccountResponse} object with populated sequence number.
     */
     loadAccount(accountId) {
         return this.accounts()
             .accountId(accountId)
             .call()
             .then(function (res) {
-                return new Account(accountId, res.sequence);
+                return new AccountResponse(res);
             });
     }
-
 }
-
- 

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -19,6 +19,112 @@ describe("server.js tests", function () {
     });
   });
 
+  describe('Server.loadAccount', function () {
+    let accountResponse = {
+      "_links": {
+        "self": {
+          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS"
+        },
+        "transactions": {
+          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/transactions{?cursor,limit,order}",
+          "templated": true
+        },
+        "operations": {
+          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/operations{?cursor,limit,order}",
+          "templated": true
+        },
+        "payments": {
+          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/payments{?cursor,limit,order}",
+          "templated": true
+        },
+        "effects": {
+          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/effects{?cursor,limit,order}",
+          "templated": true
+        },
+        "offers": {
+          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/offers{?cursor,limit,order}",
+          "templated": true
+        }
+      },
+      "id": "GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS",
+      "paging_token": "5387216134082561",
+      "account_id": "GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS",
+      "sequence": "5387216134078475",
+      "subentry_count": 5,
+      "thresholds": {
+        "low_threshold": 0,
+        "med_threshold": 0,
+        "high_threshold": 0
+      },
+      "flags": {
+        "auth_required": false,
+        "auth_revocable": false
+      },
+      "balances": [
+        {
+          "balance": "0.0000000",
+          "limit": "922337203685.4775807",
+          "asset_type": "credit_alphanum4",
+          "asset_code": "AAA",
+          "asset_issuer": "GAX4CUJEOUA27MDHTLSQCFRGQPEXCC6GMO2P2TZCG7IEBZIEGPOD6HKF"
+        },
+        {
+          "balance": "5000.0000000",
+          "limit": "922337203685.4775807",
+          "asset_type": "credit_alphanum4",
+          "asset_code": "MDL",
+          "asset_issuer": "GAX4CUJEOUA27MDHTLSQCFRGQPEXCC6GMO2P2TZCG7IEBZIEGPOD6HKF"
+        },
+        {
+          "balance": "10000.0000000",
+          "limit": "922337203685.4775807",
+          "asset_type": "credit_alphanum4",
+          "asset_code": "USD",
+          "asset_issuer": "GAX4CUJEOUA27MDHTLSQCFRGQPEXCC6GMO2P2TZCG7IEBZIEGPOD6HKF"
+        },
+        {
+          "balance": "70.0998900",
+          "asset_type": "native"
+        }
+      ],
+      "signers": [
+        {
+          "public_key": "GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS",
+          "weight": 1
+        }
+      ],
+      "data": {}
+    };
+
+    it("returns AccountResponse object", function (done) {
+      this.axiosMock.expects('get')
+        .withArgs(sinon.match('https://horizon-live.stellar.org:1337/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS'))
+        .returns(Promise.resolve({data: accountResponse}));
+
+      this.server.loadAccount("GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS")
+        .then(response => {
+          // Response data
+          expect(response.account_id).to.be.equal("GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS");
+          expect(response.subentry_count).to.be.equal(5);
+          expect(response.transactions).to.be.function;
+          expect(response.operations).to.be.function;
+          expect(response.payments).to.be.function;
+          expect(response.effects).to.be.function;
+          expect(response.offers).to.be.function;
+          // AccountResponse methods
+          expect(response.sequenceNumber()).to.be.equal("5387216134078475");
+          expect(response.sequence).to.be.equal("5387216134078475");
+          response.incrementSequenceNumber()
+          expect(response.sequenceNumber()).to.be.equal("5387216134078476");
+          expect(response.sequence).to.be.equal("5387216134078476");
+          done();
+        })
+        .catch(function (err) {
+          done(err);
+        });
+    })
+  });
+
   describe('Server._sendResourceRequest', function () {
 
     describe("requests all ledgers", function () {


### PR DESCRIPTION
As suggested in https://github.com/stellar/js-stellar-sdk/issues/66 `Server.loadAccount` returns full response now but also allows using the returned object in `TransactionBuilder`.

Because it's a breaking change, this should be merged into `0.5.0` branch.

Close https://github.com/stellar/js-stellar-sdk/issues/66