### PR TITLE
Fix #391: Remove instance check for MessageEvent on stream error.

### DIFF
--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -141,8 +141,8 @@ export class CallBuilder<
         };
 
         es.onerror = (error) => {
-          if (options.onerror && error instanceof MessageEvent) {
-            options.onerror(error);
+          if (options.onerror) {
+            options.onerror(error as MessageEvent);
           }
         };
       }

--- a/test/integration/streaming_test.js
+++ b/test/integration/streaming_test.js
@@ -1,0 +1,42 @@
+const http = require("http");
+const url = require("url");
+const port = 3100;
+
+describe("integration tests: streaming", function(done) {
+  if (typeof window !== "undefined") {
+    done();
+    return;
+  }
+
+  it("handles onerror", function(done) {
+    let server;
+    let closeStream;
+
+    const requestHandler = (request, response) => {
+      // returning a 401 will call the onerror callback.
+      response.statusCode = 401;
+      response.end();
+      server.close();
+    };
+
+    server = http.createServer(requestHandler);
+    server.listen(port, (err) => {
+      if (err) {
+        done(err);
+        return;
+      }
+
+      closeStream = new StellarSdk.Server(`http://localhost:${port}`, {
+        allowHttp: true,
+      })
+        .operations()
+        .stream({
+          onerror: (err) => {
+            server.close();
+            closeStream();
+            done();
+          },
+        });
+    });
+  });
+});


### PR DESCRIPTION
Using `MessageEvent` will throw an error if you are running the SDK on
Node (this API is not present in Node).

This was added in the TypeScript migration to match the expected
interface.

Checking the `error` instance shouldn't be a concern on the SDK but
the consumer, is up to the consumer what to do with an
error. Additionally we shouldn't be hiding errors just because they
don't match a given interface.