### PR TITLE
Allow streams timeout to be configurable

### DIFF
--- a/docs/reference/api/call_builder.md
+++ b/docs/reference/api/call_builder.md
@@ -15,7 +15,7 @@ title: CallBuilder
 | `cursor("token")` | `string` | Return only resources after the given paging token. |
 | `order({"asc" or "desc"})` | `string` |  Order the returned collection in "asc" or "desc" order. |
 | `call()` | | Triggers a HTTP Request to the Horizon server based on the builder's current configuration.  Returns a `Promise` that resolves to the server's response.  For more on `Promise`, see [these docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).|
-| `stream({options})` | object of [properties](https://developer.mozilla.org/en-US/docs/Web/API/EventSource#Properties) | Creates an `EventSource` that listens for incoming messages from the server.  URL based on builder's current configuration.  For more on `EventSource`, see [these docs](https://developer.mozilla.org/en-US/docs/Web/API/EventSource). |
+| `stream({options})` | object of [properties](https://developer.mozilla.org/en-US/docs/Web/API/EventSource#Properties) | Creates an `EventSource` that listens for incoming messages from the server.  URL based on builder's current configuration.  For more on `EventSource`, see [these docs](https://developer.mozilla.org/en-US/docs/Web/API/EventSource). Stream connection timeout is configurable through `options.reconnectTimeout` in  ms, default is 15 seconds. |
 
 
 

--- a/src/call_builder.js
+++ b/src/call_builder.js
@@ -56,6 +56,7 @@ export class CallBuilder {
    * @param {object} [options] EventSource options.
    * @param {function} [options.onmessage] Callback function to handle incoming messages.
    * @param {function} [options.onerror] Callback function to handle errors.
+   * @param {number} [options.reconnectTimeout] Custom stream connection timeout in ms, default is 15 seconds.
    * @returns {function} Close function. Run to close the connection and stop listening for new events.
    */
   stream(options) {
@@ -73,7 +74,7 @@ export class CallBuilder {
       timeout = setTimeout(() => {
         es.close();
         es = createEventSource();
-      }, options.every || 15*1000);
+      }, options.reconnectTimeout || 15*1000);
     };
 
     var createEventSource = () => {

--- a/src/call_builder.js
+++ b/src/call_builder.js
@@ -73,7 +73,7 @@ export class CallBuilder {
       timeout = setTimeout(() => {
         es.close();
         es = createEventSource();
-      }, 15*1000);
+      }, options.every || 15*1000);
     };
 
     var createEventSource = () => {


### PR DESCRIPTION
Streams are currently way too expensive, especially since the Horizon endpoints are not optimized for minimal fetching, we cannot call `horizon:accounts/ACCOUNT/balances/XLM` for example to keep the XLM balance updated in the front-end, but that's another topic.

Listening to two accounts for 10 minutes costs 2.1 MB, the data is fetched even when the balance is still not changed. We need to download a 19 KB request every time we are interested in a piece of information that is typically less than 0.256 KB in size.

<img width="878" alt="screen shot 2018-01-19 at 4 02 22 pm" src="https://user-images.githubusercontent.com/23000873/35152464-a14a1d28-fd33-11e7-8835-bbf50d2d0dc5.png">

This PR allows setting the timeout interval, which doesn't solve the original issue (not optimized API endpoints), but offers a workaround, now it's up to the developer to set that parameter instead of forcing a fetch every 15-sec rule.