### PR TITLE
Add support for strict-send and strict-receive paths end-point.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 A breaking change will get clearly marked in this log.
 
+## Unreleased
+
+### Add ➕
+
+- Add `server.strictReceivePaths` which adds support for `/paths/strict-receive`. ([444](https://github.com/stellar/js-stellar-sdk/pull/444))
+  This function takes a list of source assets or a source address, a destination
+  address, a destination asset and a destination amount.
+
+  You can call it passing a list of source assets:
+
+  ```
+  server.strictReceivePaths(sourceAssets,destinationAccount,destinationAsset, destinationAmount)
+  ```
+
+  Or a by passing a Stellar source account address:
+
+  ```
+  server.strictReceivePaths(sourceAccount,destinationAccount,destinationAsset, destinationAmount)
+  ```
+
+  When you call this function with a Stellar account address, it will look at the account’s trustlines and use them to determine all payment paths that can satisfy the desired amount.
+
+- Add `server.strictSendPaths` which adds support for `/paths/strict-send`. ([444](https://github.com/stellar/js-stellar-sdk/pull/444))
+  This function takes the asset you want to send, and the amount of that asset,
+  along with either a list of destination assets or a destination address.
+
+  You can call it passing a list of destination assets:
+
+  ```
+  server.strictSendPaths(sourceAsset, sourceAmount, [destinationAsset]).call()
+  ```
+
+  Or a by passing a Stellar account address:
+
+  ```
+  server.strictSendPaths(sourceAsset, sourceAmount, "GDRREYWHQWJDICNH4SAH4TT2JRBYRPTDYIMLK4UWBDT3X3ZVVYT6I4UQ").call()
+  ```
+
+  When you call this function with a Stellar account address, it will look at the account’s trustlines and use them to determine all payment paths that can satisfy the desired amount.
+
+### Deprecated ⚠️
+
+- [Server#paths](https://stellar.github.io/js-stellar-sdk/Server.html#paths) is deprecated in favor of [Server#strictReceivePaths](https://stellar.github.io/js-stellar-sdk/Server.html#strictReceivePaths). ([444](https://github.com/stellar/js-stellar-sdk/pull/444))
+
 ## [v3.0.1](https://github.com/stellar/js-stellar-sdk/compare/v3.0.0...v3.0.1)
 
 ### Add

--- a/src/strict_receive_path_call_builder.ts
+++ b/src/strict_receive_path_call_builder.ts
@@ -1,0 +1,79 @@
+import { Asset } from "stellar-base";
+import { CallBuilder } from "./call_builder";
+import { ServerApi } from "./server_api";
+
+/**
+ * The Stellar Network allows payments to be made across assets through path
+ * payments. A strict receive path payment specifies a series of assets to route
+ * a payment through, from source asset (the asset debited from the payer) to
+ * destination asset (the asset credited to the payee).
+ *
+ * A path search is specified using:
+ *
+ * * The source address or source assets.
+ * * The destination address
+ * * The asset and amount that the destination account should receive
+ *
+ * As part of the search, horizon will load a list of assets available to the
+ * source address and will find any payment paths from those source assets to
+ * the desired destination asset. The search's amount parameter will be used to
+ * determine if there a given path can satisfy a payment of the desired amount.
+ *
+ * If a list of assets is passed as the source, horizon will find any payment
+ * paths from those source assets to the desired destination asset.
+ *
+ * Do not create this object directly, use {@link Server#strictReceivePaths}.
+ * @see [Find Payment Paths](https://www.stellar.org/developers/horizon/reference/endpoints/path-finding.html)
+ * @extends CallBuilder
+ * @param {string} serverUrl Horizon server URL.
+ * @param {string|Asset[]} source The sender's account ID or a list of Assets. Any returned path must use a source that the sender can hold.
+ * @param {string} destination The destination account ID that any returned path should use.
+ * @param {Asset} destinationAsset The destination asset.
+ * @param {string} destinationAmount The amount, denominated in the destination asset, that any returned path should be able to satisfy.
+ */
+export class StrictReceivePathCallBuilder extends CallBuilder<
+  ServerApi.CollectionPage<ServerApi.PaymentPathRecord>
+> {
+  constructor(
+    serverUrl: uri.URI,
+    source: string | Asset[],
+    destination: string,
+    destinationAsset: Asset,
+    destinationAmount: string,
+  ) {
+    super(serverUrl);
+    this.url.segment("paths/strict-receive");
+    this.url.setQuery("destination_account", destination);
+
+    if (typeof source === "string") {
+      this.url.setQuery("source_account", source);
+    } else {
+      const assets = source
+        .map((asset) => {
+          if (asset.isNative()) {
+            return "native";
+          }
+
+          return `${asset.getCode()}:${asset.getIssuer()}`;
+        })
+        .join(",");
+      this.url.setQuery("source_assets", assets);
+    }
+
+    this.url.setQuery("destination_amount", destinationAmount);
+
+    if (!destinationAsset.isNative()) {
+      this.url.setQuery(
+        "destination_asset_type",
+        destinationAsset.getAssetType(),
+      );
+      this.url.setQuery("destination_asset_code", destinationAsset.getCode());
+      this.url.setQuery(
+        "destination_asset_issuer",
+        destinationAsset.getIssuer(),
+      );
+    } else {
+      this.url.setQuery("destination_asset_type", "native");
+    }
+  }
+}

--- a/src/strict_send_path_call_builder.ts
+++ b/src/strict_send_path_call_builder.ts
@@ -1,0 +1,71 @@
+import { Asset } from "stellar-base";
+import { CallBuilder } from "./call_builder";
+import { ServerApi } from "./server_api";
+
+/**
+ * The Stellar Network allows payments to be made across assets through path
+ * payments. A strict send path payment specifies a series of assets to route a
+ * payment through, from source asset (the asset debited from the payer) to
+ * destination asset (the asset credited to the payee).
+ *
+ * A strict send path search is specified using:
+ *
+ * The source asset
+ * The source amount
+ * The destination assets or destination account.
+ *
+ * As part of the search, horizon will load a list of assets available to the
+ * source address and will find any payment paths from those source assets to
+ * the desired destination asset. The search's source_amount parameter will be
+ * used to determine if there a given path can satisfy a payment of the desired
+ * amount.
+ *
+ * Do not create this object directly, use {@link Server#strictSendPaths}.
+ * @see [Find Payment Paths](https://www.stellar.org/developers/horizon/reference/endpoints/path-finding.html)
+ * @extends CallBuilder
+ * @param {string} serverUrl Horizon server URL.
+ * @param {Asset} sourceAsset The asset to be sent.
+ * @param {string} sourceAmount The amount, denominated in the source asset, that any returned path should be able to satisfy.
+ * @param {string|Asset[]} destination The destination account or the destination assets.
+ *
+ */
+export class StrictSendPathCallBuilder extends CallBuilder<
+  ServerApi.CollectionPage<ServerApi.PaymentPathRecord>
+> {
+  constructor(
+    serverUrl: uri.URI,
+    sourceAsset: Asset,
+    sourceAmount: string,
+    destination: string | Asset[],
+  ) {
+    super(serverUrl);
+
+    this.url.segment("paths/strict-send");
+
+    if (sourceAsset.isNative()) {
+      this.url.setQuery("source_asset_type", "native");
+    } else {
+      this.url.setQuery("source_asset_type", sourceAsset.getAssetType());
+      this.url.setQuery("source_asset_code", sourceAsset.getCode());
+      this.url.setQuery("source_asset_issuer", sourceAsset.getIssuer());
+    }
+
+    this.url.setQuery("source_amount", sourceAmount);
+
+    if (typeof destination === "string") {
+      this.url.setQuery("destination_account", destination);
+    } else {
+      const assets = destination
+        .map((asset) => {
+          if (asset.isNative()) {
+            return "native";
+          }
+
+          return `${asset.getCode()}:${asset.getIssuer()}`;
+        })
+        .join(",");
+
+      this.url.setQuery("destination_assets", assets);
+    }
+  }
+}

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -1463,6 +1463,309 @@ describe('server.js non-transaction tests', function() {
       });
     });
 
+    describe('StrictReceivePathCallBuilder', function() {
+      let pathsResponse = {
+        _embedded: {
+          records: [
+            {
+              destination_amount: '20.0000000',
+              destination_asset_code: 'EUR',
+              destination_asset_issuer:
+                'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+              destination_asset_type: 'credit_alphanum4',
+              path: [],
+              source_amount: '30.0000000',
+              source_asset_code: 'USD',
+              source_asset_issuer:
+                'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+              source_asset_type: 'credit_alphanum4'
+            },
+            {
+              destination_amount: '20.0000000',
+              destination_asset_code: 'EUR',
+              destination_asset_issuer:
+                'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+              destination_asset_type: 'credit_alphanum4',
+              path: [
+                {
+                  asset_code: '1',
+                  asset_issuer:
+                    'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+                  asset_type: 'credit_alphanum4'
+                }
+              ],
+              source_amount: '20.0000000',
+              source_asset_code: 'USD',
+              source_asset_issuer:
+                'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+              source_asset_type: 'credit_alphanum4'
+            },
+            {
+              destination_amount: '20.0000000',
+              destination_asset_code: 'EUR',
+              destination_asset_issuer:
+                'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+              destination_asset_type: 'credit_alphanum4',
+              path: [
+                {
+                  asset_code: '21',
+                  asset_issuer:
+                    'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+                  asset_type: 'credit_alphanum4'
+                },
+                {
+                  asset_code: '22',
+                  asset_issuer:
+                    'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+                  asset_type: 'credit_alphanum4'
+                }
+              ],
+              source_amount: '20.0000000',
+              source_asset_code: 'USD',
+              source_asset_issuer:
+                'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+              source_asset_type: 'credit_alphanum4'
+            }
+          ]
+        },
+        _links: {
+          self: {
+            href: '/paths/strict-receive'
+          }
+        }
+      };
+
+      it('requests the correct endpoint when source is an account', function(done) {
+        this.axiosMock
+          .expects('get')
+          .withArgs(
+            sinon.match(
+              'https://horizon-live.stellar.org:1337/paths/strict-receive?destination_account=GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V&source_account=GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP&destination_amount=20.0&destination_asset_type=credit_alphanum4&destination_asset_code=EUR&destination_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN'
+            )
+          )
+          .returns(Promise.resolve({ data: pathsResponse }));
+
+        this.server
+          .strictReceivePaths(
+            'GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP',
+            'GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V',
+            new StellarSdk.Asset(
+              'EUR',
+              'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN'
+            ),
+            '20.0'
+          ).call()
+          .then(function(response) {
+            expect(response.records).to.be.deep.equal(
+              pathsResponse._embedded.records
+            );
+            expect(response.next).to.be.function;
+            expect(response.prev).to.be.function;
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+      it('requests the correct endpoint when source is a list of assets', function(done) {
+        let destinationAssets = encodeURIComponent('native,EUR:GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN,USD:GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN');
+        this.axiosMock
+          .expects('get')
+          .withArgs(
+            sinon.match(
+              `https://horizon-live.stellar.org:1337/paths/strict-receive?destination_account=GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V&source_assets=${destinationAssets}&destination_amount=20.0&destination_asset_type=credit_alphanum4&destination_asset_code=EUR&destination_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN`
+            )
+          )
+          .returns(Promise.resolve({ data: pathsResponse }));
+
+        let assets = [
+          StellarSdk.Asset.native(),
+          new StellarSdk.Asset(
+            'EUR',
+            'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN'
+          ),
+          new StellarSdk.Asset(
+            'USD',
+            'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN'
+          )
+        ];
+
+        this.server
+          .strictReceivePaths(
+            assets,
+            'GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V',
+            new StellarSdk.Asset(
+              'EUR',
+              'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN'
+            ),
+            '20.0'
+          )
+          .call()
+          .then(function(response) {
+            expect(response.records).to.be.deep.equal(
+              pathsResponse._embedded.records
+            );
+            expect(response.next).to.be.function;
+            expect(response.prev).to.be.function;
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+    });
+    
+    describe('PathStrictSendCallBuilder', function() {
+      let pathsResponse = {
+        _embedded: {
+          records: [
+            {
+              destination_amount: '20.0000000',
+              destination_asset_code: 'EUR',
+              destination_asset_issuer:
+                'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+              destination_asset_type: 'credit_alphanum4',
+              path: [],
+              source_amount: '30.0000000',
+              source_asset_code: 'USD',
+              source_asset_issuer:
+                'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+              source_asset_type: 'credit_alphanum4'
+            },
+            {
+              destination_amount: '20.0000000',
+              destination_asset_code: 'EUR',
+              destination_asset_issuer:
+                'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+              destination_asset_type: 'credit_alphanum4',
+              path: [
+                {
+                  asset_code: '1',
+                  asset_issuer:
+                    'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+                  asset_type: 'credit_alphanum4'
+                }
+              ],
+              source_amount: '20.0000000',
+              source_asset_code: 'USD',
+              source_asset_issuer:
+                'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+              source_asset_type: 'credit_alphanum4'
+            },
+            {
+              destination_amount: '20.0000000',
+              destination_asset_code: 'EUR',
+              destination_asset_issuer:
+                'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+              destination_asset_type: 'credit_alphanum4',
+              path: [
+                {
+                  asset_code: '21',
+                  asset_issuer:
+                    'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+                  asset_type: 'credit_alphanum4'
+                },
+                {
+                  asset_code: '22',
+                  asset_issuer:
+                    'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+                  asset_type: 'credit_alphanum4'
+                }
+              ],
+              source_amount: '20.0000000',
+              source_asset_code: 'USD',
+              source_asset_issuer:
+                'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN',
+              source_asset_type: 'credit_alphanum4'
+            }
+          ]
+        },
+        _links: {
+          self: {
+            href: '/paths/strict-send'
+          }
+        }
+      };
+
+      it('requests the correct endpoint when destination is account', function(done) {
+        this.axiosMock
+          .expects('get')
+          .withArgs(
+            sinon.match(
+              'https://horizon-live.stellar.org:1337/paths/strict-send?source_asset_type=credit_alphanum4&source_asset_code=EUR&source_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN&source_amount=20.0&destination_account=GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V'
+            )
+          )
+          .returns(Promise.resolve({ data: pathsResponse }));
+
+        this.server
+          .strictSendPaths(
+            new StellarSdk.Asset(
+              'EUR',
+              'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN'
+            ),
+            '20.0',
+            'GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V'
+          )
+          .call()
+          .then(function(response) {
+            expect(response.records).to.be.deep.equal(
+              pathsResponse._embedded.records
+            );
+            expect(response.next).to.be.function;
+            expect(response.prev).to.be.function;
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+      it('requests the correct endpoint when destination is a list of assets', function(done) {
+        let destinationAssets = encodeURIComponent('native,EUR:GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN,USD:GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN');
+        this.axiosMock
+          .expects('get')
+          .withArgs(
+            sinon.match(
+              `https://horizon-live.stellar.org:1337/paths/strict-send?source_asset_type=credit_alphanum4&source_asset_code=EUR&source_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN&source_amount=20.0&destination_assets=${destinationAssets}`
+            )
+          )
+          .returns(Promise.resolve({ data: pathsResponse }));
+
+        let assets = [
+          StellarSdk.Asset.native(),
+          new StellarSdk.Asset(
+            'EUR',
+            'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN'
+          ),
+          new StellarSdk.Asset(
+            'USD',
+            'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN'
+          )
+        ];
+
+        this.server
+          .strictSendPaths(
+            new StellarSdk.Asset(
+              'EUR',
+              'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN'
+            ),
+            '20.0',
+            assets
+          )
+          .call()
+          .then(function(response) {
+            expect(response.records).to.be.deep.equal(
+              pathsResponse._embedded.records
+            );
+            expect(response.next).to.be.function;
+            expect(response.prev).to.be.function;
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+    });
+
     describe('EffectCallBuilder', function() {
       let effectsResponse = {
         _embedded: {


### PR DESCRIPTION
This PR adds support for `/paths/strict-send` and `/paths/strict-receive`  and deprecates `server.paths`

## Add ➕ 

### server.strictSendPaths

This request allows you to answer questions like  "Get me the most EUR possible for my 10 USD". 

 This functions takes the asset you want to send, the amount and a list of   assets or alternatively the destination address.

 You can call it passing a list of assets as destination:
  
  ```
  server.strictSendPaths(sourceAsset, sourceAmount, [destinationAsset]).call()
  ```

  Or an Stellar account address:

  ```
  server.strictSendPaths(sourceAsset, sourceAmount, "GDRREYWHQWJDICNH4SAH4TT2JRBYRPTDYIMLK4UWBDT3X3ZVVYT6I4UQ").call()
  ```

### server.strictReceivePaths

This request allows you to answer questions like  "How much EUR do it to send 10 USD?". 

You can call it passing a list of source assets:

```
server.strictReceivePaths(sourceAssets,destinationAccount,destinationAsset, destinationAmount)
```

Or a by passing a Stellar source account address:

```
server.strictReceivePaths(sourceAccount,destinationAccount,destinationAsset, destinationAmount)
```

When you call this function with a Stellar account address, it will look at the account’s trustlines and use them to determine all payment paths that can satisfy the desired amount.


## Deprecated ⚠️ 

- [Server#paths](https://stellar.github.io/js-stellar-sdk/Server.html#paths) is deprecated in favor of [Server#strictReceivePaths](https://stellar.github.io/js-stellar-sdk/Server.html#strictReceivePaths)