### PR TITLE
doc: make README header engaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# js-stellar-sdk
-
-[![Build Status](https://travis-ci.com/stellar/js-stellar-sdk.svg?branch=master)](https://travis-ci.com/stellar/js-stellar-sdk)
-[![Coverage Status](https://coveralls.io/repos/stellar/js-stellar-sdk/badge.svg?branch=master&service=github)](https://coveralls.io/github/stellar/js-stellar-sdk?branch=master)
-[![Dependency Status](https://david-dm.org/stellar/js-stellar-sdk.svg)](https://david-dm.org/stellar/js-stellar-sdk)
+<div align="center">
+<img alt="Stellar" src="https://www.stellar.org/old-content/2019/03/stellar-logo-solo-1.png" width="558" />
+<br/>
+<strong>Creating equitable access to the global financial system</strong>
+<h1>js-stellar-sdk</h1>
+</div>
+<p align="center">
+<a href="https://travis-ci.com/stellar/js-stellar-sdk"><img alt="Build Status" src="https://travis-ci.com/stellar/js-stellar-sdk.svg?branch=master" /></a>
+<a href="https://coveralls.io/github/stellar/js-stellar-sdk?branch=master"><img alt="Coverage Status" src="https://coveralls.io/repos/stellar/js-stellar-sdk/badge.svg?branch=master&service=github" /></a>
+</p>
 
 js-stellar-sdk is a Javascript library for communicating with a
 [Stellar Horizon server](https://github.com/stellar/go/tree/master/services/horizon).


### PR DESCRIPTION
### What

Change the beginning of the `README` to include the Stellar logo, and Stellar's mission.

See it fully rendered at:
https://github.com/leighmcculloch/stellar--js-stellar-sdk/blob/sparkle/README.md

I also removed the Dependency Status badge because it was broken. Let me know if you know how I can fix it and I'll do that instead.

### Why

At GitHub Universe one of the talks I attended talked about how creating an inviting and engaging README makes a huge difference to communicating to developers who are coming across the project. The [dev.to README] was given as an example of a great README that goes a long way to engage poeple who visit the project. I think there's probably a lot of things we can do to make our README more alive to someone visiting it, and adding our logo and including our mission is just one small thing.

The same change has been merged on the `stellar/go` repository in stellar/go#1948.

[dev.to README]: https://github.com/thepracticaldev/dev.to/blob/master/README.md