### PR TITLE
Fix broken links in documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 include: node_modules_stellar-base_*.js.html
+theme: jekyll-theme-cayman

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,1 @@
 include: node_modules_stellar-base_*.js.html
-theme: jekyll-theme-cayman

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+include: node_modules_stellar-base_*.js.html


### PR DESCRIPTION
#120 fixed.

For some reason jekyll was ignoring all `node_modules_stellar-base_src` files. Added a `_config.yml` to force these files to be included..

All 3 links in issue are now working on my site with this fix:

- https://kaplanmaxe.github.io/js-stellar-sdk/node_modules_stellar-base_src_operation.js.html
- https://kaplanmaxe.github.io/js-stellar-sdk/node_modules_stellar-base_src_asset.js.html
- https://kaplanmaxe.github.io/js-stellar-sdk/node_modules_stellar-base_src_asset.js.html