### PR TITLE
v1.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,23 +38,35 @@ env:
 notifications:
   slack:
     secure: CgXxNEQrQ82EatyF/wSdF0P5rXcWPL+fFZ1lb1aBb8RbVt5gwddJ6xWVD/nYSr6tIJvIYHYhoYsIDPENwezIPsesG7kWXerQhydsEcA34JKxzsStd/TmU6Moxuwy6KTN7yzmL6586nSvoAw9TNPgvRkJFkH07asjGIc9Rlaq7/Y=
-before_deploy: gulp build
-after_deploy: './after_deploy.sh'
+before_deploy:
+  - "gulp build"
+  # Identifies `a.b.c-xxx.n` tags as pre-releases, and `a.b.c` as stable releases
+  - |
+    function npm_dist_tag() {
+      if [[ "$TRAVIS_TAG" = *"-"* ]]; then
+        echo "next"
+      else
+        echo "latest"
+      fi
+    }
+
+after_deploy: "./after_deploy.sh"
 deploy:
   - provider: npm
     email: npm@stellar.org
     api_key: $NPM_TOKEN
     skip_cleanup: true
+    tag: $(npm_dist_tag)
     on:
       tags: true
       repo: stellar/js-stellar-sdk
       node: 6.14.0
-      condition: '$INTEGRATION = true'
+      condition: "$INTEGRATION = true"
   - provider: script
-    script: './bower_publish.sh'
+    script: "./bower_publish.sh"
     skip_cleanup: true
     on:
       tags: true
       repo: stellar/js-stellar-sdk
       node: 6.14.0
-      condition: '$INTEGRATION = true'
+      condition: "$INTEGRATION = true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 As this project is pre 1.0, breaking changes may happen for minor version bumps.
 A breaking change will get clearly marked in this log.
 
+## [v1.0.4](https://github.com/stellar/js-stellar-sdk/compare/v1.0.3...v1.0.4)
+
+- Automatically tag alpha / beta releases as "next" in NPM.
+
 ## [v1.0.3](https://github.com/stellar/js-stellar-sdk/compare/v1.0.2...v1.0.3)
 
 - Upgrade axios to 0.19.0 to close a security vulnerability.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-sdk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "stellar-sdk is a library for working with the Stellar Horizon server.",
   "main": "./lib/index.js",
   "types": "./types/index.d.ts",


### PR DESCRIPTION
- Auto-tag alpha and beta releases (any release with a dash in it) as 'next' in NPM.