### PR TITLE
Set name in custom errors

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -31,6 +31,7 @@ export class NotFoundError extends NetworkError {
     super(message, response);
     this.__proto__ = trueProto;
     this.constructor = NotFoundError;
+    this.name = "NotFoundError";
   }
 }
 
@@ -40,6 +41,7 @@ export class BadRequestError extends NetworkError {
     super(message, response);
     this.__proto__ = trueProto;
     this.constructor = BadRequestError;
+    this.name = "BadRequestError";
   }
 }
 
@@ -49,6 +51,7 @@ export class BadResponseError extends NetworkError {
     super(message, response);
     this.__proto__ = trueProto;
     this.constructor = BadResponseError;
+    this.name = "BadResponseError";
   }
 }
 
@@ -60,5 +63,6 @@ export class InvalidSep10ChallengeError extends Error {
     super(message);
     this.__proto__ = trueProto;
     this.constructor = InvalidSep10ChallengeError;
+    this.name = "InvalidSep10ChallengeError";
   }
 }


### PR DESCRIPTION
Because the user needs to be able to test if an error is a `NotFoundError`, ... or whatever.

Keep in mind that in JavaScript/TypeScript you cannot really use `instanceof` for that, at least not across packages. There is always a chance that there are multiple versions of the package installed somewhere in the dependency tree and testing an error thrown by stellar-sdk in version A with `instanceof` against a class imported from stellar-sdk version B will return `false` even though it is such an error, but instantiated by the other version of the same package.

Update: You cannot use `instanceof`, anyway, as the constructors explicitly overwrite the error's prototype.