### PR TITLE
Drop Support for Node 6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 matrix:
   include:
-    - node_js: 6.14.0
-    - node_js: 6.14.0
+    - node_js: 10.16.3
+    - node_js: 10.16.3
       env: SAUCE=true
-    - node_js: 6.14.0
+    - node_js: 10.16.3
       env: INTEGRATION=true
 cache:
   directories:
@@ -60,7 +60,7 @@ deploy:
     on:
       tags: true
       repo: stellar/js-stellar-sdk
-      node: 6.14.0
+      node: 10.16.3
       condition: "$INTEGRATION = true"
   - provider: script
     script: "./bower_publish.sh"
@@ -68,5 +68,5 @@ deploy:
     on:
       tags: true
       repo: stellar/js-stellar-sdk
-      node: 6.14.0
+      node: 10.16.3
       condition: "$INTEGRATION = true"

--- a/README.md
+++ b/README.md
@@ -156,17 +156,17 @@ cd js-stellar-sdk
 npm install
 ```
 
-3. Install Node 6.14.0
+3. Install Node 10.16.3
 
 Because we support earlier versions of Node, please install and develop on Node
-6.14.0 so you don't get surprised when your code works locally but breaks in CI.
+10.16.3 so you don't get surprised when your code works locally but breaks in CI.
 
 Here's out to install `nvm` if you haven't: https://github.com/creationix/nvm
 
 ```shell
 nvm install
 
-# if you've never installed 6.14.0 before you'll want to re-install yarn
+# if you've never installed 10.16.3 before you'll want to re-install yarn
 npm install -g yarn
 ```
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "url": "https://github.com/stellar/js-stellar-sdk.git"
   },
   "engines": {
-    "node": ">=6.14.0"
+    "node": ">=10.16.3"
   },
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Node 6 has been end-of-lifed and no longer in LTS. We now require Node 10 which is the current LTS until April 1st, 2021.