### PR TITLE
Throw BadResponseErrors instead of plain response data objects

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -14,6 +14,7 @@ Error.subclass = function(errorName) {
 export var NetworkError = Error.subclass("NetworkError");
 export var NotFoundError = NetworkError.subclass("NotFoundError");
 export var BadRequestError = Error.subclass("BadRequestError");
+export var BadResponseError = Error.subclass("BadResponseError");
 
 /**
  * From: https://github.com/joyent/node/blob/master/lib/util.js

--- a/src/federation_server.js
+++ b/src/federation_server.js
@@ -5,6 +5,7 @@ import isString from "lodash/isString";
 import pick from "lodash/pick";
 import {Config} from "./config";
 import {Account, StrKey} from 'stellar-base';
+import {BadResponseError} from './errors';
 import {StellarTomlResolver} from "./stellar_toml_resolver";
 
 // FEDERATION_RESPONSE_MAX_SIZE is the maximum size of response from a federation server
@@ -171,7 +172,7 @@ export class FederationServer {
         if (response instanceof Error) {
           return Promise.reject(response);
         } else {
-          return Promise.reject(response.data);
+          return Promise.reject(new BadResponseError(`Server query failed. Server responded: ${response.status} ${response.statusText}`, response.data));
         }
       });
   }

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,4 @@
-import {NotFoundError, NetworkError, BadRequestError} from "./errors";
+import {NotFoundError, NetworkError, BadRequestError, BadResponseError} from "./errors";
 
 import {AccountCallBuilder} from "./account_call_builder";
 import {AccountResponse} from "./account_response";
@@ -64,7 +64,7 @@ export class Server {
                 if (response instanceof Error) {
                     return Promise.reject(response);
                 } else {
-                    return Promise.reject(response.data);
+                    return Promise.reject(new BadResponseError(`Transaction submission failed. Server responded: ${response.status} ${response.statusText}`, response.data));
                 }
             });
         return toBluebird(promise);

--- a/src/stellar_toml_resolver.js
+++ b/src/stellar_toml_resolver.js
@@ -44,7 +44,7 @@ export class StellarTomlResolver {
             let tomlObject = toml.parse(response.data);
             return Promise.resolve(tomlObject);
         } catch (e) {
-            return Promise.reject(`Parsing error on line ${e.line}, column ${e.column}: ${e.message}`);
+            return Promise.reject(new Error(`Parsing error on line ${e.line}, column ${e.column}: ${e.message}`));
         }
       });
   }

--- a/test/integration/server_test.js
+++ b/test/integration/server_test.js
@@ -69,8 +69,8 @@ describe("integration tests", function () {
 
           server.submitTransaction(tx)
             .then(result => done(new Error("This promise should be rejected.")))
-            .catch(result => {
-              expect(result.extras.result_codes.transaction).to.equal('tx_bad_seq');
+            .catch(error => {
+              expect(error.data.extras.result_codes.transaction).to.equal('tx_bad_seq');
               done();
             });
         });


### PR DESCRIPTION
Adds a `BadResponseError` similar to the `BadRequestError`. Throws this error with attached response data in case of negative server responses.

Fixes #100.