### PR TITLE
Typescript fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "eventsource": "^1.0.7",
     "lodash": "^4.17.11",
     "randombytes": "^2.1.0",
-    "stellar-base": "^2.1.2",
+    "stellar-base": "^2.1.4",
     "toml": "^2.3.0",
     "tslib": "^1.10.0",
     "urijs": "^1.19.1",

--- a/src/account_call_builder.ts
+++ b/src/account_call_builder.ts
@@ -26,7 +26,7 @@ export class AccountCallBuilder extends CallBuilder<
    *
    * @see [Account Details](https://www.stellar.org/developers/horizon/reference/endpoints/accounts-single.html)
    * @param {string} id For example: `GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD`
-   * @returns {AccountCallBuilder} current AccountCallBuilder instance
+   * @returns {CallBuilder} current AccountCallBuilder instance
    */
   public accountId(id: string): CallBuilder<ServerApi.AccountRecord> {
     const builder = new CallBuilder<ServerApi.AccountRecord>(this.url.clone());

--- a/src/account_call_builder.ts
+++ b/src/account_call_builder.ts
@@ -12,7 +12,9 @@ import { ServerApi } from "./server_api";
  * @constructor
  * @param {string} serverUrl Horizon server URL.
  */
-export class AccountCallBuilder extends CallBuilder<ServerApi.AccountRecord> {
+export class AccountCallBuilder extends CallBuilder<
+  ServerApi.CollectionPage<ServerApi.AccountRecord>
+> {
   constructor(serverUrl: uri.URI) {
     super(serverUrl);
     this.url.segment("accounts");
@@ -26,9 +28,10 @@ export class AccountCallBuilder extends CallBuilder<ServerApi.AccountRecord> {
    * @param {string} id For example: `GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD`
    * @returns {AccountCallBuilder} current AccountCallBuilder instance
    */
-  public accountId(id: string): this {
-    this.filter.push(["accounts", id]);
-    return this;
+  public accountId(id: string): CallBuilder<ServerApi.AccountRecord> {
+    const builder = new CallBuilder<ServerApi.AccountRecord>(this.url.clone());
+    builder.filter.push([id]);
+    return builder;
   }
 
   /**
@@ -37,7 +40,7 @@ export class AccountCallBuilder extends CallBuilder<ServerApi.AccountRecord> {
    * @param {string} value For example: `GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD`
    * @returns {AccountCallBuilder} current AccountCallBuilder instance
    */
-  public forSigner(id: string) {
+  public forSigner(id: string): this {
     this.url.setQuery("signer", id);
     return this;
   }
@@ -49,7 +52,7 @@ export class AccountCallBuilder extends CallBuilder<ServerApi.AccountRecord> {
    * @param {Asset} value For example: `new Asset('USD','GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD')`
    * @returns {AccountCallBuilder} current AccountCallBuilder instance
    */
-  public forAsset(asset: Asset) {
+  public forAsset(asset: Asset): this {
     this.url.setQuery("asset", `${asset}`);
     return this;
   }

--- a/src/operation_call_builder.ts
+++ b/src/operation_call_builder.ts
@@ -24,7 +24,7 @@ export class OperationCallBuilder extends CallBuilder<
    * argument specifies which operation to load.
    * @see [Operation Details](https://www.stellar.org/developers/horizon/reference/endpoints/operations-single.html)
    * @param {number} operationId Operation ID
-   * @returns {OperationCallBuilder} this OperationCallBuilder instance
+   * @returns {CallBuilder} this OperationCallBuilder instance
    */
   public operation(
     operationId: string,

--- a/src/operation_call_builder.ts
+++ b/src/operation_call_builder.ts
@@ -26,9 +26,14 @@ export class OperationCallBuilder extends CallBuilder<
    * @param {number} operationId Operation ID
    * @returns {OperationCallBuilder} this OperationCallBuilder instance
    */
-  public operation(operationId: string): this {
-    this.filter.push(["operations", operationId]);
-    return this;
+  public operation(
+    operationId: string,
+  ): CallBuilder<ServerApi.OperationRecord> {
+    const builder = new CallBuilder<ServerApi.OperationRecord>(
+      this.url.clone(),
+    );
+    builder.filter.push([operationId]);
+    return builder;
   }
 
   /**

--- a/src/transaction_call_builder.ts
+++ b/src/transaction_call_builder.ts
@@ -23,11 +23,16 @@ export class TransactionCallBuilder extends CallBuilder<
    * The transaction details endpoint provides information on a single transaction. The transaction hash provided in the hash argument specifies which transaction to load.
    * @see [Transaction Details](https://www.stellar.org/developers/horizon/reference/endpoints/transactions-single.html)
    * @param {string} transactionId Transaction ID
-   * @returns {TransactionCallBuilder} current TransactionCallBuilder instance
+   * @returns {CallBuilder} a CallBuilder instance
    */
-  public transaction(transactionId: string): this {
-    this.filter.push(["transactions", transactionId]);
-    return this;
+  public transaction(
+    transactionId: string,
+  ): CallBuilder<ServerApi.TransactionRecord> {
+    const builder = new CallBuilder<ServerApi.TransactionRecord>(
+      this.url.clone(),
+    );
+    builder.filter.push([transactionId]);
+    return builder;
   }
 
   /**

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -780,6 +780,80 @@ describe('server.js non-transaction tests', function() {
   });
 
   describe('Smoke tests for the rest of the builders', function() {
+    describe('TransactionCallBuilder', function() {
+
+      it('#transaction - requests the correct endpoint', function(done) {
+        let singleTranssactionResponse = {
+          "_links": {
+            "self": {
+              "href": "https://horizon-testnet.stellar.org/transactions/6bbd8cbd90498a26210a21ec599702bead8f908f412455da300318aba36831b0"
+            },
+            "account": {
+              "href": "https://horizon-testnet.stellar.org/accounts/GBCCHT5P34DMK2LTN4SPHBAJCXYFNUEWSM7SDSWEXJA7NN6CA3HNHTM6"
+            },
+            "ledger": {
+              "href": "https://horizon-testnet.stellar.org/ledgers/121879"
+            },
+            "operations": {
+              "href": "https://horizon-testnet.stellar.org/transactions/6bbd8cbd90498a26210a21ec599702bead8f908f412455da300318aba36831b0/operations{?cursor,limit,order}",
+              "templated": true
+            },
+            "effects": {
+              "href": "https://horizon-testnet.stellar.org/transactions/6bbd8cbd90498a26210a21ec599702bead8f908f412455da300318aba36831b0/effects{?cursor,limit,order}",
+              "templated": true
+            },
+            "precedes": {
+              "href": "https://horizon-testnet.stellar.org/transactions?order=asc&cursor=523466319077376"
+            },
+            "succeeds": {
+              "href": "https://horizon-testnet.stellar.org/transactions?order=desc&cursor=523466319077376"
+            }
+          },
+          "id": "6bbd8cbd90498a26210a21ec599702bead8f908f412455da300318aba36831b0",
+          "paging_token": "523466319077376",
+          "successful": true,
+          "hash": "6bbd8cbd90498a26210a21ec599702bead8f908f412455da300318aba36831b0",
+          "ledger": 121879,
+          "created_at": "2020-02-06T01:57:18Z",
+          "source_account": "GBCCHT5P34DMK2LTN4SPHBAJCXYFNUEWSM7SDSWEXJA7NN6CA3HNHTM6",
+          "source_account_sequence": "523406189527045",
+          "fee_paid": 100,
+          "fee_charged": 100,
+          "max_fee": 100,
+          "operation_count": 1,
+          "envelope_xdr": "AAAAAEQjz6/fBsVpc28k84QJFfBW0JaTPyHKxLpB9rfCBs7TAAAAZAAB3AkAAAAFAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAMBwd6tPbAYimyr/BzBgOosIbrnrzfxfS/gmfqoDSx0IAAAAAHc1lAAAAAAAAAAABwgbO0wAAAECl/OULPE7Q3ikmwIYeECFtxVH4rh8lmk465QLIeHEeEcbYhaTfgfe8VAwKsYf4YqK+YKiSiI0BqJKDr6CeI3QJ",
+          "result_xdr": "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+          "result_meta_xdr": "AAAAAQAAAAIAAAADAAHcFwAAAAAAAAAARCPPr98GxWlzbyTzhAkV8FbQlpM/IcrEukH2t8IGztMAAAAW0UFSDAAB3AkAAAAEAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAHcFwAAAAAAAAAARCPPr98GxWlzbyTzhAkV8FbQlpM/IcrEukH2t8IGztMAAAAW0UFSDAAB3AkAAAAFAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMAAdwXAAAAAAAAAABEI8+v3wbFaXNvJPOECRXwVtCWkz8hysS6Qfa3wgbO0wAAABbRQVIMAAHcCQAAAAUAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAdwXAAAAAAAAAABEI8+v3wbFaXNvJPOECRXwVtCWkz8hysS6Qfa3wgbO0wAAABazc+0MAAHcCQAAAAUAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAdwXAAAAAAAAAAAwHB3q09sBiKbKv8HMGA6iwhuuevN/F9L+CZ+qgNLHQgAAAAAdzWUAAAHcFwAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+          "fee_meta_xdr": "AAAAAgAAAAMAAdwUAAAAAAAAAABEI8+v3wbFaXNvJPOECRXwVtCWkz8hysS6Qfa3wgbO0wAAABbRQVJwAAHcCQAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEAAdwXAAAAAAAAAABEI8+v3wbFaXNvJPOECRXwVtCWkz8hysS6Qfa3wgbO0wAAABbRQVIMAAHcCQAAAAQAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+          "memo_type": "none",
+          "signatures": [
+            "pfzlCzxO0N4pJsCGHhAhbcVR+K4fJZpOOuUCyHhxHhHG2IWk34H3vFQMCrGH+GKivmCokoiNAaiSg6+gniN0CQ=="
+          ]
+        };
+        
+        this.axiosMock
+          .expects('get')
+          .withArgs(
+            sinon.match(
+              'https://horizon-live.stellar.org:1337/transactions/6bbd8cbd90498a26210a21ec599702bead8f908f412455da300318aba36831b0'
+            )
+          )
+          .returns(Promise.resolve({ data: singleTranssactionResponse }));
+
+        this.server
+          .transactions()
+          .transaction('6bbd8cbd90498a26210a21ec599702bead8f908f412455da300318aba36831b0')
+          .call()
+          .then(function(response) {
+            expect(response).to.be.deep.equal(singleTranssactionResponse);
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+    });
+
     describe('AccountCallBuilder', function() {
 
       it('requests the correct endpoint', function(done) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4807,10 +4807,10 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-xdr@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/js-xdr/-/js-xdr-1.1.2.tgz#aba1f0952508c83f33dd7e774fa9231b3073992b"
-  integrity sha512-ipiz1CnsyjLsba+QQd5jezGXddNKGa4oO9EODy0kWr3G3R8MNslIxkhQFpyRfY3yoY7YplhRVfC3cmXb4AobZQ==
+js-xdr@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/js-xdr/-/js-xdr-1.1.3.tgz#68cf021c0d8a6f8b75e8e3f2d528575a22d7cd1a"
+  integrity sha512-zFg7dIc6lI7LiZ/eru5U/cOur/SJGkbKflgkwoFIiHewgpmBGsRJNKbeOh/8Ffzz5mYvfmsO6gHAe5wv/ZYM2g==
   dependencies:
     core-js "^2.6.3"
     cursor "^0.1.5"
@@ -7596,15 +7596,15 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stellar-base@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-2.1.2.tgz#bd7cc27f494fb1c7d7f2563efe25f7572880b1bf"
-  integrity sha512-/U0QFfMwCAa9I0TukfLzUhHvbEXSH2gGSB5ZbabeisnVf1FFFQBjazsNBfbKADrExWE+H3833DpckE6jynlIqg==
+stellar-base@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-2.1.4.tgz#e3dc7a5acdab3b796f7d8425521e157310406288"
+  integrity sha512-RbHjxqwAaeGHtIlnLdCeCBcGYqzxSUGfcy+KCFVSPc9/c2HoA0KeAh/NlsOq6V+Y7SL2gSoEQLF4ddOD6ToF+A==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^4.0.0"
     crc "^3.5.0"
-    js-xdr "^1.1.1"
+    js-xdr "^1.1.3"
     lodash "^4.17.11"
     sha.js "^2.3.6"
     tweetnacl "^1.0.0"


### PR DESCRIPTION
Fix multiple incorrect typings. For example, A `TransactionCallBuilder` is expected to return a collection of
`Transactions` when calling the method `call`, however, the `.transaction(hash)` method didn't match such expectation since it will return a single transaction.

This isn't a problem for people using vanilla JS, but people using TypeScript won't be able to compile their projects, since they are expecting a single object however TypeScript will tell them that the
return value is a collection of objects.