### PR TITLE
Add method to verify SEP0010 "Challenge" Transaction.

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -51,3 +51,14 @@ export class BadResponseError extends NetworkError {
     this.constructor = BadResponseError;
   }
 }
+
+export class InvalidSep10ChallengeError extends Error {
+  public __proto__: InvalidSep10ChallengeError;
+
+  constructor(message: string) {
+    const trueProto = new.target.prototype;
+    super(message);
+    this.__proto__ = trueProto;
+    this.constructor = InvalidSep10ChallengeError;
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,6 +99,20 @@ export namespace Utils {
       throw new InvalidSep10ChallengeError("The transaction is not signed");
     }
 
+    if (transaction.operations.length !== 1) {
+      throw new InvalidSep10ChallengeError(
+        "The transaction should contain only one operation",
+      );
+    }
+
+    const [operation] = transaction.operations;
+
+    if (!operation.source) {
+      throw new InvalidSep10ChallengeError(
+        "The transaction should contain a source account",
+      );
+    }
+
     return true;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,8 +116,8 @@ export namespace Utils {
     }
 
     const hashedSignatureBase = transaction.hash();
-    const serverKeypair = Keypair.fromPublicKey(serverAccountId);
 
+    const serverKeypair = Keypair.fromPublicKey(serverAccountId);
     const signedByServer = transaction.signatures.find((sig) => {
       return serverKeypair.verify(hashedSignatureBase, sig.signature());
     });
@@ -125,6 +125,17 @@ export namespace Utils {
     if (!signedByServer) {
       throw new InvalidSep10ChallengeError(
         "The transaction is not signed by the server",
+      );
+    }
+
+    const clientKeypair = Keypair.fromPublicKey(operation.source as string);
+    const signedByClient = transaction.signatures.find((sig) => {
+      return clientKeypair.verify(hashedSignatureBase, sig.signature());
+    });
+
+    if (!signedByClient) {
+      throw new InvalidSep10ChallengeError(
+        "The transaction is not signed by the client",
       );
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,8 +91,12 @@ export namespace Utils {
 
     if (transaction.source !== serverAccountId) {
       throw new InvalidSep10ChallengeError(
-        "Transaction source account is not equal to the server's account",
+        "The transaction source account is not equal to the server's account",
       );
+    }
+
+    if (transaction.signatures.length === 0) {
+      throw new InvalidSep10ChallengeError("The transaction is not signed");
     }
 
     return true;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,13 +132,13 @@ export namespace Utils {
       );
     }
 
-    if (!signedBy(transaction, serverAccountId)) {
+    if (!verifyTxSignedBy(transaction, serverAccountId)) {
       throw new InvalidSep10ChallengeError(
         "The transaction is not signed by the server",
       );
     }
 
-    if (!signedBy(transaction, operation.source as string)) {
+    if (!verifyTxSignedBy(transaction, operation.source as string)) {
       throw new InvalidSep10ChallengeError(
         "The transaction is not signed by the client",
       );
@@ -149,6 +149,19 @@ export namespace Utils {
     }
 
     return true;
+  }
+
+  function verifyTxSignedBy(
+    transaction: Transaction,
+    accountId: string,
+  ): boolean {
+    const hashedSignatureBase = transaction.hash();
+
+    const keypair = Keypair.fromPublicKey(accountId);
+
+    return !!transaction.signatures.find((sig) => {
+      return keypair.verify(hashedSignatureBase, sig.signature());
+    });
   }
 
   function validateTimebounds(transaction: Transaction): boolean {
@@ -162,15 +175,5 @@ export namespace Utils {
     return (
       now >= Number.parseInt(minTime, 10) && now <= Number.parseInt(maxTime, 10)
     );
-  }
-
-  function signedBy(transaction: Transaction, accountId: string): boolean {
-    const hashedSignatureBase = transaction.hash();
-
-    const keypair = Keypair.fromPublicKey(accountId);
-
-    return !!transaction.signatures.find((sig) => {
-      return keypair.verify(hashedSignatureBase, sig.signature());
-    });
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -151,7 +151,26 @@ export namespace Utils {
     return true;
   }
 
-  function verifyTxSignedBy(
+  /**
+   * Verifies if a transaction was signed by the given account id.
+   *
+   * @function
+   * @memberof Utils
+   * @param {Transaction} transaction
+   * @param {string} accountID
+   * @example
+   * let keypair = Keypair.random();
+   * const account = new StellarSdk.Account(keypair.publicKey(), "-1");
+   *
+   * const transaction = new TransactionBuilder(account, { fee: 100 })
+   *    .setTimeout(30)
+   *    .build();
+   *
+   * transaction.sign(keypair)
+   * Utils.verifyTxSignedBy(transaction, keypair.publicKey())
+   * @returns {boolean}.
+   */
+  export function verifyTxSignedBy(
     transaction: Transaction,
     accountId: string,
   ): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,10 +95,6 @@ export namespace Utils {
       );
     }
 
-    if (transaction.signatures.length === 0) {
-      throw new InvalidSep10ChallengeError("The transaction is not signed");
-    }
-
     if (transaction.operations.length !== 1) {
       throw new InvalidSep10ChallengeError(
         "The transaction should contain only one operation",
@@ -116,6 +112,19 @@ export namespace Utils {
     if (operation.type !== "manageData") {
       throw new InvalidSep10ChallengeError(
         "The transaction's operation should be manageData",
+      );
+    }
+
+    const hashedSignatureBase = transaction.hash();
+    const serverKeypair = Keypair.fromPublicKey(serverAccountId);
+
+    const signedByServer = transaction.signatures.find((sig) => {
+      return serverKeypair.verify(hashedSignatureBase, sig.signature());
+    });
+
+    if (!signedByServer) {
+      throw new InvalidSep10ChallengeError(
+        "The transaction is not signed by the server",
       );
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,6 +70,15 @@ export namespace Utils {
    * Verifies if a transaction is a valid [SEP0010](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md)
    * challenge transaction.
    *
+   * This function performs the following checks:
+   *
+   *   1. Verifies that the transaction's source is the same as the server account id.
+   *   2. Verifies that the number of operations in the transaction is equal to one and of type manageData.
+   *   3. Verifies if timeBounds are still valid.
+   *   4. Verifies if the transaction has been signed by the server and the client.
+   *   5. Verifies that the sequenceNumber is equal to zero.
+   *
+   *
    * @see [SEP0010: Stellar Web Authentication](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md)
    * @function
    * @memberof Utils

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,8 +4,10 @@ import {
   BASE_FEE,
   Keypair,
   Operation,
+  Transaction,
   TransactionBuilder,
 } from "stellar-base";
+import { InvalidSep10ChallengeError } from "./errors";
 
 /**
  * @namespace Utils
@@ -62,5 +64,37 @@ export namespace Utils {
       .toEnvelope()
       .toXDR("base64")
       .toString();
+  }
+
+  /**
+   * Verifies if a transaction is a valid [SEP0010](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md)
+   * challenge transaction.
+   *
+   * @see [SEP0010: Stellar Web Authentication](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md)
+   * @function
+   * @memberof Utils
+   * @param {string} challengeTx SEP0010 transaction challenge transaction in base64.
+   * @param {string} serverAccountID The server's stellar account.
+   * @example
+   * import { Utils, Network }  from 'stellar-sdk'
+   *
+   * Network.useTestNetwork();
+   *
+   * let challenge = Utils.verifyChallengeTx("base64tx", "server-account-id")
+   * @returns {boolean}
+   */
+  export function verifyChallengeTx(
+    challengeTx: string,
+    serverAccountId: string,
+  ): boolean {
+    const transaction = new Transaction(challengeTx);
+
+    if (transaction.source !== serverAccountId) {
+      throw new InvalidSep10ChallengeError(
+        "Transaction source account is not equal to the server's account",
+      );
+    }
+
+    return true;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,7 +109,13 @@ export namespace Utils {
 
     if (!operation.source) {
       throw new InvalidSep10ChallengeError(
-        "The transaction should contain a source account",
+        "The transaction's operation should contain a source account",
+      );
+    }
+
+    if (operation.type !== "manageData") {
+      throw new InvalidSep10ChallengeError(
+        "The transaction's operation should be manageData",
       );
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -98,6 +98,14 @@ export namespace Utils {
   ): boolean {
     const transaction = new Transaction(challengeTx);
 
+    const sequence = Number.parseInt(transaction.sequence, 10);
+
+    if (sequence !== 0) {
+      throw new InvalidSep10ChallengeError(
+        "The transaction sequence number should be zero",
+      );
+    }
+
     if (transaction.source !== serverAccountId) {
       throw new InvalidSep10ChallengeError(
         "The transaction source account is not equal to the server's account",

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -173,5 +173,22 @@ describe('Utils', function() {
         /The transaction is not signed by the server/
       );
     });
+
+    it('throws an error if transaction is not signed by the client', function() {
+      let keypair = StellarSdk.Keypair.random();
+
+      const challenge = StellarSdk.Utils.buildChallengeTx(
+        keypair,
+        "GBDIT5GUJ7R5BXO3GJHFXJ6AZ5UQK6MNOIDMPQUSMXLIHTUNR2Q5CFNF",
+        "SDF"
+      );
+
+      expect(
+        () => StellarSdk.Utils.verifyChallengeTx(challenge, keypair.publicKey())
+      ).to.throw(
+        StellarSdk.InvalidSep10ChallengeError,
+        /The transaction is not signed by the client/
+      );
+    });
   });
 });

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -133,7 +133,34 @@ describe('Utils', function() {
         () => StellarSdk.Utils.verifyChallengeTx(challenge, keypair.publicKey())
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /The transaction should contain a source account/
+        /The transaction\'s operation should contain a source account/
+      );
+    });
+
+    it('throws an error if operation is not manage data', function() {
+      let keypair = StellarSdk.Keypair.random();
+      const account = new StellarSdk.Account(keypair.publicKey(), "-1");
+      const transaction = new StellarSdk.TransactionBuilder(account, { fee: 100 })
+            .addOperation(
+              StellarSdk.Operation.accountMerge({
+                destination: keypair.publicKey(),
+                source: keypair.publicKey()
+              })
+            )
+            .setTimeout(30)
+            .build();
+
+      transaction.sign(keypair);
+      const challenge = transaction
+            .toEnvelope()
+            .toXDR("base64")
+            .toString();
+
+      expect(
+        () => StellarSdk.Utils.verifyChallengeTx(challenge, keypair.publicKey())
+      ).to.throw(
+        StellarSdk.InvalidSep10ChallengeError,
+        /The transaction\'s operation should be manageData/
       );
     });
   });

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -1,4 +1,8 @@
 describe('Utils', function() {
+  beforeEach(function() {
+    StellarSdk.Network.useTestNetwork();
+  });
+
   describe('Utils.buildChallengeTx', function() {
     it('returns challenge which follows SEP0010 spec', function() {
       let keypair = StellarSdk.Keypair.random();
@@ -40,6 +44,27 @@ describe('Utils', function() {
       const transaction = new StellarSdk.Transaction(challenge);
       const { maxTime, minTime } = transaction.timeBounds;
       expect(parseInt(maxTime) - parseInt(minTime)).to.eql(600);
+    });
+  });
+
+  describe('Utils.verifyChallengeTx', function() {
+    it('throws an error if transaction source account is different to server account id', function() {
+      let keypair = StellarSdk.Keypair.random();
+
+      const challenge = StellarSdk.Utils.buildChallengeTx(
+        keypair,
+        "GBDIT5GUJ7R5BXO3GJHFXJ6AZ5UQK6MNOIDMPQUSMXLIHTUNR2Q5CFNF",
+        "SDF"
+      );
+
+      let serverAccountId = StellarSdk.Keypair.random().publicKey();
+
+      expect(
+        () => StellarSdk.Utils.verifyChallengeTx(challenge, serverAccountId)
+      ).to.throw(
+        StellarSdk.InvalidSep10ChallengeError,
+        /Transaction source account is not equal to the server's account/
+      );
     });
   });
 });

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -277,4 +277,36 @@ describe('Utils', function() {
       );
     });
   });
+
+  describe('Utils.verifyTxSignedBy', function() {
+    beforeEach(function() {
+      this.keypair = StellarSdk.Keypair.random();
+      this.account = new StellarSdk.Account(this.keypair.publicKey(), "-1");
+      this.transaction = new StellarSdk.TransactionBuilder(this.account, { fee: 100 })
+        .setTimeout(30)
+        .build();
+    });
+
+    afterEach(function() {
+      this.keypair, this.account, this.transaction = null;
+    });
+
+    it('returns true if the transaction was signed by the given account', function() {
+      this.transaction.sign(this.keypair);
+
+      expect(StellarSdk.Utils.verifyTxSignedBy(this.transaction, this.keypair.publicKey())).to.eql(true);
+    });
+
+    it('returns false if the transaction was not signed by the given account', function() {
+      this.transaction.sign(this.keypair);
+
+      let differentKeypair = StellarSdk.Keypair.random();
+
+      expect(StellarSdk.Utils.verifyTxSignedBy(this.transaction, differentKeypair.publicKey())).to.eql(false);
+    });
+
+    it('works with an unsigned transaction', function() {
+      expect(StellarSdk.Utils.verifyTxSignedBy(this.transaction, this.keypair.publicKey())).to.eql(false);
+    });
+  });
 });

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -86,6 +86,27 @@ describe('Utils', function() {
       expect(StellarSdk.Utils.verifyChallengeTx(signedChallenge, keypair.publicKey())).to.eql(true);
     });
 
+    it('throws an error if transaction sequenceNumber if different to zero', function() {
+      let keypair = StellarSdk.Keypair.random();
+
+      const account = new StellarSdk.Account(keypair.publicKey(), "100");
+      const transaction = new StellarSdk.TransactionBuilder(account, { fee: 100 })
+            .setTimeout(30)
+            .build();
+
+      let challenge = transaction
+          .toEnvelope()
+          .toXDR("base64")
+          .toString();
+
+      expect(
+        () => StellarSdk.Utils.verifyChallengeTx(challenge, keypair.publicKey())
+      ).to.throw(
+        StellarSdk.InvalidSep10ChallengeError,
+        /The transaction sequence number should be zero/
+      );
+    });
+
     it('throws an error if transaction source account is different to server account id', function() {
       let keypair = StellarSdk.Keypair.random();
 

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -51,8 +51,13 @@ describe('Utils', function() {
       );
 
       const transaction = new StellarSdk.Transaction(challenge);
-      const { maxTime, minTime } = transaction.timeBounds;
-      expect(parseInt(maxTime) - parseInt(minTime)).to.eql(600);
+
+      let maxTime = parseInt(transaction.timeBounds.maxTime);
+      let minTime = parseInt(transaction.timeBounds.minTime);
+
+      expect(minTime).to.eql(0);
+      expect(maxTime).to.eql(600);
+      expect(maxTime - minTime).to.eql(600);
     });
   });
 

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -63,7 +63,27 @@ describe('Utils', function() {
         () => StellarSdk.Utils.verifyChallengeTx(challenge, serverAccountId)
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /Transaction source account is not equal to the server's account/
+        /The transaction source account is not equal to the server's account/
+      );
+    });
+
+    it('throws an error if transaction has no signatures', function() {
+      let keypair = StellarSdk.Keypair.random();
+      const account = new StellarSdk.Account(keypair.publicKey(), "-1");
+      const transaction = new StellarSdk.TransactionBuilder(account, { fee: 100 })
+            .setTimeout(30)
+            .build();
+
+      const challenge = transaction
+            .toEnvelope()
+            .toXDR("base64")
+            .toString();
+
+      expect(
+        () => StellarSdk.Utils.verifyChallengeTx(challenge, keypair.publicKey())
+      ).to.throw(
+        StellarSdk.InvalidSep10ChallengeError,
+        /The transaction is not signed/
       );
     });
   });


### PR DESCRIPTION
Fixes #369

## Task


- [x] verify that transaction source account is equal to the server's signing key;
- [x] verify that transaction has time bounds set, and that current time is between the minimum and maximum bounds;
- [x] verify that transaction contains a single Manage Data operation and its source account is not null;
- [x] verify that transaction envelope has a correct signature by server's signing key;
- [x] verify that transaction envelope has a correct signature by the operation's source account;

