### PR TITLE
Use gulp.series for gulp 4.x

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,7 +183,7 @@ gulp.task(
 gulp.task(
   'watch',
   gulp.series('build', function watch() {
-    return gulp.watch('lib/**/*', gulp.series(['clear-screen', 'build']));
+    return gulp.watch('src/**/*', gulp.series(['clear-screen', 'build']));
   })
 );
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ gulp.task(
     function buildNode(done) {
       // TODO: Gulp-ify using `gulp-typescript`.
       try {
-        cp.execSync(`tsc`, {stdio: 'inherit'})
+        cp.execSync(`npx tsc`, {stdio: 'inherit'})
         done()
       } catch(err) {
         done(err)
@@ -55,7 +55,7 @@ gulp.task(
     function buildNode(done) {
       // TODO: Gulp-ify using `gulp-typescript`.
       try {
-        cp.execSync(`tsc --removeComments false --outDir libdocs --target es6 --module esnext`, {stdio: 'inherit'})
+        cp.execSync(`npx tsc --removeComments false --outDir libdocs --target es6 --module esnext`, {stdio: 'inherit'})
         done()
       } catch(err) {
         done(err)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -183,7 +183,7 @@ gulp.task(
 gulp.task(
   'watch',
   gulp.series('build', function watch() {
-    return gulp.watch('lib/**/*', ['clear-screen', 'build']);
+    return gulp.watch('lib/**/*', gulp.series(['clear-screen', 'build']));
   })
 );
 


### PR DESCRIPTION
Removes this error from a `node_modules/.bin/gulp watch` command. It looks like it is now [a requirement](https://stackoverflow.com/a/39665899/463012) for gulp 4, which is already set to this version in [package.json](https://github.com/stellar/js-stellar-sdk/blob/master/package.json#L83).

```txt
'watch' errored after 4.18 ms
Error: watching lib/**/*: watch task has to be a function (optionally generated by using gulp.parallel or gulp.series)
    at Gulp.watch (…/js-stellar-sdk/node_modules/gulp/index.js:28:11)
    at watch (…/js-stellar-sdk/gulpfile.js:186:17)

```