### PR TITLE
AccountCallBuilder : add two methods for query filter

### DIFF
--- a/src/account_call_builder.ts
+++ b/src/account_call_builder.ts
@@ -1,3 +1,4 @@
+import { Asset } from "stellar-base";
 import { CallBuilder } from "./call_builder";
 import { ServerApi } from "./server_api";
 
@@ -27,6 +28,29 @@ export class AccountCallBuilder extends CallBuilder<ServerApi.AccountRecord> {
    */
   public accountId(id: string): this {
     this.filter.push(["accounts", id]);
+    return this;
+  }
+
+  /**
+   * This endpoint filters accounts by signer account.
+   * @see [Accounts](https://www.stellar.org/developers/horizon/reference/endpoints/accounts.html)
+   * @param {string} value For example: `GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD`
+   * @returns {AccountCallBuilder} current AccountCallBuilder instance
+   */
+  public forSigner(id: string) {
+    this.url.setQuery("signer", id);
+    return this;
+  }
+
+  /**
+   * This endpoint filters all accounts who are trustees to an asset.
+   * @see [Accounts](https://www.stellar.org/developers/horizon/reference/endpoints/accounts.html)
+   * @see Asset
+   * @param {Asset} value For example: `new Asset('USD','GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD')`
+   * @returns {AccountCallBuilder} current AccountCallBuilder instance
+   */
+  public forAsset(asset: Asset) {
+    this.url.setQuery("asset", `${asset}`);
     return this;
   }
 }

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -231,26 +231,26 @@ describe('server.js non-transaction tests', function() {
     let accountResponse = {
       "_links": {
         "self": {
-          "href": "https://horizon-live.stellar.org:1337/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS"
+          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS"
         },
         "transactions": {
-          "href": "https://horizon-live.stellar.org:1337/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/transactions{?cursor,limit,order}",
+          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/transactions{?cursor,limit,order}",
           "templated": true
         },
         "operations": {
-          "href": "https://horizon-live.stellar.org:1337/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/operations{?cursor,limit,order}",
+          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/operations{?cursor,limit,order}",
           "templated": true
         },
         "payments": {
-          "href": "https://horizon-live.stellar.org:1337/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/payments{?cursor,limit,order}",
+          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/payments{?cursor,limit,order}",
           "templated": true
         },
         "effects": {
-          "href": "https://horizon-live.stellar.org:1337/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/effects{?cursor,limit,order}",
+          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/effects{?cursor,limit,order}",
           "templated": true
         },
         "offers": {
-          "href": "https://horizon-live.stellar.org:1337/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/offers{?cursor,limit,order}",
+          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/offers{?cursor,limit,order}",
           "templated": true
         }
       },

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -231,26 +231,26 @@ describe('server.js non-transaction tests', function() {
     let accountResponse = {
       "_links": {
         "self": {
-          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS"
+          "href": "https://horizon-live.stellar.org:1337/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS"
         },
         "transactions": {
-          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/transactions{?cursor,limit,order}",
+          "href": "https://horizon-live.stellar.org:1337/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/transactions{?cursor,limit,order}",
           "templated": true
         },
         "operations": {
-          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/operations{?cursor,limit,order}",
+          "href": "https://horizon-live.stellar.org:1337/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/operations{?cursor,limit,order}",
           "templated": true
         },
         "payments": {
-          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/payments{?cursor,limit,order}",
+          "href": "https://horizon-live.stellar.org:1337/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/payments{?cursor,limit,order}",
           "templated": true
         },
         "effects": {
-          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/effects{?cursor,limit,order}",
+          "href": "https://horizon-live.stellar.org:1337/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/effects{?cursor,limit,order}",
           "templated": true
         },
         "offers": {
-          "href": "https://horizon-testnet.stellar.org/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/offers{?cursor,limit,order}",
+          "href": "https://horizon-live.stellar.org:1337/accounts/GBAH7FQMC3CZJ4WD6GE7G7YXCIU36LC2IHXQ7D5MQAUO4PODOWIVLSFS/offers{?cursor,limit,order}",
           "templated": true
         }
       },
@@ -774,65 +774,66 @@ describe('server.js non-transaction tests', function() {
 
   describe('Smoke tests for the rest of the builders', function() {
     describe('AccountCallBuilder', function() {
-      let singleAccountResponse = {
-        _links: {
-          effects: {
-            href:
-              '/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/effects{?cursor,limit,order}',
-            templated: true
-          },
-          offers: {
-            href:
-              '/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/offers{?cursor,limit,order}',
-            templated: true
-          },
-          operations: {
-            href:
-              '/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/operations{?cursor,limit,order}',
-            templated: true
-          },
-          self: {
-            href:
-              '/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K'
-          },
-          transactions: {
-            href:
-              '/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/transactions{?cursor,limit,order}',
-            templated: true
-          }
-        },
-        id: 'GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K',
-        paging_token: '146028892161',
-        account_id: 'GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K',
-        sequence: 146028888090,
-        subentry_count: 0,
-        inflation_destination: null,
-        home_domain: '',
-        thresholds: {
-          low_threshold: 0,
-          med_threshold: 0,
-          high_threshold: 0
-        },
-        flags: {
-          auth_required: false,
-          auth_revocable: false
-        },
-        balances: [
-          {
-            asset_type: 'native',
-            balance: '9760000.3997400'
-          }
-        ],
-        signers: [
-          {
-            public_key:
-              'GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K',
-            weight: 1
-          }
-        ]
-      };
 
       it('requests the correct endpoint', function(done) {
+        let singleAccountResponse = {
+          _links: {
+            effects: {
+              href:
+                '/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/effects{?cursor,limit,order}',
+              templated: true
+            },
+            offers: {
+              href:
+                '/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/offers{?cursor,limit,order}',
+              templated: true
+            },
+            operations: {
+              href:
+                '/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/operations{?cursor,limit,order}',
+              templated: true
+            },
+            self: {
+              href:
+                '/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K'
+            },
+            transactions: {
+              href:
+                '/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/transactions{?cursor,limit,order}',
+              templated: true
+            }
+          },
+          id: 'GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K',
+          paging_token: '146028892161',
+          account_id: 'GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K',
+          sequence: 146028888090,
+          subentry_count: 0,
+          inflation_destination: null,
+          home_domain: '',
+          thresholds: {
+            low_threshold: 0,
+            med_threshold: 0,
+            high_threshold: 0
+          },
+          flags: {
+            auth_required: false,
+            auth_revocable: false
+          },
+          balances: [
+            {
+              asset_type: 'native',
+              balance: '9760000.3997400'
+            }
+          ],
+          signers: [
+            {
+              public_key:
+                'GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K',
+              weight: 1
+            }
+          ]
+        };
+        
         this.axiosMock
           .expects('get')
           .withArgs(
@@ -856,6 +857,102 @@ describe('server.js non-transaction tests', function() {
       });
       
       it('adds a "signer" query to the endpoint', function(done) {
+        let accountsForSignerResponse = {
+          _links: {
+            self: {
+              href: '/accounts?cursor=&limit=10&order=asc&signer=GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42'
+            },
+            next: {
+              href: '/accounts?cursor=GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42&limit=10&order=asc&signer=GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42'
+            },
+            prev: {
+              href: '/accounts?cursor=GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42&limit=10&order=desc&signer=GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42'
+            }
+          },
+          _embedded: {
+            records: [
+              {
+                _links: {
+                  self: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42'
+                  },
+                  transactions: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/transactions{?cursor,limit,order}',
+                    templated: true
+                  },
+                  operations: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/operations{?cursor,limit,order}',
+                    templated: true
+                  },
+                  payments: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/payments{?cursor,limit,order}',
+                    templated: true
+                  },
+                  effects: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/effects{?cursor,limit,order}',
+                    templated: true
+                  },
+                  offers: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/offers{?cursor,limit,order}',
+                    templated: true
+                  },
+                  trades: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/trades{?cursor,limit,order}',
+                    templated: true
+                  },
+                  data: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/data/{key}',
+                    templated: true
+                  }
+                },
+                id: 'GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42',
+                account_id: 'GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42',
+                sequence: '4233832731508737',
+                subentry_count: 1,
+                last_modified_ledger: 986912,
+                thresholds: {
+                  low_threshold: 0,
+                  med_threshold: 0,
+                  high_threshold: 0
+                },
+                flags: {
+                  auth_required: false,
+                  auth_revocable: false,
+                  auth_immutable: false
+                },
+                balances: [
+                  {
+                    balance: '0.0000000',
+                    limit: '450.0000000',
+                    buying_liabilities: '0.0000000',
+                    selling_liabilities: '0.0000000',
+                    last_modified_ledger: 986912,
+                    is_authorized: true,
+                    asset_type: 'credit_alphanum4',
+                    asset_code: 'USD',
+                    asset_issuer: 'GDUEG67IE5TJUVWRRTMXDP3Q6EMMZJ6HL5OMWLBYOIUIZEUW2T2PBPJH'
+                  },
+                  {
+                    balance: '9999.9999900',
+                    buying_liabilities: '0.0000000',
+                    selling_liabilities: '0.0000000',
+                    asset_type: 'native'
+                  }
+                ],
+                signers: [
+                  {
+                    weight: 1,
+                    key: 'GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42',
+                    type: 'ed25519_public_key'
+                  }
+                ],
+                data: {},
+                paging_token: 'GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42'
+              }
+            ]
+          }
+        };
+        
         this.axiosMock
           .expects('get')
           .withArgs(
@@ -863,14 +960,18 @@ describe('server.js non-transaction tests', function() {
               'https://horizon-live.stellar.org:1337/accounts?signer=GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42'
             )
           )
-          .returns(Promise.resolve({ data: 'correct' }));
+          .returns(Promise.resolve({ data: accountsForSignerResponse }));
           
         this.server
           .accounts()
           .forSigner('GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42')
           .call()
           .then(function(response) {
-            expect(response).to.equal('correct');
+            expect(response.records).to.be.deep.equal(
+              accountsForSignerResponse._embedded.records
+            );
+            expect(response.next).to.be.function;
+            expect(response.prev).to.be.function;
             done();
           })
           .catch(function(err) {
@@ -879,6 +980,102 @@ describe('server.js non-transaction tests', function() {
       });
       
       it('adds an "asset" query to the endpoint', function(done) {
+        let accountsForAssetResponse = {
+          _links: {
+            self: {
+              href: '/accounts?asset=USD%3AGDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD\u0026cursor=\u0026limit=10\u0026order=asc'
+            },
+            next: {
+              href: '/accounts?asset=USD%3AGDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD\u0026cursor=GC4J73PTB5WN7MOJWOAECPHRCV2UU3WCY37L3BNY6RZVKE23JGQYJMJ6\u0026limit=10\u0026order=asc'
+            },
+            prev: {
+              href: '/accounts?asset=USD%3AGDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD\u0026cursor=GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667\u0026limit=10\u0026order=desc'
+            }
+          },
+          _embedded: {
+            records: [
+              {
+                _links: {
+                  self: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667'
+                  },
+                  transactions: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/transactions{?cursor,limit,order}',
+                    templated: true
+                  },
+                  operations: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/operations{?cursor,limit,order}',
+                    templated: true
+                  },
+                  payments: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/payments{?cursor,limit,order}',
+                    templated: true
+                  },
+                  effects: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/effects{?cursor,limit,order}',
+                    templated: true
+                  },
+                  offers: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/offers{?cursor,limit,order}',
+                    templated: true
+                  },
+                  trades: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/trades{?cursor,limit,order}',
+                    templated: true
+                  },
+                  data: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/data/{key}',
+                    templated: true
+                  }
+                },
+                id: 'GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667',
+                account_id: 'GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667',
+                sequence: '3902600558673934',
+                subentry_count: 3,
+                last_modified_ledger: 983682,
+                thresholds: {
+                  low_threshold: 0,
+                  med_threshold: 0,
+                  high_threshold: 0
+                },
+                flags: {
+                  auth_required: false,
+                  auth_revocable: false,
+                  auth_immutable: false
+                },
+                balances: [
+                  {
+                    balance: '0.0000000',
+                    limit: '25.0000000',
+                    buying_liabilities: '0.0000000',
+                    selling_liabilities: '0.0000000',
+                    last_modified_ledger: 983682,
+                    is_authorized: true,
+                    asset_type: 'credit_alphanum4',
+                    asset_code: 'USD',
+                    asset_issuer: 'GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD'
+                  },
+                  {
+                    balance: '9999.9998600',
+                    buying_liabilities: '0.0000000',
+                    selling_liabilities: '0.0000000',
+                    asset_type: 'native'
+                  }
+                ],
+                signers: [
+                  {
+                    weight: 1,
+                    key: 'GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667',
+                    type: 'ed25519_public_key'
+                  }
+                ],
+                data: {},
+                paging_token: 'GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667'
+              }
+            ]
+          }
+        };
+        
         this.axiosMock
           .expects('get')
           .withArgs(
@@ -886,14 +1083,18 @@ describe('server.js non-transaction tests', function() {
               'https://horizon-live.stellar.org:1337/accounts?asset=USD%3AGDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD'
             )
           )
-          .returns(Promise.resolve({ data: 'correct' }));
+          .returns(Promise.resolve({ data: accountsForAssetResponse }));
           
         this.server
           .accounts()
           .forAsset(new StellarSdk.Asset('USD','GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD'))
           .call()
           .then(function(response) {
-            expect(response).to.equal('correct');
+            expect(response.records).to.be.deep.equal(
+              accountsForAssetResponse._embedded.records
+            );
+            expect(response.next).to.be.function;
+            expect(response.prev).to.be.function;
             done();
           })
           .catch(function(err) {

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -854,6 +854,53 @@ describe('server.js non-transaction tests', function() {
             done(err);
           });
       });
+      
+      it('adds a "signer" query to the endpoint', function(done) {
+        this.axiosMock
+          .expects('get')
+          .withArgs(
+            sinon.match(
+              'https://horizon-live.stellar.org:1337/accounts?signer=GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42'
+            )
+          )
+          .returns(Promise.resolve({ data: 'correct' }));
+          
+        this.server
+          .accounts()
+          .forSigner('GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42')
+          .call()
+          .then(function(response) {
+            expect(response).to.equal('correct');
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+      
+      it('adds an "asset" query to the endpoint', function(done) {
+        this.axiosMock
+          .expects('get')
+          .withArgs(
+            sinon.match(
+              'https://horizon-live.stellar.org:1337/accounts?asset=USD%3AGDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD'
+            )
+          )
+          .returns(Promise.resolve({ data: 'correct' }));
+          
+        this.server
+          .accounts()
+          .forAsset(new StellarSdk.Asset('USD','GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD'))
+          .call()
+          .then(function(response) {
+            expect(response).to.equal('correct');
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+      
     });
 
     describe('OfferCallBuilder', function() {


### PR DESCRIPTION
Following https://github.com/stellar/go/pull/1835 and according to https://www.stellar.org/developers/horizon/reference/endpoints/accounts.html, adds the ability to filter by 
* account signer
* account trustee of an asset