### PR TITLE
[types] Use "key" instead of "public_key" for account signers

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -169,8 +169,9 @@ export namespace Server {
     flags: Horizon.Flags;
     balances: Horizon.BalanceLine[];
     signers: Array<{
-      public_key: string;
+      key: string;
       weight: number;
+      type: string;
     }>;
     data: (options: { value: string }) => Promise<{ value: string }>;
     data_attr: {


### PR DESCRIPTION
public_key no longer exists