### PR TITLE
Bump stellar-base to 2.1.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "eventsource": "^1.0.7",
     "lodash": "^4.17.11",
     "randombytes": "^2.1.0",
-    "stellar-base": "^2.0.1",
+    "stellar-base": "^2.1.2",
     "toml": "^2.3.0",
     "tslib": "^1.10.0",
     "urijs": "^1.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7591,10 +7591,10 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stellar-base@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-2.0.1.tgz#611bf7f844a451593eb9627d64aafb0cfb8e3df3"
-  integrity sha512-X42xGMjAlbEO2lE6quEAjd8p8PyvBCjdJZ0CkaD/FfmZhqqd9/sOQwjH1YQFfaHwzdIqbiYFnMc/pYVBfREI7g==
+stellar-base@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-2.1.2.tgz#bd7cc27f494fb1c7d7f2563efe25f7572880b1bf"
+  integrity sha512-/U0QFfMwCAa9I0TukfLzUhHvbEXSH2gGSB5ZbabeisnVf1FFFQBjazsNBfbKADrExWE+H3833DpckE6jynlIqg==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^4.0.0"


### PR DESCRIPTION
Force stellar-sdk to pick the latest version of stellar-base.  Fixes #451 .
