### PR TITLE
Add support for top-level offers end-point with account, selling, and buying filter.

### DIFF
--- a/src/federation_server.ts
+++ b/src/federation_server.ts
@@ -239,9 +239,7 @@ export class FederationServer {
         } else {
           return Promise.reject(
             new BadResponseError(
-              `Server query failed. Server responded: ${response.status} ${
-                response.statusText
-              }`,
+              `Server query failed. Server responded: ${response.status} ${response.statusText}`,
               response.data,
             ),
           );

--- a/src/offer_call_builder.ts
+++ b/src/offer_call_builder.ts
@@ -1,3 +1,4 @@
+import { Asset } from "stellar-base";
 import { CallBuilder } from "./call_builder";
 import { ServerApi } from "./server_api";
 
@@ -20,14 +21,50 @@ export class OfferCallBuilder extends CallBuilder<
   }
 
   /**
-   * Returns offers relating to a single account.
+   * Returns all offers where the given account is the seller.
    *
    * @see [Offers](https://www.stellar.org/developers/horizon/reference/endpoints/offers.html)
    * @param {string} id For example: `GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD`
-   * @returns {AccountCallBuilder} current AccountCallBuilder instance
+   * @returns {OfferCallBuilder} current OfferCallBuilder instance
    */
   public forAccount(id: string): this {
     this.url.setQuery("seller", id);
+    return this;
+  }
+
+  /**
+   * Returns all offers buying an asset.
+   * @see [Offers](https://www.stellar.org/developers/horizon/reference/endpoints/offers.html)
+   * @see Asset
+   * @param {Asset} value For example: `new Asset('USD','GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD')`
+   * @returns {OfferCallBuilder} current OfferCallBuilder instance
+   */
+  public buying(asset: Asset): this {
+    if (!asset.isNative()) {
+      this.url.setQuery("buying_asset_type", asset.getAssetType());
+      this.url.setQuery("buying_asset_code", asset.getCode());
+      this.url.setQuery("buying_asset_issuer", asset.getIssuer());
+    } else {
+      this.url.setQuery("buying_asset_type", "native");
+    }
+    return this;
+  }
+
+  /**
+   * Returns all offers selling an asset.
+   * @see [Offers](https://www.stellar.org/developers/horizon/reference/endpoints/offers.html)
+   * @see Asset
+   * @param {Asset} value For example: `new Asset('EUR','GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD')`
+   * @returns {OfferCallBuilder} current OfferCallBuilder instance
+   */
+  public selling(asset: Asset): this {
+    if (!asset.isNative()) {
+      this.url.setQuery("selling_asset_type", asset.getAssetType());
+      this.url.setQuery("selling_asset_code", asset.getCode());
+      this.url.setQuery("selling_asset_issuer", asset.getIssuer());
+    } else {
+      this.url.setQuery("selling_asset_type", "native");
+    }
     return this;
   }
 }

--- a/src/offer_call_builder.ts
+++ b/src/offer_call_builder.ts
@@ -1,32 +1,33 @@
 import { CallBuilder } from "./call_builder";
-import { BadRequestError } from "./errors";
 import { ServerApi } from "./server_api";
 
 /**
  * Creates a new {@link OfferCallBuilder} pointed to server defined by serverUrl.
  * Do not create this object directly, use {@link Server#offers}.
  *
- * @see [Offers for Account](https://www.stellar.org/developers/horizon/reference/endpoints/offers-for-account.html)
+ * @see [Offers](https://www.stellar.org/developers/horizon/reference/endpoints/offers.html)
  * @class OfferCallBuilder
  * @constructor
  * @extends CallBuilder
  * @param {string} serverUrl Horizon server URL.
- * @param {string} resource Resource to query offers
- * @param {...string} resourceParams Parameters for selected resource
  */
 export class OfferCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.OfferRecord>
 > {
-  constructor(
-    serverUrl: uri.URI,
-    resource: string,
-    ...resourceParams: string[]
-  ) {
+  constructor(serverUrl: uri.URI) {
     super(serverUrl);
-    if (resource === "accounts") {
-      this.url.segment([resource, ...resourceParams, "offers"]);
-    } else {
-      throw new BadRequestError("Bad resource specified for offer:", resource);
-    }
+    this.url.segment("offers");
+  }
+
+  /**
+   * Returns offers relating to a single account.
+   *
+   * @see [Offers](https://www.stellar.org/developers/horizon/reference/endpoints/offers.html)
+   * @param {string} id For example: `GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD`
+   * @returns {AccountCallBuilder} current AccountCallBuilder instance
+   */
+  public forAccount(id: string): this {
+    this.url.setQuery("seller", id);
+    return this;
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -469,27 +469,21 @@ export class Server {
   }
 
   /**
-   * People on the Stellar network can make offers to buy or sell assets. This endpoint represents all the offers a particular account makes.
-   * Currently this method only supports querying offers for account and should be used like this:
+   * People on the Stellar network can make offers to buy or sell assets. This endpoint represents all the offers on the DEX.
+   *
+   * You can query all offers for account using the function `.accountId`:
+   *
    * ```
-   * server.offers('accounts', accountId).call()
+   * server.offers()
+   *  .forAccount(accountId).call()
    *  .then(function(offers) {
    *    console.log(offers);
    *  });
    * ```
-   * @param {string} resource Resource to query offers
-   * @param {...string} resourceParams Parameters for selected resource
    * @returns {OfferCallBuilder} New {@link OfferCallBuilder} object
    */
-  public offers(
-    resource: string,
-    ...resourceParams: string[]
-  ): OfferCallBuilder {
-    return new OfferCallBuilder(
-      URI(this.serverURL as any),
-      resource,
-      ...resourceParams,
-    );
+  public offers(): OfferCallBuilder {
+    return new OfferCallBuilder(URI(this.serverURL as any));
   }
 
   /**

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -1112,32 +1112,27 @@ describe('server.js non-transaction tests', function() {
     });
 
     describe('OfferCallBuilder', function() {
-      function buildOffersResponse(withAccount) {
-          const prefix = withAccount ? '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42' : '';
-
-          return {
+      const offersResponse = {
             _embedded: {
               records: []
             },
             _links: {
               next: {
                 href:
-                  `${prefix}/offers?order=asc\u0026limit=10\u0026cursor=`
+                  '/offers'
               },
               prev: {
                 href:
-                  `${prefix}/offers?order=desc\u0026limit=10\u0026cursor=`
+                  '/offers'
               },
               self: {
                 href:
-                  `${prefix}/offers?order=asc\u0026limit=10\u0026cursor=`
+                  '/offers'
               }
             }
           };
-      }
 
       it('without params requests the correct endpoint', function(done) {
-        const offersResponse = buildOffersResponse(false);
         this.axiosMock
           .expects('get')
           .withArgs(
@@ -1163,8 +1158,7 @@ describe('server.js non-transaction tests', function() {
           });
       });
 
-      it('accountId requests the correct endpoint', function(done) {
-        const offersResponse = buildOffersResponse(true);
+      it('forAccount requests the correct endpoint', function(done) {
         this.axiosMock
           .expects('get')
           .withArgs(
@@ -1177,6 +1171,70 @@ describe('server.js non-transaction tests', function() {
         this.server
           .offers()
           .forAccount('GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K')
+          .order('asc')
+          .call()
+          .then(function(response) {
+            expect(response.records).to.be.deep.equal(
+              offersResponse._embedded.records
+            );
+            expect(response.next).to.be.function;
+            expect(response.prev).to.be.function;
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+      it('selling requests the correct endpoint', function(done) {
+        const selling = new StellarSdk.Asset(
+          'USD',
+          'GDVDKQFP665JAO7A2LSHNLQIUNYNAAIGJ6FYJVMG4DT3YJQQJSRBLQDG'
+        );
+        
+        this.axiosMock
+          .expects('get')
+          .withArgs(
+            sinon.match(
+              'https://horizon-live.stellar.org:1337/offers?selling_asset_type=credit_alphanum4&selling_asset_code=USD&selling_asset_issuer=GDVDKQFP665JAO7A2LSHNLQIUNYNAAIGJ6FYJVMG4DT3YJQQJSRBLQDG&order=asc'
+            )
+          )
+          .returns(Promise.resolve({ data: offersResponse }));
+
+        this.server
+          .offers()
+          .selling(selling)
+          .order('asc')
+          .call()
+          .then(function(response) {
+            expect(response.records).to.be.deep.equal(
+              offersResponse._embedded.records
+            );
+            expect(response.next).to.be.function;
+            expect(response.prev).to.be.function;
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+      it('buying requests the correct endpoint', function(done) {
+        const buying = new StellarSdk.Asset(
+          'COP',
+          'GDVDKQFP665JAO7A2LSHNLQIUNYNAAIGJ6FYJVMG4DT3YJQQJSRBLQDG'
+        );
+        
+        this.axiosMock
+          .expects('get')
+          .withArgs(
+            sinon.match(
+              'https://horizon-live.stellar.org:1337/offers?buying_asset_type=credit_alphanum4&buying_asset_code=COP&buying_asset_issuer=GDVDKQFP665JAO7A2LSHNLQIUNYNAAIGJ6FYJVMG4DT3YJQQJSRBLQDG&order=asc'
+            )
+          )
+          .returns(Promise.resolve({ data: offersResponse }));
+
+        this.server
+          .offers()
+          .buying(buying)
           .order('asc')
           .call()
           .then(function(response) {


### PR DESCRIPTION
This pull request extends the `offers` builder to support requests at the top level `/offers` route.

You can list all offers by doing `server.offers()` or use any of the following filters:

- seller: `server.offers().accountId(accountId)`
- buying: `server.offers().buying(asset)`
- selling:  `server.offers().selling(asset)`

This change introduces a breaking change since it changes the signature for the function `server.offers()`.  

Before if you wanted to list all the offers for a given account, you'll do `server.offers('accounts', accountID)`, now you need to do `server.offers().accountId(accountId)`.




