### PR TITLE
Limit federation and stellar.toml responses length

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,8 @@ require('es6-promise').polyfill();
 export * from "./errors";
 export {Config} from "./config";
 export {Server} from "./server";
-export {FederationServer} from "./federation_server";
-export {StellarTomlResolver} from "./stellar_toml_resolver";
+export {FederationServer, FEDERATION_RESPONSE_MAX_SIZE} from "./federation_server";
+export {StellarTomlResolver, STELLAR_TOML_MAX_SIZE} from "./stellar_toml_resolver";
 
 // expose classes and functions from stellar-base
 export * from "stellar-base";

--- a/src/stellar_toml_resolver.js
+++ b/src/stellar_toml_resolver.js
@@ -3,6 +3,9 @@ import Promise from 'bluebird';
 import toml from 'toml';
 import {Config} from "./config";
 
+// STELLAR_TOML_MAX_SIZE is the maximum size of stellar.toml file
+export const STELLAR_TOML_MAX_SIZE = 5 * 1024;
+
 /**
  * StellarTomlResolver allows resolving `stellar.toml` files.
  */
@@ -35,7 +38,7 @@ export class StellarTomlResolver {
     if (allowHttp) {
         protocol = 'http';
     }
-    return axios.get(`${protocol}://${domain}/.well-known/stellar.toml`)
+    return axios.get(`${protocol}://${domain}/.well-known/stellar.toml`, {maxContentLength: STELLAR_TOML_MAX_SIZE})
       .then(response => {
       	try {
             let tomlObject = toml.parse(response.data);


### PR DESCRIPTION
* Limit length of federation server and stellar.toml responses.
* Throw error if `memo` is not of type `string` in federation response.