### PR TITLE
Clone the passed URI in CallBuilder constructor, to not mutate the outside ref

### DIFF
--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -52,7 +52,7 @@ export class CallBuilder<
   protected originalSegments: string[];
 
   constructor(serverUrl: uri.URI) {
-    this.url = serverUrl;
+    this.url = serverUrl.clone();
     this.filter = [];
     this.originalSegments = this.url.segment() || [];
   }

--- a/test/unit/call_builders_test.js
+++ b/test/unit/call_builders_test.js
@@ -1,0 +1,17 @@
+const URI = require("urijs");
+const CallBuilder = require('../../lib/call_builder').CallBuilder;
+
+describe('CallBuilder functions', function() {
+  
+  it('doesn\'t mutate the constructor passed url argument (it clones it instead)', function() {
+    let arg = URI('https://onedomain');
+    const builder = new CallBuilder(arg);
+    builder.url.segment('one_segment');
+    builder.checkFilter();
+    
+    expect(arg.toString()).not.to.be.equal('https://onedomain');
+    expect(builder.url.toString()).to.be.equal('https://onedomain/one_segment');
+  });
+  
+});
+

--- a/test/unit/call_builders_test.js
+++ b/test/unit/call_builders_test.js
@@ -4,13 +4,13 @@ const CallBuilder = require('../../lib/call_builder').CallBuilder;
 describe('CallBuilder functions', function() {
   
   it('doesn\'t mutate the constructor passed url argument (it clones it instead)', function() {
-    let arg = URI('https://onedomain');
+    let arg = URI('https://onedom.ain/');
     const builder = new CallBuilder(arg);
     builder.url.segment('one_segment');
     builder.checkFilter();
     
-    expect(arg.toString()).not.to.be.equal('https://onedomain');
-    expect(builder.url.toString()).to.be.equal('https://onedomain/one_segment');
+    expect(arg.toString()).not.to.be.equal('https://onedom.ain/one_segment'); // https://onedom.ain/
+    expect(builder.url.toString()).to.be.equal('https://onedom.ain/one_segment');
   });
   
 });


### PR DESCRIPTION
Hello,

The passed [*URI*](http://medialize.github.io/URI.js/) arg is modified on a later `call()` inside the `checkFilter` method, while the outside reference still pointing on it, making it to change.

It was most probably harmless since all the `CallBuilder` implementations are supposed to be constructed from inside a `Server` method, [where](https://github.com/stellar/js-stellar-sdk/blob/master/src/server.ts#L168) it seems they are already cloned by re-instantiating them (`this.serverURL` being already a *URI* instance) : 

    URI(this.serverURL as any)

I didn't removed those *URI* calls from `Server` methods and I rather ask for opinions here.
