### PR TITLE
enforce number type on check to start and end time for trade aggregations

### DIFF
--- a/src/trade_aggregation_call_builder.ts
+++ b/src/trade_aggregation_call_builder.ts
@@ -58,7 +58,7 @@ export class TradeAggregationCallBuilder extends CallBuilder<
     } else {
       this.url.setQuery("counter_asset_type", "native");
     }
-    if (typeof start_time === "undefined" || typeof end_time === "undefined") {
+    if (typeof start_time !== "number" || typeof end_time !== "number") {
       throw new BadRequestError("Invalid time bounds", [start_time, end_time]);
     } else {
       this.url.setQuery("start_time", start_time.toString());


### PR DESCRIPTION
Fixes #398 .

This seems to make sense, we should expect a number since both of these are of type number -- that being said, I do not have typescript experience so it is possible this is redundant (yet if it was redundant, #398 shouldn't happen). 