### PR TITLE
Ensure that all horizon calls through CallBuilder use _parseResponse

### DIFF
--- a/src/call_builder.js
+++ b/src/call_builder.js
@@ -130,7 +130,7 @@ export class CallBuilder {
         uri = URI(link.href);
       }
 
-      return this._sendNormalRequest(uri).then(r => this._parseRecord(r));
+      return this._sendNormalRequest(uri).then(r => this._parseResponse(r));
     };
   } 
 


### PR DESCRIPTION
This references #142. I believe this will be a breaking change for those who are using the `_link` functions for collections.