### PR TITLE
Create new URI instead of passing serverUrl (Fix #379).

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -488,7 +488,11 @@ export class Server {
     resource: string,
     ...resourceParams: string[]
   ): OfferCallBuilder {
-    return new OfferCallBuilder(this.serverURL, resource, ...resourceParams);
+    return new OfferCallBuilder(
+      URI(this.serverURL as any),
+      resource,
+      ...resourceParams,
+    );
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -167,7 +167,7 @@ export class Server {
    * @returns {Promise} Promise that resolves to the fee stats returned by Horizon.
    */
   public async operationFeeStats(): Promise<any> {
-    const cb = new CallBuilder(this.serverURL);
+    const cb = new CallBuilder(URI(this.serverURL as any));
     cb.filter.push(["operation_fee_stats"]);
     return cb.call();
   }
@@ -551,7 +551,7 @@ export class Server {
     destinationAmount: string,
   ): PathCallBuilder {
     return new PathCallBuilder(
-      this.serverURL,
+      URI(this.serverURL as any),
       source,
       destination,
       destinationAsset,
@@ -626,7 +626,7 @@ export class Server {
     offset: number,
   ): TradeAggregationCallBuilder {
     return new TradeAggregationCallBuilder(
-      this.serverURL,
+      URI(this.serverURL as any),
       base,
       counter,
       start_time,

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -2329,5 +2329,28 @@ describe('server.js non-transaction tests', function() {
           });
       });
     });
+
+    describe('Regressions', function() {
+      it('offers callBuilder does not pollute Server instance URI #379', function(done) {
+        this.axiosMock
+          .expects('get')
+          .withArgs(
+            sinon.match(
+              'https://horizon-live.stellar.org:1337/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/effects'
+            )
+          )
+          .returns(Promise.resolve({ data: {} }));
+
+        const account = "GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K";
+
+        const offerCallBuilder = this.server.offers("accounts", account);
+        const effectCallBuilder = this.server.effects().forAccount(account).limit(1);
+        effectCallBuilder.call().then(function(response) {
+          done();
+        }).catch(function(err) {
+          done(err);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
The culprit was that we were passing a reference to serverURL which was getting modified in the builders.