### PR TITLE
Fix jsdoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "gulp-webpack": "^1.3.1",
     "isparta": "^3.1.0",
     "istanbul": "~0.3.2",
-    "jsdoc": "^3.4.1",
+    "jsdoc": "3.5.3",
     "jshint-stylish": "^1.0.1",
     "karma": "^0.13.2",
     "karma-chai": "^0.1.0",
@@ -83,7 +83,7 @@
     "event-source-polyfill": "0.0.7",
     "eventsource": "^0.2.1",
     "lodash": "^4.0.1",
-    "stellar-base": "^0.7.5",
+    "stellar-base": "^0.7.6",
     "toml": "^2.3.0"
   }
 }

--- a/src/account_response.js
+++ b/src/account_response.js
@@ -1,18 +1,18 @@
 import {Account as BaseAccount} from "stellar-base";
 import forIn from "lodash/forIn";
 
+/**
+ * Do not create this object directly, use {@link Server#loadAccount}.
+ *
+ * Returns information and links relating to a single account.
+ * The balances section in the returned JSON will also list all the trust lines this account has set up.
+ * It also contains {@link Account} object and exposes it's methods so can be used in {@link TransactionBuilder}.
+ *
+ * @see [Account Details](https://www.stellar.org/developers/horizon/reference/accounts-single.html)
+ * @param {string} response Response from horizon account endpoint.
+ * @returns {AccountResponse}
+ */
 export class AccountResponse {
-    /**
-     * Do not create this object directly, use {@link Server#loadAccount}.
-     *
-     * Returns information and links relating to a single account.
-     * The balances section in the returned JSON will also list all the trust lines this account has set up.
-     * It also contains {@link Account} object and exposes it's methods so can be used in {@link TransactionBuilder}.
-     *
-     * @see [Account Details](https://www.stellar.org/developers/horizon/reference/accounts-single.html)
-     * @param {string} response Response from horizon account endpoint.
-     * @returns {AccountResponse}
-     */
     constructor(response) {
         this._baseAccount = new BaseAccount(response.account_id, response.sequence);
         // Extract response fields

--- a/src/federation_server.js
+++ b/src/federation_server.js
@@ -11,17 +11,17 @@ import {StellarTomlResolver} from "./stellar_toml_resolver";
 // FEDERATION_RESPONSE_MAX_SIZE is the maximum size of response from a federation server
 export const FEDERATION_RESPONSE_MAX_SIZE = 100 * 1024;
 
+/**
+ * FederationServer handles a network connection to a
+ * [federation server](https://www.stellar.org/developers/learn/concepts/federation.html)
+ * instance and exposes an interface for requests to that instance.
+ * @constructor
+ * @param {string} serverURL The federation server URL (ex. `https://acme.com/federation`).
+ * @param {string} domain Domain this server represents
+ * @param {object} [opts]
+ * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments! You can also use {@link Config} class to set this globally.
+ */
 export class FederationServer {
-  /**
-   * FederationServer handles a network connection to a
-   * [federation server](https://www.stellar.org/developers/learn/concepts/federation.html)
-   * instance and exposes an interface for requests to that instance.
-   * @constructor
-   * @param {string} serverURL The federation server URL (ex. `https://acme.com/federation`).
-   * @param {string} domain Domain this server represents
-   * @param {object} [opts]
-   * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments! You can also use {@link Config} class to set this globally.
-   */
   constructor(serverURL, domain, opts = {}) {
     // TODO `domain` regexp
     this.serverURL = URI(serverURL);

--- a/src/offer_call_builder.js
+++ b/src/offer_call_builder.js
@@ -2,16 +2,16 @@ import {CallBuilder} from "./call_builder";
 import {OrderbookCallBuilder} from "./orderbook_call_builder";
 import {BadRequestError} from "./errors";
 
+/**
+ * Creates a new {@link OfferCallBuilder} pointed to server defined by serverUrl.
+ *
+ * Do not create this object directly, use {@link Server#offers}.
+ * @see [Offers for Account](https://www.stellar.org/developers/horizon/reference/offers-for-account.html)
+ * @param {string} serverUrl Horizon server URL.
+ * @param {string} resource Resource to query offers
+ * @param {...string} resourceParams Parameters for selected resource
+ */
 export class OfferCallBuilder extends CallBuilder {
-    /**
-     * Creates a new {@link OfferCallBuilder} pointed to server defined by serverUrl.
-     *
-     * Do not create this object directly, use {@link Server#offers}.
-     * @see [Offers for Account](https://www.stellar.org/developers/horizon/reference/offers-for-account.html)
-     * @param {string} serverUrl Horizon server URL.
-     * @param {string} resource Resource to query offers
-     * @param {...string} resourceParams Parameters for selected resource
-     */
     constructor(serverUrl, resource, ...resourceParams) {
         super(serverUrl);
         if (resource === 'accounts') {

--- a/src/orderbook_call_builder.js
+++ b/src/orderbook_call_builder.js
@@ -1,15 +1,15 @@
 import {CallBuilder} from "./call_builder";
 
+/**
+ * Creates a new {@link OrderbookCallBuilder} pointed to server defined by serverUrl.
+ *
+ * Do not create this object directly, use {@link Server#orderbook}.
+ * @see [Orderbook Details](https://www.stellar.org/developers/horizon/reference/orderbook-details.html)
+ * @param {string} serverUrl serverUrl Horizon server URL.
+ * @param {Asset} selling Asset being sold
+ * @param {Asset} buying Asset being bought
+ */
 export class OrderbookCallBuilder extends CallBuilder {
-    /**
-     * Creates a new {@link OrderbookCallBuilder} pointed to server defined by serverUrl.
-     *
-     * Do not create this object directly, use {@link Server#orderbook}.
-     * @see [Orderbook Details](https://www.stellar.org/developers/horizon/reference/orderbook-details.html)
-     * @param {string} serverUrl serverUrl Horizon server URL.
-     * @param {Asset} selling Asset being sold
-     * @param {Asset} buying Asset being bought
-     */
     constructor(serverUrl, selling, buying) {
         super(serverUrl);
         this.url.segment('order_book');

--- a/src/path_call_builder.js
+++ b/src/path_call_builder.js
@@ -1,29 +1,29 @@
 import {CallBuilder} from './call_builder';
 
+/**
+ * The Stellar Network allows payments to be made across assets through path payments. A path payment specifies a
+ * series of assets to route a payment through, from source asset (the asset debited from the payer) to destination
+ * asset (the asset credited to the payee).
+ *
+ * A path search is specified using:
+ *
+ * * The destination address
+ * * The source address
+ * * The asset and amount that the destination account should receive
+ *
+ * As part of the search, horizon will load a list of assets available to the source address and will find any
+ * payment paths from those source assets to the desired destination asset. The search's amount parameter will be
+ * used to determine if there a given path can satisfy a payment of the desired amount.
+ *
+ * Do not create this object directly, use {@link Server#paths}.
+ * @see [Find Payment Paths](https://www.stellar.org/developers/horizon/reference/path-finding.html)
+ * @param {string} serverUrl Horizon server URL.
+ * @param {string} source The sender's account ID. Any returned path must use a source that the sender can hold.
+ * @param {string} destination The destination account ID that any returned path should use.
+ * @param {Asset} destinationAsset The destination asset.
+ * @param {string} destinationAmount The amount, denominated in the destination asset, that any returned path should be able to satisfy.
+ */
 export class PathCallBuilder extends CallBuilder {
-    /**
-     * The Stellar Network allows payments to be made across assets through path payments. A path payment specifies a
-     * series of assets to route a payment through, from source asset (the asset debited from the payer) to destination
-     * asset (the asset credited to the payee).
-     *
-     * A path search is specified using:
-     *
-     * * The destination address
-     * * The source address
-     * * The asset and amount that the destination account should receive
-     *
-     * As part of the search, horizon will load a list of assets available to the source address and will find any
-     * payment paths from those source assets to the desired destination asset. The search's amount parameter will be
-     * used to determine if there a given path can satisfy a payment of the desired amount.
-     *
-     * Do not create this object directly, use {@link Server#paths}.
-     * @see [Find Payment Paths](https://www.stellar.org/developers/horizon/reference/path-finding.html)
-     * @param {string} serverUrl Horizon server URL.
-     * @param {string} source The sender's account ID. Any returned path must use a source that the sender can hold.
-     * @param {string} destination The destination account ID that any returned path should use.
-     * @param {Asset} destinationAsset The destination asset.
-     * @param {string} destinationAmount The amount, denominated in the destination asset, that any returned path should be able to satisfy.
-     */
     constructor(serverUrl, source, destination, destinationAsset, destinationAmount) {
         super(serverUrl);
         this.url.segment('paths');

--- a/src/server.js
+++ b/src/server.js
@@ -22,15 +22,15 @@ let URITemplate = require("urijs").URITemplate;
 
 export const SUBMIT_TRANSACTION_TIMEOUT = 20*1000;
 
+/**
+ * Server handles the network connection to a [Horizon](https://www.stellar.org/developers/horizon/learn/index.html)
+ * instance and exposes an interface for requests to that instance.
+ * @constructor
+ * @param {string} serverURL Horizon Server URL (ex. `https://horizon-testnet.stellar.org`).
+ * @param {object} [opts]
+ * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments! You can also use {@link Config} class to set this globally.
+ */
 export class Server {
-    /**
-     * Server handles the network connection to a [Horizon](https://www.stellar.org/developers/horizon/learn/index.html)
-     * instance and exposes an interface for requests to that instance.
-     * @constructor
-     * @param {string} serverURL Horizon Server URL (ex. `https://horizon-testnet.stellar.org`).
-     * @param {object} [opts]
-     * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments! You can also use {@link Config} class to set this globally.
-     */
     constructor(serverURL, opts = {}) {
         this.serverURL = URI(serverURL);
 


### PR DESCRIPTION
Fixes jsdoc by moving class docs back to class definition and fix jsdoc
Version to 3.5.3 so updates won't surprise anymore.

As in https://github.com/stellar/js-stellar-base/pull/114