### PR TITLE
Change mention of CDN browser usage to CDNJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Using npm to include js-stellar-sdk in your own project:
 npm install --save stellar-sdk
 ```
 
-Alternatively, you can use jsDelivr or cdnjs in a browser
+Alternatively, you can use cdnjs in a browser:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/stellar-sdk@latest/lib/index.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/stellar-sdk/{version}/stellar-sdk.js"></script>
 ````
 
 ## Install


### PR DESCRIPTION
### What
Change the CDN mentioned and exampled that can be used in browsers to CDNJS instead of jsDelivr.

### Why
We mention and provide an example with jsDelivr at the top of the README, and then an example with CDNJS further buried in the README. The jsDelivr example doesn't seem to work from my own testing and I couldn't figure out how to make it work. It looks like it what we have hosted there might be tailored for use on a backend not in a browser. The CDNJS worked well for me and we use it in the second example further down so we may as well use it here.

There might still be a take away that the team should look into why jsDelivr isn't working and get it working for people who prefer it.