### PR TITLE
Add fee_charged an max_fee to TransactionResponse interface.

### DIFF
--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -31,6 +31,8 @@ export namespace Horizon {
     created_at: string;
     fee_meta_xdr: string;
     fee_paid: number;
+    fee_charged: number;
+    max_fee: number;
     id: string;
     memo_type: MemoType;
     memo?: string;


### PR DESCRIPTION
Document `fee_charged` and `max_fee` which were added in Horizon `0.18.0`. This fields should be used instead of `max_fee` which will be deprecated in Horizon 0.25.0

This is the first step before https://github.com/stellar/js-stellar-sdk/issues/450