### PR TITLE
Add timeout to CallBuilder.stream() method

### DIFF
--- a/test/integration/server_test.js
+++ b/test/integration/server_test.js
@@ -90,8 +90,7 @@ describe("integration tests", function () {
       this.timeout(10*1000);
       let randomAccount = StellarSdk.Keypair.random();
 
-      let eventStream;
-      eventStream = server.accounts()
+      let eventStreamClose = server.accounts()
         .cursor('now')
         .stream({
           onmessage: account => {
@@ -101,7 +100,7 @@ describe("integration tests", function () {
         });
 
       createNewAccount(randomAccount.accountId());
-      setTimeout(() => eventStream.close(), 10*1000);
+      setTimeout(() => eventStreamClose(), 10*1000);
     });
   });
 });

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -128,21 +128,6 @@ describe("server.js tests", function () {
             });
         });
       });
-
-      describe("as stream", function () {
-        it("attaches onmessage handler to an EventSource", function (done) {
-          let eventSource = this.server.ledgers()
-            .stream({
-              onmessage: function (res) {
-                eventSource.close();
-                expect(res.test).to.be.equal("body");
-                done();
-              }
-            });
-
-          eventSource.onmessage({data: '{"test": "body"}'});
-        });
-      });
     });
 
     describe("requests a single ledger", function () {
@@ -337,21 +322,6 @@ describe("server.js tests", function () {
             .catch(function (err) {
               done(err);
             })
-        });
-      });
-      describe("as stream", function () {
-        it("attaches onmessage handler to an EventSource", function (done) {
-          var eventSource = this.server.transactions()
-            .forLedger("1")
-            .stream({
-              onmessage: function (res) {
-                eventSource.close();
-                expect(res.test).to.be.equal("body");
-                done();
-              }
-            });
-
-          eventSource.onmessage({data: '{"test": "body"}'});
         });
       });
     });


### PR DESCRIPTION
This PR introduces rebuilt `CallBuilder.stream()` method. The specification for `EventSource` states that it should [*fail the connection*](https://www.w3.org/TR/2012/WD-eventsource-20120426/#fail-the-connection) (not attempt to reconnect) after receiving HTTP status code other than 200, 305, 401, 407, 301, 302, 303, and 307.

This is problematic because when horizon is behind a proxy server, it may fail with 504 Gateway Timeout when there are no new events for a long period of time and we want to reconnect if such event occurs.

The first attempt to fix this was using `readyState` property of the `EventSource` object. The problem is the value of this property does not follow the spec (ex. it does not equal CLOSED when connection is closed).

In the solution proposed in this PR, we create a timeout (right now set to 15 seconds) along with a new `EventSource` object. If no messages appear, timeout function is called and restarts the connection. When new message arrives, timeout is cancelled and set again.

Because of the fact that we create new `EventSource` objects the `stream()` method returns the `close` function that closes the latest internal `EventSource` object and cancells the timeout.

Unfortunatelly, there is still a case when some events may be omited. Let's say that a user streams the latest transactions with the cursor: `now`. There is a small time window during reconnect phase when the stream is stopped. This can be solved, however, by sending some `init` message with the latest `paging_token` by horizon.

Close https://github.com/stellar/js-stellar-sdk/issues/74