### PR TITLE
StellarTomlResolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "es6-promise": "^3.0.2",
     "event-source-polyfill": "0.0.7",
     "eventsource": "^0.2.1",
-    "jsdoc": "jsdoc3/jsdoc#master",
+    "jsdoc": "^3.4.1",
     "lodash": "^4.0.1",
     "stellar-base": "^0.6.0",
     "toml": "^2.3.0"

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,52 @@
+import clone from 'lodash/clone';
+
+let defaultConfig = {
+  allowHttp: false
+}
+
+let config = clone(defaultConfig);
+
+/**
+ * Global config class.
+ *
+ * Usage node:
+ * ```
+ * import {Config} from 'stellar-sdk';
+ * Config.setAllowHttp(true);
+ * ```
+ *
+ * Usage browser:
+ * ```
+ * StellarSdk.Config.setAllowHttp(true);
+ * ```
+ * @static
+ */
+class Config {
+  /**
+   * Sets `allowHttp` flag globally. When set to `true`, connections to insecure http protocol servers will be allowed.
+   * Must be set to `false` in production. Default: `false`.
+   * @param {boolean} value
+   * @static
+   */
+  static setAllowHttp(value) {
+    config.allowHttp = value;
+  }
+
+  /**
+   * Returns the value of `allowHttp` flag.
+   * @static
+   */
+  static isAllowHttp() {
+    return clone(config.allowHttp);
+  }
+
+  /**
+   * Sets all global config flags to default values.
+   * @static
+   */
+  static setDefault() {
+    config = clone(defaultConfig);
+  }
+}
+
+export {Config};

--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,7 @@ import clone from 'lodash/clone';
 
 let defaultConfig = {
   allowHttp: false
-}
+};
 
 let config = clone(defaultConfig);
 

--- a/src/federation_server.js
+++ b/src/federation_server.js
@@ -108,12 +108,12 @@ export class FederationServer {
    * @returns {Promise}
    */
   static createForDomain(domain, opts = {}) {
-    return StellarTomlResolver.resolve(domain, opts)
+    return StellarTomlResolver.resolve(domain)
       .then(tomlObject => {
         if (!tomlObject.FEDERATION_SERVER) {
           return Promise.reject(new Error('stellar.toml does not contain FEDERATION_SERVER field'));
         }
-        return new FederationServer(tomlObject.FEDERATION_SERVER, domain);
+        return new FederationServer(tomlObject.FEDERATION_SERVER, domain, opts);
       });
   }
 

--- a/src/federation_server.js
+++ b/src/federation_server.js
@@ -3,6 +3,7 @@ import URI from 'urijs';
 import Promise from 'bluebird';
 import isString from "lodash/isString";
 import pick from "lodash/pick";
+import {Config} from "./config";
 import {Account, Keypair} from 'stellar-base';
 import {StellarTomlResolver} from "./stellar_toml_resolver";
 
@@ -15,14 +16,19 @@ export class FederationServer {
    * @param {string} serverURL The federation server URL (ex. `https://acme.com/federation`).
    * @param {string} domain Domain this server represents
    * @param {object} [opts]
-   * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments!
+   * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments! You can also use {@link Config} class to set this globally.
    */
   constructor(serverURL, domain, opts = {}) {
     // TODO `domain` regexp
     this.serverURL = URI(serverURL);
     this.domain = domain;
 
-    if (this.serverURL.protocol() != 'https' && !opts.allowHttp) {
+    let allowHttp = Config.isAllowHttp();
+    if (typeof opts.allowHttp !== 'undefined') {
+        allowHttp = opts.allowHttp;
+    }
+
+    if (this.serverURL.protocol() != 'https' && !allowHttp) {
       throw new Error('Cannot connect to insecure federation server');
     }
   }

--- a/src/federation_server.js
+++ b/src/federation_server.js
@@ -1,10 +1,10 @@
 import axios from 'axios';
 import URI from 'urijs';
 import Promise from 'bluebird';
-import toml from 'toml';
 import isString from "lodash/isString";
 import pick from "lodash/pick";
 import {Account, Keypair} from 'stellar-base';
+import {StellarTomlResolver} from "./stellar_toml_resolver";
 
 export class FederationServer {
   /**
@@ -59,9 +59,11 @@ export class FederationServer {
    * @see <a href="https://www.stellar.org/developers/learn/concepts/federation.html" target="_blank">Federation doc</a>
    * @see <a href="https://www.stellar.org/developers/learn/concepts/stellar-toml.html" target="_blank">Stellar.toml doc</a>
    * @param {string} value Stellar Address (ex. `bob*stellar.org`)
+   * @param {object} [opts]
+   * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments!
    * @returns {Promise}
    */
-  static resolve(value) {
+  static resolve(value, opts = {}) {
     // Check if `value` is in account ID format
     if (value.indexOf('*') < 0) {
       if (!Keypair.isValidPublicKey(value)) {
@@ -76,7 +78,7 @@ export class FederationServer {
       if (addressParts.length != 2 || !domain) {
         return Promise.reject(new Error('Invalid Stellar address'));
       }
-      return FederationServer.createForDomain(domain)
+      return FederationServer.createForDomain(domain, opts)
         .then(federationServer => federationServer.resolveAddress(value));
     }
   }
@@ -95,12 +97,13 @@ export class FederationServer {
    * ```
    * @see <a href="https://www.stellar.org/developers/learn/concepts/stellar-toml.html" target="_blank">Stellar.toml doc</a>
    * @param {string} domain Domain to get federation server for
+   * @param {object} [opts]
+   * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments!
    * @returns {Promise}
    */
-  static createForDomain(domain) {
-    return axios.get(`https://www.${domain}/.well-known/stellar.toml`)
-      .then(response => {
-        let tomlObject = toml.parse(response.data);
+  static createForDomain(domain, opts = {}) {
+    return StellarTomlResolver.resolve(domain, opts)
+      .then(tomlObject => {
         if (!tomlObject.FEDERATION_SERVER) {
           return Promise.reject(new Error('stellar.toml does not contain FEDERATION_SERVER field'));
         }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ require('es6-promise').polyfill();
 
 // stellar-sdk classes to expose
 export * from "./errors";
+export {Config} from "./config";
 export {Server} from "./server";
 export {FederationServer} from "./federation_server";
 export {StellarTomlResolver} from "./stellar_toml_resolver";

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ require('es6-promise').polyfill();
 export * from "./errors";
 export {Server} from "./server";
 export {FederationServer} from "./federation_server";
+export {StellarTomlResolver} from "./stellar_toml_resolver";
 
 // expose classes and functions from stellar-base
 export * from "stellar-base";

--- a/src/server.js
+++ b/src/server.js
@@ -2,6 +2,7 @@ import {NotFoundError, NetworkError, BadRequestError} from "./errors";
 
 import {AccountCallBuilder} from "./account_call_builder";
 import {AccountResponse} from "./account_response";
+import {Config} from "./config";
 import {LedgerCallBuilder} from "./ledger_call_builder";
 import {TransactionCallBuilder} from "./transaction_call_builder";
 import {OperationCallBuilder} from "./operation_call_builder";
@@ -28,12 +29,17 @@ export class Server {
      * @constructor
      * @param {string} serverURL Horizon Server URL (ex. `https://horizon-testnet.stellar.org`).
      * @param {object} [opts]
-     * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments!
+     * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments! You can also use {@link Config} class to set this globally.
      */
     constructor(serverURL, opts = {}) {
         this.serverURL = URI(serverURL);
 
-        if (this.serverURL.protocol() != 'https' && !opts.allowHttp) {
+        let allowHttp = Config.isAllowHttp();
+        if (typeof opts.allowHttp !== 'undefined') {
+            allowHttp = opts.allowHttp;
+        }
+
+        if (this.serverURL.protocol() != 'https' && !allowHttp) {
             throw new Error('Cannot connect to insecure horizon server');
         }
     }

--- a/src/stellar_toml_resolver.js
+++ b/src/stellar_toml_resolver.js
@@ -1,0 +1,39 @@
+import axios from 'axios';
+import Promise from 'bluebird';
+import toml from 'toml';
+
+export class StellarTomlResolver {
+  /**
+   * Returns a parsed `stellar.toml` file for a given domain.
+   * Returns a `Promise` that resolves to the parsed stellar.toml object. If `stellar.toml` file does not exist for a given domain or is invalid Promise will reject.
+   * ```js
+   * StellarSdk.StellarTomlResolver.resolve('acme.com')
+   *   .then(stellarToml => {
+   *     // stellarToml in an object representing domain stellar.toml file.
+   *   })
+   *   .catch(error => {
+   *     // stellar.toml does not exist or is invalid
+   *   });
+   * ```
+   * @see <a href="https://www.stellar.org/developers/learn/concepts/stellar-toml.html" target="_blank">Stellar.toml doc</a>
+   * @param {string} domain Domain to get stellar.toml file for
+   * @param {object} [opts]
+   * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments!
+   * @returns {Promise}
+   */
+  static resolve(domain, opts = {}) {
+    let protocol = 'https';
+    if (opts.allowHttp) {
+        protocol = 'http';
+    }
+    return axios.get(`${protocol}://www.${domain}/.well-known/stellar.toml`)
+      .then(response => {
+      	try {
+            let tomlObject = toml.parse(response.data);
+            return Promise.resolve(tomlObject);
+        } catch (e) {
+            return Promise.reject(`Parsing error on line ${e.line}, column ${e.column}: ${e.message}`);
+        }
+      });
+  }
+}

--- a/src/stellar_toml_resolver.js
+++ b/src/stellar_toml_resolver.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import Promise from 'bluebird';
 import toml from 'toml';
+import {Config} from "./config";
 
 export class StellarTomlResolver {
   /**
@@ -22,8 +23,13 @@ export class StellarTomlResolver {
    * @returns {Promise}
    */
   static resolve(domain, opts = {}) {
+    let allowHttp = Config.isAllowHttp();
+    if (typeof opts.allowHttp !== 'undefined') {
+        allowHttp = opts.allowHttp;
+    }
+
     let protocol = 'https';
-    if (opts.allowHttp) {
+    if (allowHttp) {
         protocol = 'http';
     }
     return axios.get(`${protocol}://www.${domain}/.well-known/stellar.toml`)

--- a/test/unit/federation_server_test.js
+++ b/test/unit/federation_server_test.js
@@ -2,6 +2,7 @@ describe("federation-server.js tests", function () {
   beforeEach(function () {
     this.server = new StellarSdk.FederationServer('https://acme.com:1337/federation', 'stellar.org');
     this.axiosMock = sinon.mock(axios);
+    StellarSdk.Config.setDefault();
   });
 
   afterEach(function () {
@@ -15,6 +16,11 @@ describe("federation-server.js tests", function () {
     });
 
     it("allow insecure server when opts.allowHttp flag is set", function () {
+      expect(() => new StellarSdk.FederationServer('http://acme.com:1337/federation', 'stellar.org', {allowHttp: true})).to.not.throw();
+    });
+
+    it("allow insecure server when global Config.allowHttp flag is set", function () {
+      StellarSdk.Config.setAllowHttp(true);
       expect(() => new StellarSdk.FederationServer('http://acme.com:1337/federation', 'stellar.org', {allowHttp: true})).to.not.throw();
     });
   });

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -2,6 +2,7 @@ describe("server.js tests", function () {
   beforeEach(function () {
     this.server = new StellarSdk.Server('https://horizon-live.stellar.org:1337');
     this.axiosMock = sinon.mock(axios);
+    StellarSdk.Config.setDefault();
   });
 
   afterEach(function () {
@@ -16,6 +17,11 @@ describe("server.js tests", function () {
 
     it("allow insecure server when opts.allowHttp flag is set", function () {
       expect(() => new StellarSdk.Server('http://horizon-live.stellar.org:1337', {allowHttp: true})).to.not.throw();
+    });
+
+    it("allow insecure server when global Config.allowHttp flag is set", function () {
+      StellarSdk.Config.setAllowHttp(true);
+      expect(() => new StellarSdk.Server('http://horizon-live.stellar.org:1337')).to.not.throw();
     });
   });
 

--- a/test/unit/stellar_toml_resolver_test.js
+++ b/test/unit/stellar_toml_resolver_test.js
@@ -1,0 +1,70 @@
+describe("stellar_toml_resolver.js tests", function () {
+  beforeEach(function () {
+    this.axiosMock = sinon.mock(axios);
+  });
+
+  afterEach(function () {
+    this.axiosMock.verify();
+    this.axiosMock.restore();
+  });
+
+  describe('StellarTomlResolver.resolve', function () {
+    it("returns stellar.toml object for valid request and stellar.toml file", function (done) {
+      this.axiosMock.expects('get')
+        .withArgs(sinon.match('https://www.acme.com/.well-known/stellar.toml'))
+        .returns(Promise.resolve({
+          data: `
+#   The endpoint which clients should query to resolve stellar addresses
+#   for users on your domain.
+FEDERATION_SERVER="https://api.stellar.org/federation"
+`
+        }));
+
+      StellarSdk.StellarTomlResolver.resolve('acme.com')
+        .then(stellarToml => {
+          expect(stellarToml.FEDERATION_SERVER).equals('https://api.stellar.org/federation');
+          done();
+        });
+    });
+
+    it("returns stellar.toml object for valid request and stellar.toml file when allowHttp is `true`", function (done) {
+      this.axiosMock.expects('get')
+        .withArgs(sinon.match('http://www.acme.com/.well-known/stellar.toml'))
+        .returns(Promise.resolve({
+          data: `
+#   The endpoint which clients should query to resolve stellar addresses
+#   for users on your domain.
+FEDERATION_SERVER="http://api.stellar.org/federation"
+`
+        }));
+
+      StellarSdk.StellarTomlResolver.resolve('acme.com', {allowHttp: true})
+        .then(stellarToml => {
+          expect(stellarToml.FEDERATION_SERVER).equals('http://api.stellar.org/federation');
+          done();
+        });
+    });
+
+    it("rejects when stellar.toml file is invalid", function (done) {
+      this.axiosMock.expects('get')
+        .withArgs(sinon.match('https://www.acme.com/.well-known/stellar.toml'))
+        .returns(Promise.resolve({
+          data: `
+/#   The endpoint which clients should query to resolve stellar addresses
+#   for users on your domain.
+FEDERATION_SERVER="https://api.stellar.org/federation"
+`
+        }));
+
+      StellarSdk.StellarTomlResolver.resolve('acme.com').should.be.rejectedWith(/Parsing error on line/).and.notify(done);
+    });
+
+    it("rejects when there was a connection error", function (done) {
+      this.axiosMock.expects('get')
+        .withArgs(sinon.match('https://www.acme.com/.well-known/stellar.toml'))
+        .returns(Promise.reject());
+
+      StellarSdk.StellarTomlResolver.resolve('acme.com').should.be.rejected.and.notify(done);
+    });
+  });
+});

--- a/test/unit/stellar_toml_resolver_test.js
+++ b/test/unit/stellar_toml_resolver_test.js
@@ -1,6 +1,7 @@
 describe("stellar_toml_resolver.js tests", function () {
   beforeEach(function () {
     this.axiosMock = sinon.mock(axios);
+    StellarSdk.Config.setDefault();
   });
 
   afterEach(function () {
@@ -39,6 +40,26 @@ FEDERATION_SERVER="http://api.stellar.org/federation"
         }));
 
       StellarSdk.StellarTomlResolver.resolve('acme.com', {allowHttp: true})
+        .then(stellarToml => {
+          expect(stellarToml.FEDERATION_SERVER).equals('http://api.stellar.org/federation');
+          done();
+        });
+    });
+
+    it("returns stellar.toml object for valid request and stellar.toml file when global Config.allowHttp flag is set", function (done) {
+      StellarSdk.Config.setAllowHttp(true);
+
+      this.axiosMock.expects('get')
+        .withArgs(sinon.match('http://www.acme.com/.well-known/stellar.toml'))
+        .returns(Promise.resolve({
+          data: `
+#   The endpoint which clients should query to resolve stellar addresses
+#   for users on your domain.
+FEDERATION_SERVER="http://api.stellar.org/federation"
+`
+        }));
+
+      StellarSdk.StellarTomlResolver.resolve('acme.com')
         .then(stellarToml => {
           expect(stellarToml.FEDERATION_SERVER).equals('http://api.stellar.org/federation');
           done();


### PR DESCRIPTION
This PR introduces `StellarTomlResolver` that is responsible for downloading and parsing [`stellar.toml`](https://www.stellar.org/developers/guides/concepts/stellar-toml.html) files. The API is simple:
```js
StellarSdk.StellarTomlResolver.resolve('acme.com')
  .then(stellarToml => {
    console.log(stellarToml.FEDERATION_SERVER);
    console.log(stellarToml.CURRENCIES);
  });
```
The second parameter in `resolve` method: `opts` allows setting `allowHttp` option, that will download `stellar.toml` file over `http` protocol (instead of `https`).