### PR TITLE
Fix manage data value in SEP0010 challenge builder.

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "eventsource": "^1.0.7",
     "lodash": "^4.17.11",
     "randombytes": "^2.1.0",
-    "stellar-base": "^1.0.3",
+    "stellar-base": "^1.1.1",
     "toml": "^2.3.0",
     "tslib": "^1.10.0",
     "urijs": "^1.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7855,10 +7855,10 @@ statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
 
-stellar-base@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-1.0.3.tgz#8d3121ca1ce85321b0647c44e69e5877be8e16e1"
-  integrity sha512-1JP/OnjUfbXryrICQJOrxsGgw9VlsgdpGje67692uI9mN8xP+2EyTF1fDs2KllO1Xx/6AaIB+DaU9VGv2nBMgw==
+stellar-base@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-1.1.1.tgz#2a97b25584e3e92241a601903a96a776938848cf"
+  integrity sha512-E7L6bjM2OlY4wtf+G9ruG52/LXP/Bs7i5L4jbJJK+RFK/2jp6CNqK97i8/isKF/XpO46WW14EwqOUnXvVfBioQ==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^4.0.0"


### PR DESCRIPTION
>The value must be a 64 byte long base64 encoded
>cryptographic-quality random string

We were generating a 64 bytes nonce which wasn't necessarily encoded in base64.

Closes #395