### PR TITLE
TypeError: Cannot read property 'length' of undefined from uri.js

### DIFF
--- a/src/call_builder.js
+++ b/src/call_builder.js
@@ -30,6 +30,12 @@ export class CallBuilder {
     }
 
     if (this.filter.length === 1) {
+      this.filter[0].forEach(element => {
+        if (typeof element === 'undefined') {
+          throw new _errors.BadRequestError(`Invalid values are set in filters specified - ${element}`, this.filter);
+        }
+      });
+
       //append filters to original segments
       let newSegment = this.originalSegments.concat(this.filter[0]);
       this.url.segment(newSegment);


### PR DESCRIPTION
Issue was giving an error from `uri.js` since I was using an environment variable that was not set, causing it not to stop and let the user know it is an issue with parameters sent. The commit changes are to check for any undefined values before building the URI