### PR TITLE
Add typings for new fields in fee_stats.

### DIFF
--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -312,6 +312,22 @@ export namespace Horizon {
   export interface TransactionResponseCollection
     extends ResponseCollection<TransactionResponse> {}
 
+  export interface FeeDistribution {
+    max: string;
+    min: string;
+    mode: string;
+    p10: string;
+    p20: string;
+    p30: string;
+    p40: string;
+    p50: string;
+    p60: string;
+    p70: string;
+    p80: string;
+    p90: string;
+    p95: string;
+    p99: string;
+  }
   export interface FeeStatsResponse {
     last_ledger: string;
     last_ledger_base_fee: string;
@@ -329,6 +345,8 @@ export namespace Horizon {
     p90_accepted_fee: string;
     p95_accepted_fee: string;
     p99_accepted_fee: string;
+    fee_charged: FeeDistribution;
+    max_fee: FeeDistribution;
   }
 
   export type ErrorResponseData =

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -118,7 +118,39 @@ describe('server.js non-transaction tests', function() {
       "p80_accepted_fee": "2000",
       "p90_accepted_fee": "2000",
       "p95_accepted_fee": "2000",
-      "p99_accepted_fee": "2000"
+      "p99_accepted_fee": "2000",
+      "max_fee": {
+        "max": "2000",
+        "min": "100",
+        "mode": "2000",
+        "p10": "100",
+        "p20": "100",
+        "p30": "100",
+        "p40": "300",
+        "p50": "650",
+        "p60": "2000",
+        "p70": "2000",
+        "p80": "2000",
+        "p90": "2000",
+        "p95": "2000",
+        "p99": "2000",
+      },
+      "fee_charged": {
+        "min": "100",
+        "max": "100",
+        "mode": "100",
+        "p10": "100",
+        "p20": "100",
+        "p30": "100",
+        "p40": "100",
+        "p50": "100",
+        "p60": "100",
+        "p70": "100",
+        "p80": "100",
+        "p90": "100",
+        "p95": "100",
+        "p99": "100"
+      }
     };
 
     it('returns the base reserve', function(done) {


### PR DESCRIPTION
Horizon v0.24.0 will include two new fields in the `/fee_stats` end-point see https://github.com/stellar/go/pull/1964

This PR extend the TypeScript typings with the new fields.