### PR TITLE
Increase stellar.toml size limit, improve error message

### DIFF
--- a/src/federation_server.js
+++ b/src/federation_server.js
@@ -170,7 +170,11 @@ export class FederationServer {
       })
       .catch(response => {
         if (response instanceof Error) {
-          return Promise.reject(response);
+          if (response.message.match(/^maxContentLength size/)) {
+            throw new Error(`federation response exceeds allowed size of ${FEDERATION_RESPONSE_MAX_SIZE}`);
+          } else {
+            return Promise.reject(response);
+          }
         } else {
           return Promise.reject(new BadResponseError(`Server query failed. Server responded: ${response.status} ${response.statusText}`, response.data));
         }

--- a/src/stellar_toml_resolver.js
+++ b/src/stellar_toml_resolver.js
@@ -4,7 +4,7 @@ import toml from 'toml';
 import {Config} from "./config";
 
 // STELLAR_TOML_MAX_SIZE is the maximum size of stellar.toml file
-export const STELLAR_TOML_MAX_SIZE = 5 * 1024;
+export const STELLAR_TOML_MAX_SIZE = 100 * 1024;
 
 /**
  * StellarTomlResolver allows resolving `stellar.toml` files.
@@ -45,6 +45,13 @@ export class StellarTomlResolver {
             return Promise.resolve(tomlObject);
         } catch (e) {
             return Promise.reject(new Error(`Parsing error on line ${e.line}, column ${e.column}: ${e.message}`));
+        }
+      })
+      .catch(err => {
+        if (err.message.match(/^maxContentLength size/)) {
+          throw new Error(`stellar.toml file exceeds allowed size of ${STELLAR_TOML_MAX_SIZE}`);
+        } else {
+          throw err;
         }
       });
   }

--- a/test/unit/federation_server_test.js
+++ b/test/unit/federation_server_test.js
@@ -222,7 +222,7 @@ FEDERATION_SERVER="https://api.stellar.org/federation"
       }).listen(4444, () => {
         new StellarSdk.FederationServer('http://localhost:4444/federation', 'stellar.org', {allowHttp: true})
           .resolveAddress('bob*stellar.org')
-          .should.be.rejectedWith(/maxContentLength size of [0-9]+ exceeded/)
+          .should.be.rejectedWith(/federation response exceeds allowed size of [0-9]+/)
           .notify(done)
           .then(() => tempServer.close());
       });

--- a/test/unit/stellar_toml_resolver_test.js
+++ b/test/unit/stellar_toml_resolver_test.js
@@ -101,7 +101,7 @@ FEDERATION_SERVER="https://api.stellar.org/federation"
         res.end(response);
       }).listen(4444, () => {
         StellarSdk.StellarTomlResolver.resolve("localhost:4444", {allowHttp: true})
-          .should.be.rejectedWith(/maxContentLength size of [0-9]+ exceeded/)
+          .should.be.rejectedWith(/stellar.toml file exceeds allowed size of [0-9]+/)
           .notify(done)
           .then(() => tempServer.close());
       });


### PR DESCRIPTION
The limit of stellar.toml file response size we introduced in https://github.com/stellar/js-stellar-sdk/pull/85 is too small for some use cases.

Close https://github.com/stellar/js-stellar-sdk/issues/104.