### PR TITLE
Add is_authorized to BalanceLineAsset.

### DIFF
--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -61,6 +61,7 @@ export namespace Horizon {
     buying_liabilities: string;
     selling_liabilities: string;
     last_modified_ledger: number;
+    is_authorized: boolean;
   }
   export type BalanceLine<
     T extends AssetType = AssetType


### PR DESCRIPTION
Add missing property  to BalanceLineAsset. Without this, `is_authorized` won't show up when using TS.