### PR TITLE
Remove bower from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,11 @@ Using npm to include js-stellar-sdk in your own project:
 npm install --save stellar-sdk
 ```
 
-For browsers,
-[use Bower to install js-stellar-sdk](#to-self-host-for-use-in-the-browser). It
-exports a variable `StellarSdk`. The example below assumes you have
-`stellar-sdk.js` relative to your html file.
+Alternatively, you can use jsDelivr or cdnjs in a browser
 
 ```html
-<script src="stellar-sdk.js"></script>
-<script>
-  console.log(StellarSdk);
-</script>
-```
+<script src="https://cdn.jsdelivr.net/npm/stellar-sdk@latest/lib/index.min.js"></script>
+````
 
 ## Install
 


### PR DESCRIPTION
bower is a deprecated project we shouldn't be mentioning it.  Replace it with a cdnjs tag for people who just want to run something.