### PR TITLE
Also listen to stream events with addEventListener

### DIFF
--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -126,7 +126,7 @@ export class CallBuilder<
       createTimeout();
 
       if (es) {
-        es.onmessage = (message) => {
+        const onMessage = (message: any) => {
           const result = message.data
             ? this._parseRecord(JSON.parse(message.data))
             : message;
@@ -140,11 +140,20 @@ export class CallBuilder<
           }
         };
 
-        es.onerror = (error) => {
+        const onError = (error: any) => {
           if (options.onerror) {
             options.onerror(error as MessageEvent);
           }
         };
+
+        es.onmessage = onMessage;
+        es.onerror = onError;
+
+        // use addEventListener too, just in case
+        if (es.addEventListener) {
+          es.addEventListener("message", onMessage);
+          es.addEventListener("error", onError);
+        }
       }
 
       return es;

--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -146,13 +146,13 @@ export class CallBuilder<
           }
         };
 
-        es.onmessage = onMessage;
-        es.onerror = onError;
+        es.onmessage = onMessage.bind(this);
+        es.onerror = onError.bind(this);
 
         // use addEventListener too, just in case
         if (es.addEventListener) {
-          es.addEventListener("message", onMessage);
-          es.addEventListener("error", onError);
+          es.addEventListener("message", onMessage.bind(this));
+          es.addEventListener("error", onError.bind(this));
         }
       }
 

--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -146,13 +146,13 @@ export class CallBuilder<
           }
         };
 
-        es.onmessage = onMessage.bind(this);
-        es.onerror = onError.bind(this);
-
         // use addEventListener too, just in case
         if (es.addEventListener) {
           es.addEventListener("message", onMessage.bind(this));
           es.addEventListener("error", onError.bind(this));
+        } else {
+          es.onmessage = onMessage.bind(this);
+          es.onerror = onError.bind(this);
         }
       }
 


### PR DESCRIPTION
Some EventSource polyfills (like one React Native package) support addEventListener but not onmessage / onerror. It's possible other implementations could use onmessage but not addEventListener. So to be safe, use both.