### PR TITLE
PaymentPathRecord does not implement Horizon.BaseResponse.

### DIFF
--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -340,7 +340,7 @@ export namespace ServerApi {
     counter: Asset;
   }
 
-  export interface PaymentPathRecord extends Horizon.BaseResponse {
+  export interface PaymentPathRecord {
     path: Array<{
       asset_code: string;
       asset_issuer: string;


### PR DESCRIPTION
The typing for `PaymentPathRecord` is incorrect, making it extend from `BaseResponse` assumes the response has a `links` attribute, however, each response in path_payment doesn't include `links`.

This is how a response from Horizon looks like:

```json
{
  "_embedded": {
    "records": [
      {
        "source_asset_type": "credit_alphanum4",
        "source_asset_code": "USD",
        "source_asset_issuer": "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX",
        "source_amount": "1000.0000000",
        "destination_asset_type": "credit_alphanum4",
        "destination_asset_code": "EURT",
        "destination_asset_issuer": "GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
        "destination_amount": "908.5197805",
        "path": [
          
        ]
      },
   ]
}
```
      