### PR TITLE
Add helper for fetching timebounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ A breaking change will get clearly marked in this log.
   to set `window.EventSource`.
 - Upgrade `stellar-base` to a version that doesn't use the `crypto` library,
   fixing a bug with Angular 6
+- Add `Server.prototype.fetchTimebounds`, a helper function that helps you set
+  the `timebounds` property when initting `TransactionBuilder`.
 
 ## [v0.14.0](https://github.com/stellar/js-stellar-sdk/compare/v0.13.0...v0.14.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ A breaking change will get clearly marked in this log.
 - Upgrade `stellar-base` to a version that doesn't use the `crypto` library,
   fixing a bug with Angular 6
 - Add `Server.prototype.fetchTimebounds`, a helper function that helps you set
-  the `timebounds` property when initting `TransactionBuilder`.
+  the `timebounds` property when initting `TransactionBuilder`. It bases the
+  timebounds on server time rather than local time.
 
 ## [v0.14.0](https://github.com/stellar/js-stellar-sdk/compare/v0.13.0...v0.14.0)
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "homepage": "https://github.com/stellar/js-stellar-sdk",
   "devDependencies": {
+    "axios-mock-adapter": "^1.16.0",
     "babel-cli": "^6.26.0",
     "babel-core": "~6.26.3",
     "babel-eslint": "^10.0.1",

--- a/src/horizon_axios_client.js
+++ b/src/horizon_axios_client.js
@@ -49,7 +49,7 @@ export default HorizonAxiosClient;
 /**
  * Given a hostname, get the current time of that server (i.e., use the last-
  * recorded server time and offset it by the time since then.) If there IS no
- * recorded server time, then return null.
+ * recorded server time, or it's been 5 minutes since the last, return null.
  * @param {string} hostname Hostname of a Horizon server.
  * @returns {number} The UNIX timestamp (in seconds, not milliseconds)
  * representing the current time on that server, or `null` if we don't have
@@ -68,5 +68,11 @@ export function getCurrentServerTime(hostname) {
   }
 
   const currentTime = _toSeconds(new Date().getTime());
+
+  // if it's been more than 5 minutes from the last time, then null it out
+  if (currentTime - localTimeRecorded > 60 * 5) {
+    return null;
+  }
+
   return currentTime - localTimeRecorded + serverTime;
 }

--- a/src/horizon_axios_client.js
+++ b/src/horizon_axios_client.js
@@ -1,9 +1,72 @@
 import axios from 'axios';
+import URI from 'urijs';
+
 import { version } from '../package.json';
 
-export default axios.create({
+// keep a local map of server times
+// (export this purely for testing purposes)
+export const SERVER_TIME_MAP = {
+  /* each entry will map the server domain to the last-known time and the local 
+  time it was recorded
+  ex:
+
+  "horizon-testnet.stellar.org": {
+    serverTime: 1552513039,
+    localTimeRecorded: 1552513052
+  }
+  */
+};
+
+const HorizonAxiosClient = axios.create({
   headers: {
     'X-Client-Name': 'js-stellar-sdk',
     'X-Client-Version': version
   }
 });
+
+function _toSeconds(ms) {
+  return Math.floor(ms / 1000);
+}
+
+HorizonAxiosClient.interceptors.response.use((response) => {
+  const hostname = URI(response.config.url).hostname();
+  const serverTime = _toSeconds(Date.parse(response.headers.Date));
+  const localTimeRecorded = _toSeconds(new Date().getTime());
+
+  SERVER_TIME_MAP[hostname] = {
+    serverTime,
+    localTimeRecorded
+  };
+
+  // if (!isNaN(serverTime))
+  // SERVER_TIME_MAP[]
+
+  return response;
+});
+
+export default HorizonAxiosClient;
+
+/**
+ * Given a hostname, get the current time of that server (i.e., use the last-
+ * recorded server time and offset it by the time since then.) If there IS no
+ * recorded server time, then return null.
+ * @param {string} hostname Hostname of a Horizon server.
+ * @returns {number} The UNIX timestamp (in seconds, not milliseconds)
+ * representing the current time on that server, or `null` if we don't have
+ * a record of that time.
+ */
+export function getCurrentServerTime(hostname) {
+  const { serverTime, localTimeRecorded } = SERVER_TIME_MAP[hostname] || {};
+
+  if (
+    serverTime === undefined ||
+    localTimeRecorded === undefined ||
+    serverTime === null ||
+    localTimeRecorded === null
+  ) {
+    return null;
+  }
+
+  const currentTime = _toSeconds(new Date().getTime());
+  return currentTime - localTimeRecorded + serverTime;
+}

--- a/src/horizon_axios_client.js
+++ b/src/horizon_axios_client.js
@@ -33,13 +33,13 @@ HorizonAxiosClient.interceptors.response.use((response) => {
   const serverTime = _toSeconds(Date.parse(response.headers.Date));
   const localTimeRecorded = _toSeconds(new Date().getTime());
 
-  SERVER_TIME_MAP[hostname] = {
-    serverTime,
-    localTimeRecorded
-  };
-
-  // if (!isNaN(serverTime))
-  // SERVER_TIME_MAP[]
+  // eslint-disable-next-line no-restricted-globals
+  if (!isNaN(serverTime)) {
+    SERVER_TIME_MAP[hostname] = {
+      serverTime,
+      localTimeRecorded
+    };
+  }
 
   return response;
 });

--- a/src/horizon_axios_client.js
+++ b/src/horizon_axios_client.js
@@ -58,12 +58,7 @@ export default HorizonAxiosClient;
 export function getCurrentServerTime(hostname) {
   const { serverTime, localTimeRecorded } = SERVER_TIME_MAP[hostname] || {};
 
-  if (
-    serverTime === undefined ||
-    localTimeRecorded === undefined ||
-    serverTime === null ||
-    localTimeRecorded === null
-  ) {
+  if (!serverTime || !localTimeRecorded) {
     return null;
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -62,8 +62,8 @@ export class Server {
    * your machine's local time could be different from Horizon's. This gives you
    * more assurance that your timebounds will reflect what you want.
    *
-   * Note that this will generate your timebounds when you **run the function**,
-   * not when you submit the function! So give yourself enough time to get
+   * Note that this will generate your timebounds when you **init the transaction**,
+   * not when you build or submit the transaction! So give yourself enough time to get
    * the transaction built and signed before submitting.
    *
    * Example:

--- a/src/server.js
+++ b/src/server.js
@@ -77,6 +77,11 @@ export class Server {
    * (with the shape `{ minTime: 0, maxTime: N }`) that you can set the `timebounds` option to.
    */
   fetchTimebounds(seconds, _isRetry = false) {
+    // throw if we're not in an instance
+    if (!this.serverURL) {
+      throw new Error('You must run on a StellarSdk class instance');
+    }
+
     // HorizonAxiosClient instead of this.ledgers so we can get at them headers
     const currentTime = getCurrentServerTime(this.serverURL.hostname());
 

--- a/src/server.js
+++ b/src/server.js
@@ -77,11 +77,6 @@ export class Server {
    * (with the shape `{ minTime: 0, maxTime: N }`) that you can set the `timebounds` option to.
    */
   fetchTimebounds(seconds, _isRetry = false) {
-    // throw if we're not in an instance
-    if (!this.serverURL) {
-      throw new Error('You must run on a StellarSdk class instance');
-    }
-
     // HorizonAxiosClient instead of this.ledgers so we can get at them headers
     const currentTime = getCurrentServerTime(this.serverURL.hostname());
 

--- a/src/server.js
+++ b/src/server.js
@@ -103,8 +103,9 @@ export class Server {
       });
     }
 
-    // otherwise, retry (by calling the fee endpoint)
-    return HorizonAxiosClient.get(`${URI(this.serverURL)}/fee_stats`).then(() =>
+    // otherwise, retry (by calling the root endpoint)
+    // toString automatically adds the trailing slash
+    return HorizonAxiosClient.get(URI(this.serverURL).toString()).then(() =>
       this.fetchTimebounds(seconds, true)
     );
   }

--- a/src/server.js
+++ b/src/server.js
@@ -71,14 +71,13 @@ export class Server {
    *  .build();
    * ```
    * @argument {number} seconds Number of seconds past the current time to wait.
-   * @argument {bool} _isRetry True if this is a retry. Only set this internally!
+   * @argument {bool} [_isRetry=false] True if this is a retry. Only set this internally!
    * This is to avoid a scenario where Horizon is horking up the wrong date.
    * @returns {Promise<number>} Promise that resolves a `timebounds` object
    * (with the shape `{ minTime: 0, maxTime: N }`) that you can set the `timebounds` option to.
    */
-  fetchTimebounds(seconds, _isRetry) {
+  fetchTimebounds(seconds, _isRetry = false) {
     // HorizonAxiosClient instead of this.ledgers so we can get at them headers
-
     const currentTime = getCurrentServerTime(this.serverURL.hostname());
 
     if (currentTime) {
@@ -97,7 +96,7 @@ export class Server {
     }
 
     // otherwise, retry (by calling the fee endpoint)
-    return HorizonAxiosClient.get('fee_stats').then(() =>
+    return HorizonAxiosClient.get(`${URI(this.serverURL)}/fee_stats`).then(() =>
       this.fetchTimebounds(seconds, true)
     );
   }

--- a/test/integration/client_headers_test.js
+++ b/test/integration/client_headers_test.js
@@ -1,6 +1,6 @@
 const http = require('http');
 const url = require('url');
-const port = 3000;
+const port = 3100;
 
 describe('integration tests', function(done) {
   if (typeof window !== 'undefined') {

--- a/test/unit/horizon_axios_client_test.js
+++ b/test/unit/horizon_axios_client_test.js
@@ -1,0 +1,34 @@
+const SERVER_TIME_MAP = require('../../src/horizon_axios_client')
+  .SERVER_TIME_MAP;
+const getCurrentServerTime = require('../../src/horizon_axios_client')
+  .getCurrentServerTime;
+
+describe('getCurrentServerTime', () => {
+  let clock;
+
+  beforeEach(() => {
+    // set it to 50 seconds
+    clock = sinon.useFakeTimers(50000);
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it('returns null when the hostname hasnt been hit', () => {
+    expect(getCurrentServerTime('host')).to.be.null;
+  });
+
+  it('returns null when no time is available', () => {
+    SERVER_TIME_MAP.host = {};
+    expect(getCurrentServerTime('host')).to.be.null;
+  });
+
+  it('returns the delta between then and now', () => {
+    SERVER_TIME_MAP.host = {
+      serverTime: 10,
+      localTimeRecorded: 0
+    };
+    expect(getCurrentServerTime('host')).to.equal(60);
+  });
+});

--- a/test/unit/horizon_axios_client_test.js
+++ b/test/unit/horizon_axios_client_test.js
@@ -27,8 +27,8 @@ describe('getCurrentServerTime', () => {
   it('returns the delta between then and now', () => {
     SERVER_TIME_MAP.host = {
       serverTime: 10,
-      localTimeRecorded: 0
+      localTimeRecorded: 5
     };
-    expect(getCurrentServerTime('host')).to.equal(60);
+    expect(getCurrentServerTime('host')).to.equal(55);
   });
 });

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -124,6 +124,12 @@ describe('server.js tests', function() {
           done(e);
         });
     });
+
+    it('throw if not issued on StellarSdk instance', function() {
+      expect(() => StellarSdk.Server.prototype.fetchTimebounds()).to.throw(
+        /StellarSdk class instance/
+      );
+    });
   });
 
   describe('Server.fetchBaseFee', function() {

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -46,8 +46,8 @@ describe('server.js tests', function() {
     let clock;
 
     beforeEach(function() {
-      // set now to 50 seconds
-      clock = sinon.useFakeTimers(50000);
+      // set now to 10050 seconds
+      clock = sinon.useFakeTimers(10050 * 1000);
     });
 
     afterEach(function() {
@@ -63,7 +63,7 @@ describe('server.js tests', function() {
       this.server
         .fetchTimebounds(20)
         .then((serverTime) => {
-          expect(serverTime).to.eql({ minTime: 0, maxTime: 80 });
+          expect(serverTime).to.eql({ minTime: 0, maxTime: 10080 });
           done();
         })
         .catch((e) => {
@@ -118,7 +118,7 @@ describe('server.js tests', function() {
         this.server
           .fetchTimebounds(20)
           .then((serverTime) => {
-            expect(serverTime).to.eql({ minTime: 0, maxTime: 70 });
+            expect(serverTime).to.eql({ minTime: 0, maxTime: 10070 });
             done();
           })
           .catch((e) => {

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -84,13 +84,15 @@ describe('server.js non-transaction tests', function() {
       });
 
       it('fetches if nothing is recorded', function(done) {
-        this.axiosMockAdapter.onGet(/fee_stats/).reply(
-          200,
-          {},
-          {
-            Date: 'Wed, 13 Mar 2019 22:15:07 GMT'
-          }
-        );
+        this.axiosMockAdapter
+          .onGet('https://horizon-live.stellar.org:1337/')
+          .reply(
+            200,
+            {},
+            {
+              Date: 'Wed, 13 Mar 2019 22:15:07 GMT'
+            }
+          );
 
         SERVER_TIME_MAP['horizon-live.stellar.org'] = undefined;
 
@@ -111,13 +113,15 @@ describe('server.js non-transaction tests', function() {
       });
 
       it('fetches if the old time is too old', function(done) {
-        this.axiosMockAdapter.onGet(/fee_stats/).reply(
-          200,
-          {},
-          {
-            Date: 'Wed, 13 Mar 2019 22:15:07 GMT'
-          }
-        );
+        this.axiosMockAdapter
+          .onGet('https://horizon-live.stellar.org:1337/')
+          .reply(
+            200,
+            {},
+            {
+              Date: 'Wed, 13 Mar 2019 22:15:07 GMT'
+            }
+          );
 
         SERVER_TIME_MAP['horizon-live.stellar.org'] = {
           serverTime: 'Wed, 13 Mar 2010 22:15:07 GMT',
@@ -141,7 +145,9 @@ describe('server.js non-transaction tests', function() {
       });
 
       it('fetches falls back to local time if fetch is bad', function(done) {
-        this.axiosMockAdapter.onGet(/fee_stats/).reply(200, {}, {});
+        this.axiosMockAdapter
+          .onGet('https://horizon-live.stellar.org:1337/')
+          .reply(200, {}, {});
 
         SERVER_TIME_MAP['horizon-live.stellar.org'] = undefined;
 

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -76,15 +76,15 @@ describe('server.js tests', function() {
         // use MockAdapter instead of this.axiosMock
         // because we don't want to replace the get function
         // we need to use axios's one so interceptors run!!
-        this.mock = new MockAdapter(HorizonAxiosClient);
+        this.axiosMockAdapter = new MockAdapter(HorizonAxiosClient);
       });
 
       afterEach(function() {
-        this.mock.restore();
+        this.axiosMockAdapter.restore();
       });
 
       it('fetches if nothing is recorded', function(done) {
-        this.axiosMock.onGet(/fee_stats/).reply(
+        this.axiosMockAdapter.onGet(/fee_stats/).reply(
           200,
           {},
           {
@@ -111,7 +111,7 @@ describe('server.js tests', function() {
       });
 
       it('fetches falls back to local time if fetch is bad', function(done) {
-        this.axiosMock.onGet(/fee_stats/).reply(200, {}, {});
+        this.axiosMockAdapter.onGet(/fee_stats/).reply(200, {}, {});
 
         SERVER_TIME_MAP['horizon-live.stellar.org'] = undefined;
 

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -124,12 +124,6 @@ describe('server.js tests', function() {
           done(e);
         });
     });
-
-    it('throw if not issued on StellarSdk instance', function() {
-      expect(() => StellarSdk.Server.prototype.fetchTimebounds()).to.throw(
-        /StellarSdk class instance/
-      );
-    });
   });
 
   describe('Server.fetchBaseFee', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,6 +537,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axios-mock-adapter@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/axios-mock-adapter/-/axios-mock-adapter-1.16.0.tgz#cdd55bb60d8cb3fcd77fdb9cbb269e47b8b95180"
+  integrity sha512-m2D8ngMTQ5p4zZNBsPKoENgwz5rDfd0pZmXI/spdE2eeeKIcR3jquk+NRiBVFtb9UJlciBYplNzSUmgQ6X385Q==
+  dependencies:
+    deep-equal "^1.0.1"
+
 axios@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
@@ -1943,6 +1950,11 @@ deep-eql@0.1.3:
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
   dependencies:
     type-detect "0.1.1"
+
+deep-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
 
 deep-extend@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Addresses #232.

(1) Add an axios interceptor that tracks the server's reported time from headers
(2) Add a function, `ServerSdk.Server.prototype.fetchTimebounds(seconds: Number)`, that returns a `timebounds` object for `TransactionBuilder` based on the server time. If no server time is recorded locally, or the recorded time is older than 5 minutes, it'll attempt to go to the network; if THAT fails, use the local time.
