### PR TITLE
Add string or number typing for upcoming type deprecations.

### DIFF
--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -203,7 +203,7 @@ export namespace Horizon {
       OperationResponseType.manageOffer,
       OperationResponseTypeI.manageOffer
     > {
-    offer_id: number;
+    offer_id: number | string;
     amount: string;
     buying_asset_type: AssetType;
     buying_asset_code?: string;
@@ -219,7 +219,7 @@ export namespace Horizon {
       OperationResponseType.createPassiveOffer,
       OperationResponseTypeI.createPassiveOffer
     > {
-    offer_id: number;
+    offer_id: number | string;
     amount: string;
     buying_asset_type: AssetType;
     buying_asset_code?: string;

--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -104,7 +104,7 @@ export namespace ServerApi {
     auth_revokable_flag?: boolean;
 
     // seq bumped
-    new_seq?: number;
+    new_seq?: number | string;
 
     // signer created / removed / updated
     weight?: number;
@@ -319,7 +319,7 @@ export namespace ServerApi {
         n: number;
       };
       price: string;
-      amount: string
+      amount: string;
     }>;
     asks: Array<{
       price_r: {
@@ -327,7 +327,7 @@ export namespace ServerApi {
         n: number;
       };
       price: string;
-      amount: string
+      amount: string;
     }>;
     base: Asset;
     counter: Asset;

--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -75,7 +75,7 @@ export namespace ServerApi {
     public_key?: string;
 
     // trade
-    offer_id?: number;
+    offer_id?: number | string;
     bought_amount?: string;
     bought_asset_type?: string;
     bought_asset_code?: string;
@@ -150,7 +150,7 @@ export namespace ServerApi {
   }
 
   export interface OfferRecord extends Horizon.BaseResponse {
-    id: string;
+    id: number | string;
     paging_token: string;
     seller: string;
     selling: OfferAsset;

--- a/src/trade_aggregation_call_builder.ts
+++ b/src/trade_aggregation_call_builder.ts
@@ -103,8 +103,8 @@ export class TradeAggregationCallBuilder extends CallBuilder<
 }
 
 interface TradeAggregationRecord extends Horizon.BaseResponse {
-  timestamp: string;
-  trade_count: number;
+  timestamp: number | string;
+  trade_count: number | string;
   base_volume: string;
   counter_volume: string;
   avg: string;


### PR DESCRIPTION
Horizon 0.25 will change the data type for multiple fields from `int64` to `string`, the main reason for this change is that JS doesn't have proper `int64` support, resulting in incorrect data.  

This change will let people start updating their code so it won't break once horizon change the data type to `string`.

The following are the fields changing, update your code to handle both `string` or `number` in the payload:

- `EffectRecord#offer_id`
- `EffectRecord#new_seq`
- `OfferRecord#id`
- `TradeAggregationRecord#timestam`
- `TradeAggregationRecord#trade_count`
- `ManageOfferOperationResponse#offer_id`
- `PassiveOfferOperationResponse#offer_id`



See the following issue more for information  https://github.com/stellar/go/issues/1609