### PR TITLE
Add single script to build docs and call it when combined with jsdoc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "prepare": "gulp build",
     "test": "babel-node ./node_modules/.bin/gulp test",
-    "docs": "gulp build:docs && jsdoc -c .jsdoc.json",
+    "build:docs": "gulp build:docs",
+    "docs": "yarn build:docs && jsdoc -c .jsdoc.json",
     "dtslint": "dtslint test/types",
     "preversion": "gulp test",
     "version": "gulp build",


### PR DESCRIPTION
We'll need this to solve https://github.com/stellar/developers/issues/117.

The developers script call `/node_modules/.bin/jsdoc -c .jsdoc.json
--explain` [here](https://github.com/stellar/developers/blob/1c753962b44472fcda43f25324685f9629971907/gulp/code-symbol-tags.js#L24) -- but in order for it to work properly, we need to call `gulp
build:docs` first it generated the libdocs files which have the final sources after transpilation.