### PR TITLE
Make CallCollectionFunction return a CollectionPage

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -156,7 +156,7 @@ export namespace Server {
   > = () => Promise<T>;
   type CallCollectionFunction<
     T extends Horizon.BaseResponse = Horizon.BaseResponse
-  > = (options?: CallFunctionTemplateOptions) => Promise<CollectionRecord<T>>;
+  > = (options?: CallFunctionTemplateOptions) => Promise<CollectionPage<T>>;
 
   interface AccountRecord extends Horizon.BaseResponse {
     id: string;


### PR DESCRIPTION
Modifies the type definition of `CallCollectionFunction` to return a `CollectionPage` instead of `CollectionRecord`. Resolves #341 