### PR TITLE
[types] Update Horizon.AccountSigner types.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -661,8 +661,9 @@ export namespace Horizon {
     auth_revocable: boolean;
   }
   interface AccountSigner {
-    public_key: string;
+    key: string;
     weight: number;
+    type: string;
   }
   interface AccountResponse
     extends BaseResponse<


### PR DESCRIPTION
Should be { key, weight, type } to match base class types.