### PR TITLE
Remove deprecated argument destinationAccount on server.strictReceivePaths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Change ⚠️
+
+- Change arguments on [server.strictReceivePaths](https://stellar.github.io/js-stellar-sdk/Server.html#strictReceivePaths) since we included `destinationAccount` as argument, which is not longer required on Horizon. ([477](https://github.com/stellar/js-stellar-sdk/pull/447))
+
 ## [v3.1.0](https://github.com/stellar/js-stellar-sdk/compare/v3.0.0...v3.1.0)
 
 ### Add ➕
@@ -15,13 +19,13 @@ A breaking change will get clearly marked in this log.
   You can call it passing a list of source assets:
 
   ```
-  server.strictReceivePaths(sourceAssets,destinationAccount,destinationAsset, destinationAmount)
+  server.strictReceivePaths(sourceAssets,destinationAsset, destinationAmount)
   ```
 
   Or a by passing a Stellar source account address:
 
   ```
-  server.strictReceivePaths(sourceAccount,destinationAccount,destinationAsset, destinationAmount)
+  server.strictReceivePaths(sourceAccount,destinationAsset, destinationAmount)
   ```
 
   When you call this function with a Stellar account address, it will look at the account’s trustlines and use them to determine all payment paths that can satisfy the desired amount.

--- a/src/server.ts
+++ b/src/server.ts
@@ -584,21 +584,18 @@ export class Server {
    * paths from those source assets to the desired destination asset.
    *
    * @param {string|Asset[]} source The sender's account ID or a list of assets. Any returned path will use a source that the sender can hold.
-   * @param {string} destination The destination account ID that any returned path should use.
    * @param {Asset} destinationAsset The destination asset.
    * @param {string} destinationAmount The amount, denominated in the destination asset, that any returned path should be able to satisfy.
    * @returns {StrictReceivePathCallBuilder} New {@link StrictReceivePathCallBuilder} object configured with the current Horizon server configuration.
    */
   public strictReceivePaths(
     source: string | Asset[],
-    destination: string,
     destinationAsset: Asset,
     destinationAmount: string,
   ): PathCallBuilder {
     return new StrictReceivePathCallBuilder(
       URI(this.serverURL as any),
       source,
-      destination,
       destinationAsset,
       destinationAmount,
     );

--- a/src/strict_receive_path_call_builder.ts
+++ b/src/strict_receive_path_call_builder.ts
@@ -27,7 +27,6 @@ import { ServerApi } from "./server_api";
  * @extends CallBuilder
  * @param {string} serverUrl Horizon server URL.
  * @param {string|Asset[]} source The sender's account ID or a list of Assets. Any returned path must use a source that the sender can hold.
- * @param {string} destination The destination account ID that any returned path should use.
  * @param {Asset} destinationAsset The destination asset.
  * @param {string} destinationAmount The amount, denominated in the destination asset, that any returned path should be able to satisfy.
  */
@@ -37,13 +36,11 @@ export class StrictReceivePathCallBuilder extends CallBuilder<
   constructor(
     serverUrl: uri.URI,
     source: string | Asset[],
-    destination: string,
     destinationAsset: Asset,
     destinationAmount: string,
   ) {
     super(serverUrl);
     this.url.segment("paths/strict-receive");
-    this.url.setQuery("destination_account", destination);
 
     if (typeof source === "string") {
       this.url.setQuery("source_account", source);

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -1540,7 +1540,7 @@ describe('server.js non-transaction tests', function() {
           .expects('get')
           .withArgs(
             sinon.match(
-              'https://horizon-live.stellar.org:1337/paths/strict-receive?destination_account=GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V&source_account=GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP&destination_amount=20.0&destination_asset_type=credit_alphanum4&destination_asset_code=EUR&destination_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN'
+              'https://horizon-live.stellar.org:1337/paths/strict-receive?source_account=GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP&destination_amount=20.0&destination_asset_type=credit_alphanum4&destination_asset_code=EUR&destination_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN'
             )
           )
           .returns(Promise.resolve({ data: pathsResponse }));
@@ -1548,7 +1548,6 @@ describe('server.js non-transaction tests', function() {
         this.server
           .strictReceivePaths(
             'GARSFJNXJIHO6ULUBK3DBYKVSIZE7SC72S5DYBCHU7DKL22UXKVD7MXP',
-            'GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V',
             new StellarSdk.Asset(
               'EUR',
               'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN'
@@ -1573,7 +1572,7 @@ describe('server.js non-transaction tests', function() {
           .expects('get')
           .withArgs(
             sinon.match(
-              `https://horizon-live.stellar.org:1337/paths/strict-receive?destination_account=GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V&source_assets=${destinationAssets}&destination_amount=20.0&destination_asset_type=credit_alphanum4&destination_asset_code=EUR&destination_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN`
+              `https://horizon-live.stellar.org:1337/paths/strict-receive?source_assets=${destinationAssets}&destination_amount=20.0&destination_asset_type=credit_alphanum4&destination_asset_code=EUR&destination_asset_issuer=GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN`
             )
           )
           .returns(Promise.resolve({ data: pathsResponse }));
@@ -1593,7 +1592,6 @@ describe('server.js non-transaction tests', function() {
         this.server
           .strictReceivePaths(
             assets,
-            'GAEDTJ4PPEFVW5XV2S7LUXBEHNQMX5Q2GM562RJGOQG7GVCE5H3HIB4V',
             new StellarSdk.Asset(
               'EUR',
               'GDSBCQO34HWPGUGQSP3QBFEXVTSR2PW46UIGTHVWGWJGQKH3AFNHXHXN'


### PR DESCRIPTION
We included an argument on `strictReceivePaths` which is not longer required. This updates the method to take the right arguments. Fixes #466

Although this is a "breaking" change, we'll release this as a minor bump since this was just released yesterday and most of the people were using `server.paths` anyways. 

