### PR TITLE
Add home_domain to ServerApi.AccountRecord

### DIFF
--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -36,6 +36,7 @@ export namespace ServerApi {
     account_id: string;
     sequence: string;
     subentry_count: number;
+    home_domain?: string;
     inflation_destination?: string;
     last_modified_ledger: number;
     thresholds: Horizon.AccountThresholds;


### PR DESCRIPTION
Congrats to v2.0 of the stellar-sdk!

Just played around and noticed that the optional `home_domain` is missing on the `AccountRecord`.