### PR TITLE
Don't restrict engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
     "type": "git",
     "url": "https://github.com/stellar/js-stellar-sdk.git"
   },
-  "engines": {
-    "node": ">=10.16.3"
-  },
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "license": "Apache-2.0",
   "bugs": {


### PR DESCRIPTION
The code will technically run fine on these older versions, and it's relatively trivial to circumvent this with `yarn --ignore-engines`, so I don't think it's going to significantly improve security for library consumers.