### PR TITLE
Update challenge transaction helpers sep 10

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,6 +95,7 @@ export namespace Utils {
    * @returns {Transaction} the actual submited Transaction
    * @returns {string} The stellar clientAccountID that the wallet wishes to authenticate with the server.
    */
+
   export function readChallengeTx(
     challengeTx: string,
     serverAccountId: string,
@@ -258,7 +259,7 @@ export namespace Utils {
     // Confirm we matched a signature to the server signer.
     if (signersFound.length === 0) {
       throw new InvalidSep10ChallengeError(
-        "Transaction not signed by clients: '" + clientSigners.join() + "'",
+        "Transaction not signed by client(s): '" + clientSigners.join() + "'",
       );
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,7 +121,7 @@ export namespace Utils {
     // verify operation
     if (transaction.operations.length !== 1) {
       throw new InvalidSep10ChallengeError(
-        "The transaction should contain only one operation",
+        "The transaction should contain exactly one operation",
       );
     }
 
@@ -132,6 +132,7 @@ export namespace Utils {
         "The transaction's operation should contain a source account",
       );
     }
+    const clientAccountID: string = operation.source!;
 
     if (operation.type !== "manageData") {
       throw new InvalidSep10ChallengeError(
@@ -160,7 +161,7 @@ export namespace Utils {
       );
     }
 
-    return { tx: transaction, clientAccountID: "" };
+    return { tx: transaction, clientAccountID };
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -367,7 +367,7 @@ export namespace Utils {
       ...Array.from(clientSigners),
     ];
 
-    const signersFound: string[] = verifyTxMultiSignedBy(tx, ...allSigners);
+    const signersFound: string[] = gatherTxSigners(tx, ...allSigners);
 
     // Confirm the server is in the list of signers found and remove it.
     let serverSignerFound: boolean = false;
@@ -484,12 +484,12 @@ export namespace Utils {
     transaction: Transaction,
     accountId: string,
   ): boolean {
-    return verifyTxMultiSignedBy(transaction, accountId).length !== 0;
+    return gatherTxSigners(transaction, accountId).length !== 0;
   }
 
   /**
    *
-   * verifyTxMultiSignedBy checks if a transaction has been signed by one or more of
+   * gatherTxSigners checks if a transaction has been signed by one or more of
    * the given signers, returning a list of non-repeated signers that were found to have
    * signed the given transaction.
    *
@@ -507,10 +507,10 @@ export namespace Utils {
    *    .build();
    *
    * transaction.sign(keypair1, keypair2)
-   * Utils.verifyTxMultiSignedBy(transaction, [keypair1.publicKey(), keypair2.publicKey()])
+   * Utils.gatherTxSigners(transaction, [keypair1.publicKey(), keypair2.publicKey()])
    * @returns {string[]} a list of signers that were found to have signed the transaction.
    */
-  export function verifyTxMultiSignedBy(
+  export function gatherTxSigners(
     transaction: Transaction,
     ...accountIDs: string[]
   ): string[] {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -384,12 +384,10 @@ export namespace Utils {
       );
     }
 
-    // Confirm we matched a signature to the server signer.
+    // Confirm we matched at least one given signer with the transaction signatures
     if (signersFound.length === 1) {
       throw new InvalidSep10ChallengeError(
-        "Transaction not signed by client(s): '" +
-          Array.from(clientSigners).join() +
-          "'",
+        "None of the given signers match the transaction signatures",
       );
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,7 +95,6 @@ export namespace Utils {
    * @returns {Transaction} the actual submited Transaction
    * @returns {string} The stellar clientAccountID that the wallet wishes to authenticate with the server.
    */
-
   export function readChallengeTx(
     challengeTx: string,
     serverAccountId: string,
@@ -190,7 +189,39 @@ export namespace Utils {
    * @param {number} threshold The required threshold for verifying this transaction
    * @param {Map<string, number>} signerSummary a map of signers to their weights, used to validate if the signers' total weight can meet a given threshold
    * @example
-   * // TODO
+   * import { Networks, Transaction, Utils }  from 'stellar-sdk';
+   *
+   * const serverKP = Keypair.random();
+   * const clientKP1 = Keypair.random();
+   * const clientKP2 = Keypair.random();
+   *
+   * // Challenge, possibly built in the server side
+   * const challenge = Utils.buildChallengeTx(
+   *   serverKP,
+   *   clientKP1.publicKey(),
+   *   "SDF",
+   *   300,
+   *   Networks.TESTNET
+   * );
+   *
+   * // clock.tick(200);  // Simulates a 200 ms delay when communicating from server to client
+   *
+   * // Trsansaction gathered from a challenge, possibly from the client side
+   * const transaction = new Transaction(challenge, Networks.TESTNET);
+   * transaction.sign(clientKP1, clientKP2);
+   * const signedChallenge = transaction
+   *         .toEnvelope()
+   *         .toXDR("base64")
+   *         .toString();
+   *
+   * // Defining the threshold and signerSummary
+   * const threshold = 3;
+   * const signerSummary = new Map();
+   * signerSummary.set(clientKP1.publicKey(), 1);
+   * signerSummary.set(clientKP2.publicKey(), 2);
+   *
+   * // The result below should be equal to [clientKP1.publicKey(), clientKP2.publicKey()]
+   * Utils.verifyChallengeTxThreshold(signedChallenge, serverKP.publicKey(), Networks.TESTNET, threshold, signerSummary);
    * @returns {string[]} The list of signers that were found, given that the threshold was met
    */
   export function verifyChallengeTxThreshold(
@@ -239,7 +270,33 @@ export namespace Utils {
    * @param {string} network The network passphrase.
    * @param {string[]} accountIDs The stellar account public keys that have supposedly been used to sign the transaction
    * @example
-   * // TODO
+   * import { Networks, Transaction, Utils }  from 'stellar-sdk';
+   *
+   * const serverKP = Keypair.random();
+   * const clientKP1 = Keypair.random();
+   * const clientKP2 = Keypair.random();
+   *
+   * // Challenge, possibly built in the server side
+   * const challenge = Utils.buildChallengeTx(
+   *   serverKP,
+   *   clientKP1.publicKey(),
+   *   "SDF",
+   *   300,
+   *   Networks.TESTNET
+   * );
+   *
+   * // clock.tick(200);  // Simulates a 200 ms delay when communicating from server to client
+   *
+   * // Trsansaction gathered from a challenge, possibly from the client side
+   * const transaction = new Transaction(challenge, Networks.TESTNET);
+   * transaction.sign(clientKP1, clientKP2);
+   * const signedChallenge = transaction
+   *         .toEnvelope()
+   *         .toXDR("base64")
+   *         .toString();
+   *
+   * // The result below should be equal to [clientKP1.publicKey(), clientKP2.publicKey()]
+   * Utils.verifyChallengeTxSigners(signedChallenge, serverKP.publicKey(), Networks.TESTNET, threshold, clientKP1.publicKey(), clientKP2.publicKey());
    * @returns {string[]} The list of signers that were found, excluding the server account ID
    */
   export function verifyChallengeTxSigners(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -369,25 +369,15 @@ export namespace Utils {
 
     const signersFound: string[] = gatherTxSigners(tx, ...allSigners);
 
-    // Confirm the server is in the list of signers found and remove it.
-    let serverSignerFound: boolean = false;
-    for (let i = 0; i < signersFound.length; i++) {
-      if (signersFound[i] === serverKP.publicKey()) {
-        serverSignerFound = true;
-        signersFound.splice(i, 1);
-        break;
-      }
-    }
-
     // Confirm we matched a signature to the server signer.
-    if (!serverSignerFound) {
+    if (!signersFound.includes(serverKP.publicKey())) {
       throw new InvalidSep10ChallengeError(
         "Transaction not signed by server: '" + serverKP.publicKey() + "'",
       );
     }
 
     // Confirm we matched a signature to the server signer.
-    if (signersFound.length === 0) {
+    if (signersFound.length === 1) {
       throw new InvalidSep10ChallengeError(
         "Transaction not signed by client(s): '" +
           Array.from(clientSigners).join() +
@@ -395,12 +385,15 @@ export namespace Utils {
       );
     }
 
-    // Confirm all signatures, including the server signature represented by the "+ 1", were consumed by a signer:
-    if (signersFound.length + 1 !== tx.signatures.length) {
+    // Confirm all signatures, including the server signature, were consumed by a signer:
+    if (signersFound.length !== tx.signatures.length) {
       throw new InvalidSep10ChallengeError(
         "Transaction has unrecognized signatures",
       );
     }
+
+    // Remove the server public key before returning
+    signersFound.splice(signersFound.indexOf(serverKP.publicKey()), 1);
 
     return signersFound;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -429,12 +429,18 @@ export namespace Utils {
    *
    * let challenge = Utils.verifyChallengeTx("base64tx", "server-account-id", Networks.TESTNET)
    * @returns {boolean}
+   *
+   * @deprecated Use {@link Utils#verifyChallengeTxThreshold}
    */
   export function verifyChallengeTx(
     challengeTx: string,
     serverAccountId: string,
     networkPassphrase?: string,
   ): boolean {
+    console.warn(
+      "`Utils#verifyChallengeTx` is deprecated. Please use `Utils#verifyChallengeTxThreshold`.",
+    );
+
     const { tx, clientAccountID } = readChallengeTx(
       challengeTx,
       serverAccountId,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -242,7 +242,7 @@ export namespace Utils {
       challengeTx,
       serverAccountID,
       networkPassphrase,
-      ...signers,
+      signers,
     );
     let weight = 0;
 
@@ -318,7 +318,7 @@ export namespace Utils {
     challengeTx: string,
     serverAccountID: string,
     networkPassphrase: string,
-    ...accountIDs: string[]
+    accountIDs: string[],
   ): string[] {
     // Read the transaction which validates its structure.
     const { tx } = readChallengeTx(
@@ -367,7 +367,7 @@ export namespace Utils {
       ...Array.from(clientSigners),
     ];
 
-    const signersFound: string[] = gatherTxSigners(tx, ...allSigners);
+    const signersFound: string[] = gatherTxSigners(tx, allSigners);
 
     // Confirm we matched a signature to the server signer.
     if (!signersFound.includes(serverKP.publicKey())) {
@@ -475,9 +475,9 @@ export namespace Utils {
    */
   export function verifyTxSignedBy(
     transaction: Transaction,
-    accountId: string,
+    accountID: string,
   ): boolean {
-    return gatherTxSigners(transaction, accountId).length !== 0;
+    return gatherTxSigners(transaction, [accountID]).length !== 0;
   }
 
   /**
@@ -505,7 +505,7 @@ export namespace Utils {
    */
   export function gatherTxSigners(
     transaction: Transaction,
-    ...accountIDs: string[]
+    accountIDs: string[],
   ): string[] {
     const hashedSignatureBase = transaction.hash();
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,6 @@ import {
   BASE_FEE,
   Keypair,
   Operation,
-  StrKey,
   TimeoutInfinite,
   Transaction,
   TransactionBuilder,
@@ -533,12 +532,14 @@ export namespace Utils {
         break;
       }
 
-      // Raise an error on invalid G signers:
-      if (!StrKey.isValidEd25519PublicKey(signer)) {
-        throw new InvalidSep10ChallengeError("Signer is not a valid address");
+      let keypair: Keypair;
+      try {
+        keypair = Keypair.fromPublicKey(signer); // This can throw a few different errors
+      } catch (err) {
+        throw new InvalidSep10ChallengeError(
+          "Signer is not a valid address: " + err.message,
+        );
       }
-
-      const keypair = Keypair.fromPublicKey(signer); // This can throw new Error('Invalid Stellar public key');
 
       for (let i = 0; i < txSignatures.length; i++) {
         const decSig = txSignatures[i];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -328,7 +328,15 @@ export namespace Utils {
     );
 
     // Ensure the server account ID is an address and not a seed.
-    const serverKP = Keypair.fromPublicKey(serverAccountID); // can throw 'Invalid Stellar public key'
+    let serverKP: Keypair;
+    try {
+      serverKP = Keypair.fromPublicKey(serverAccountID); // can throw 'Invalid Stellar public key'
+    } catch (err) {
+      throw new Error(
+        "Couldn't infer keypair from the provided 'serverAccountID': " +
+          err.message,
+      );
+    }
 
     // Deduplicate the client signers and ensure the server is not included
     // anywhere we check or output the list of signers.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -366,17 +366,17 @@ export namespace Utils {
       serverKP.publicKey(),
       ...Array.from(clientSigners),
     ];
-    const allSignersFound: string[] = verifyTxMultiSignedBy(tx, ...allSigners);
+
+    const signersFound: string[] = verifyTxMultiSignedBy(tx, ...allSigners);
 
     // Confirm the server is in the list of signers found and remove it.
     let serverSignerFound: boolean = false;
-    const signersFound: string[] = new Array();
-    for (const signer of allSignersFound) {
-      if (signer === serverKP.publicKey()) {
+    for (let i = 0; i < signersFound.length; i++) {
+      if (signersFound[i] === serverKP.publicKey()) {
         serverSignerFound = true;
-        continue;
+        signersFound.splice(i, 1);
+        break;
       }
-      signersFound.push(signer);
     }
 
     // Confirm we matched a signature to the server signer.
@@ -395,8 +395,8 @@ export namespace Utils {
       );
     }
 
-    // Confirm all signatures were consumed by a signer.
-    if (allSignersFound.length !== tx.signatures.length) {
+    // Confirm all signatures, including the server signature represented by the "+ 1", were consumed by a signer:
+    if (signersFound.length + 1 !== tx.signatures.length) {
       throw new InvalidSep10ChallengeError(
         "Transaction has unrecognized signatures",
       );
@@ -490,8 +490,8 @@ export namespace Utils {
   /**
    *
    * verifyTxMultiSignedBy checks if a transaction has been signed by one or more of
-   * the signers, returning a list of signers that were found to have signed the
-   * transaction.
+   * the given signers, returning a list of non-repeated signers that were found to have
+   * signed the given transaction.
    *
    * @function
    * @memberof Utils

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -166,7 +166,7 @@ export namespace Utils {
   }
 
   /**
-   * VerifyChallengeTxThreshold verifies that for a SEP 10 challenge transaction
+   * verifyChallengeTxThreshold verifies that for a SEP 10 challenge transaction
    * all signatures on the transaction are accounted for and that the signatures
    * meet a threshold on an account. A transaction is verified if it is signed by
    * the server account, and all other signatures match a signer that has been
@@ -211,7 +211,7 @@ export namespace Utils {
    *
    * // clock.tick(200);  // Simulates a 200 ms delay when communicating from server to client
    *
-   * // Trsansaction gathered from a challenge, possibly from the client side
+   * // Transaction gathered from a challenge, possibly from the client side
    * const transaction = new Transaction(challenge, Networks.TESTNET);
    * transaction.sign(clientKP1, clientKP2);
    * const signedChallenge = transaction
@@ -259,7 +259,7 @@ export namespace Utils {
   }
 
   /**
-   * VerifyChallengeTxSigners verifies that for a SEP 10 challenge transaction all
+   * verifyChallengeTxSigners verifies that for a SEP 10 challenge transaction all
    * signatures on the transaction are accounted for. A transaction is verified
    * if it is signed by the server account, and all other signatures match a signer
    * that has been provided as an argument (as the accountIDs list). Additional signers
@@ -302,7 +302,7 @@ export namespace Utils {
    *
    * // clock.tick(200);  // Simulates a 200 ms delay when communicating from server to client
    *
-   * // Trsansaction gathered from a challenge, possibly from the client side
+   * // Transaction gathered from a challenge, possibly from the client side
    * const transaction = new Transaction(challenge, Networks.TESTNET);
    * transaction.sign(clientKP1, clientKP2);
    * const signedChallenge = transaction

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -362,7 +362,7 @@ export namespace Utils {
       }
 
       // Ignore non-G... account/address signers.
-      if (!StrKey.isValidEd25519PublicKey(signer)) {
+      if (signer.charAt(0) !== "G") {
         continue;
       }
 
@@ -533,7 +533,12 @@ export namespace Utils {
         break;
       }
 
-      const keypair = Keypair.fromPublicKey(signer);
+      // Raise an error on invalid G signers:
+      if (!StrKey.isValidEd25519PublicKey(signer)) {
+        throw new InvalidSep10ChallengeError("Signer is not a valid address");
+      }
+
+      const keypair = Keypair.fromPublicKey(signer); // This can throw new Error('Invalid Stellar public key');
 
       for (let i = 0; i < txSignatures.length; i++) {
         const decSig = txSignatures[i];

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -323,7 +323,6 @@ describe('Utils', function() {
         .build();
 
       transaction.sign(serverKeypair);
-
       const challenge = transaction
         .toEnvelope()
         .toXDR("base64")
@@ -877,7 +876,7 @@ describe('Utils', function() {
       );
     });
 
-    it("throws an error if the challenge was signed by an unrecognized client", function() {
+    it("throws an error if none of the given signers have signed the transaction", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
@@ -892,12 +891,15 @@ describe('Utils', function() {
         challenge,
         StellarSdk.Networks.TESTNET,
       );
-      const unrecognizedKP = StellarSdk.Keypair.random();
-      transaction.sign(unrecognizedKP);
+      transaction.sign(StellarSdk.Keypair.random(), StellarSdk.Keypair.random());
+      const signedChallenge = transaction
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       expect(() =>
         StellarSdk.Utils.verifyChallengeTxSigners(
-          challenge,
+          signedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
           [this.clientKP1.publicKey()],
@@ -1159,10 +1161,14 @@ describe('Utils', function() {
         StellarSdk.Networks.TESTNET,
       );
       transaction.sign(this.clientKP1);
+      const signedChallenge = transaction
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       expect(() =>
         StellarSdk.Utils.verifyChallengeTxSigners(
-          challenge,
+          signedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
           [this.clientKP2.publicKey(), this.clientKP2.publicKey()],
@@ -1622,10 +1628,7 @@ describe('Utils', function() {
         this.keypair2.publicKey(),
       ];
       expect(
-        StellarSdk.Utils.gatherTxSigners(this.transaction, [
-          this.keypair1.publicKey(),
-          this.keypair2.publicKey(),
-        ]),
+        StellarSdk.Utils.gatherTxSigners(this.transaction, expectedSignatures),
       ).to.eql(expectedSignatures);
     });
 

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -1362,7 +1362,7 @@ describe('Utils', function() {
         () => StellarSdk.Utils.verifyChallengeTx(challenge, keypair.publicKey(), StellarSdk.Networks.TESTNET)
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /The transaction should contain only one operation/
+        /The transaction should contain exactly one operation/,
       );
     });
 
@@ -1416,7 +1416,7 @@ describe('Utils', function() {
         () => StellarSdk.Utils.verifyChallengeTx(challenge, keypair.publicKey(), StellarSdk.Networks.TESTNET)
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /The transaction\'s operation should be manageData/
+        /The transaction\'s operation type should be \'manageData\'/,
       );
     });
 

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -69,6 +69,30 @@ describe('Utils', function() {
   });
 
   describe('Utils.readChallengeTx', function() {
+    it('returns the transaction and the clientAccountID (client\'s pubKey) if the challenge was created successfully', function() {
+      let serverKP = StellarSdk.Keypair.random();
+      let clientKP = StellarSdk.Keypair.random();
+
+      const challenge = StellarSdk.Utils.buildChallengeTx(
+        serverKP,
+        clientKP.publicKey(),
+        "SDF",
+        300,
+        StellarSdk.Networks.TESTNET
+      );
+
+      clock.tick(200);
+
+      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
+
+      expect(
+        StellarSdk.Utils.readChallengeTx(challenge, serverKP.publicKey(), StellarSdk.Networks.TESTNET)
+        ).to.eql({ 
+          tx: transaction, 
+          clientAccountID: clientKP.publicKey() 
+        });
+    });
+
     it('throws an error if transaction sequenceNumber if different to zero', function() {
       let keypair = StellarSdk.Keypair.random();
 
@@ -128,7 +152,7 @@ describe('Utils', function() {
         () => StellarSdk.Utils.readChallengeTx(challenge, keypair.publicKey(), StellarSdk.Networks.TESTNET)
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /The transaction should contain only one operation/
+        /The transaction should contain exactly one operation/
       );
     });
 
@@ -308,7 +332,7 @@ describe('Utils', function() {
 
       this.operation = StellarSdk.Operation.manageData({
         source: this.clientKP1.publicKey(),
-        name: 'SDF testserver auth',
+        name: 'SDF-test auth',
         value: randomBytes(48).toString('base64')
       });
       
@@ -422,21 +446,6 @@ describe('Utils', function() {
         /Transaction has unrecognized signatures/
       );
     });
-
-    // it('invalidServer')
-    // it('validServerAndClientMasterKey')
-    // it('invalidServerAndNoClient')
-    // it('invalidServerAndUnrecognizedClient')
-    // it('validServerAndMultipleClientSigners')
-    // it('validServerAndMultipleClientSignersReverseOrder')
-    // it('validServerAndClientSignersNotMasterKey')
-    // it('validServerAndClientSignersIgnoresServerSigner')
-    // it('invalidServerNoClientSignersIgnoresServerSigner')
-    // it('validServerAndClientSignersIgnoresDuplicateSigner')
-    // it('validIgnorePreauthTxHashAndXHash')
-    // it('invalidServerAndClientSignersIgnoresDuplicateSignerInError')
-    // it('invalidServerAndClientSignersFailsDuplicateSignatures')
-    // it('invalidServerAndClientSignersFailsSignerSeed')
   });
 
   describe('Utils.verifyChallengeTx', function() {

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -915,9 +915,7 @@ describe('Utils', function() {
       );
       const clientSigners = [this.clientKP1, this.clientKP2];
       transaction.sign(...clientSigners);
-      const clientSignersPubKey = clientSigners.map((kp) => {
-        return kp.publicKey();
-      });
+      const clientSignersPubKey = clientSigners.map(kp => kp.publicKey());
 
       const signedChallenge = transaction
         .toEnvelope()
@@ -951,9 +949,7 @@ describe('Utils', function() {
       );
       const clientSigners = [this.clientKP1, this.clientKP2];
       transaction.sign(...clientSigners.reverse());
-      const clientSignersPubKey = clientSigners.map((kp) => {
-        return kp.publicKey();
-      });
+      const clientSignersPubKey = clientSigners.map(kp => kp.publicKey());
 
       const signedChallenge = transaction
         .toEnvelope()

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -894,9 +894,7 @@ describe('Utils', function() {
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        "Transaction not signed by client(s): '" +
-          this.clientKP1.publicKey() +
-          "'",
+        /None of the given signers match the transaction signatures/,
       );
     });
 
@@ -1067,9 +1065,7 @@ describe('Utils', function() {
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        "Transaction not signed by client(s): '" +
-          this.clientKP2.publicKey() +
-          "'",
+        /None of the given signers match the transaction signatures/,
       );
     });
 
@@ -1141,7 +1137,7 @@ describe('Utils', function() {
       ).to.eql([this.clientKP2.publicKey()]);
     });
 
-    it("throws an error if the signers (duplicated) provided have not signed the actual transaction", function() {
+    it("throws an error if duplicated signers have been provided and they haven't actually signed the transaction", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
@@ -1167,9 +1163,7 @@ describe('Utils', function() {
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        "Transaction not signed by client(s): '" +
-          this.clientKP2.publicKey() +
-          "'",
+        /None of the given signers match the transaction signatures/,
       );
     });
 
@@ -1272,7 +1266,7 @@ describe('Utils', function() {
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        "Transaction not signed by client(s): '" + clientSigners.join() + "'",
+        /None of the given signers match the transaction signatures/,
       );
     });
 

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -100,7 +100,7 @@ describe('Utils', function() {
       });
     });
 
-    it("throws an error if transaction sequenceNumber if different to zero", function() {
+    it("throws an error if transaction sequenceNumber is different to zero", function() {
       let keypair = StellarSdk.Keypair.random();
 
       const account = new StellarSdk.Account(keypair.publicKey(), "100");
@@ -1303,7 +1303,7 @@ describe('Utils', function() {
       expect(StellarSdk.Utils.verifyChallengeTx(signedChallenge, keypair.publicKey(), StellarSdk.Networks.TESTNET)).to.eql(true);
     });
 
-    it('throws an error if transaction sequenceNumber if different to zero', function() {
+    it('throws an error if transaction sequenceNumber is different to zero', function() {
       let keypair = StellarSdk.Keypair.random();
 
       const account = new StellarSdk.Account(keypair.publicKey(), "100");

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -1,5 +1,9 @@
 const randomBytes = require("randombytes");
 
+function newClientSigner(key, weight) {
+  return { key, weight }
+}
+
 describe('Utils', function() {
   let clock, txBuilderOpts;
 
@@ -457,8 +461,9 @@ describe('Utils', function() {
         .build();
 
       const threshold = 1;
-      const signerSummary = new Map();
-      signerSummary.set(this.clientKP1.publicKey(), 1);
+      const signerSummary = [
+        newClientSigner(this.clientKP1.publicKey(), 1)
+      ];
 
       transaction.sign(this.clientKP1);
 
@@ -503,8 +508,9 @@ describe('Utils', function() {
         .toString();
 
       const threshold = 1;
-      const signerSummary = new Map();
-      signerSummary.set(this.clientKP1.publicKey(), 1);
+      const signerSummary = [
+        newClientSigner(this.clientKP1.publicKey(), 1)
+      ];
 
       expect(
         StellarSdk.Utils.verifyChallengeTxThreshold(
@@ -539,9 +545,10 @@ describe('Utils', function() {
         .toString();
 
       const threshold = 3;
-      const signerSummary = new Map();
-      signerSummary.set(this.clientKP1.publicKey(), 1);
-      signerSummary.set(this.clientKP2.publicKey(), 2);
+      const signerSummary = [
+        newClientSigner(this.clientKP1.publicKey(), 1),
+        newClientSigner(this.clientKP2.publicKey(), 2)
+      ];
 
       expect(
         StellarSdk.Utils.verifyChallengeTxThreshold(
@@ -576,10 +583,11 @@ describe('Utils', function() {
         .toString();
 
       const threshold = 3;
-      const signerSummary = new Map();
-      signerSummary.set(this.clientKP1.publicKey(), 1);
-      signerSummary.set(this.clientKP2.publicKey(), 2);
-      signerSummary.set(this.clientKP3.publicKey(), 2);
+      const signerSummary = [
+        newClientSigner(this.clientKP1.publicKey(), 1),
+        newClientSigner(this.clientKP2.publicKey(), 2),
+        newClientSigner(this.clientKP3.publicKey(), 2)
+      ];
 
       expect(
         StellarSdk.Utils.verifyChallengeTxThreshold(
@@ -618,13 +626,14 @@ describe('Utils', function() {
         .toString();
 
       const threshold = 3;
-      const signerSummary = new Map();
-      signerSummary.set(this.clientKP1.publicKey(), 1);
-      signerSummary.set(this.clientKP2.publicKey(), 2);
-      signerSummary.set(this.clientKP3.publicKey(), 2);
-      signerSummary.set(preauthTxHash, 10);
-      signerSummary.set(xHash, 10);
-      signerSummary.set(unknownSignerType, 10);
+      const signerSummary = [
+        newClientSigner(this.clientKP1.publicKey(), 1),
+        newClientSigner(this.clientKP2.publicKey(), 2),
+        newClientSigner(this.clientKP3.publicKey(), 2),
+        newClientSigner(preauthTxHash, 10),
+        newClientSigner(xHash, 10),
+        newClientSigner(unknownSignerType, 10),
+      ];
 
       expect(
         StellarSdk.Utils.verifyChallengeTxThreshold(
@@ -659,10 +668,11 @@ describe('Utils', function() {
         .toString();
 
       const threshold = 10;
-      const signerSummary = new Map();
-      signerSummary.set(this.clientKP1.publicKey(), 1);
-      signerSummary.set(this.clientKP2.publicKey(), 2);
-      signerSummary.set(this.clientKP3.publicKey(), 2);
+      const signerSummary = [
+        newClientSigner(this.clientKP1.publicKey(), 1),
+        newClientSigner(this.clientKP2.publicKey(), 2),
+        newClientSigner(this.clientKP3.publicKey(), 2),
+      ];
 
       expect(() =>
         StellarSdk.Utils.verifyChallengeTxThreshold(
@@ -700,9 +710,10 @@ describe('Utils', function() {
         .toString();
 
       const threshold = 10;
-      const signerSummary = new Map();
-      signerSummary.set(this.clientKP1.publicKey(), 1);
-      signerSummary.set(this.clientKP2.publicKey(), 2);
+      const signerSummary = [
+        newClientSigner(this.clientKP1.publicKey(), 1),
+        newClientSigner(this.clientKP2.publicKey(), 2),
+      ];
 
       expect(() =>
         StellarSdk.Utils.verifyChallengeTxThreshold(
@@ -740,7 +751,6 @@ describe('Utils', function() {
         .toString();
 
       const threshold = 10;
-      const signerSummary = new Map();
 
       expect(() =>
         StellarSdk.Utils.verifyChallengeTxThreshold(
@@ -748,7 +758,7 @@ describe('Utils', function() {
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
           threshold,
-          signerSummary,
+          [],
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -1562,7 +1562,7 @@ describe('Utils', function() {
     });
   });
 
-  describe("Utils.verifyTxMultiSignedBy", function() {
+  describe("Utils.gatherTxSigners", function() {
     beforeEach(function() {
       this.keypair1 = StellarSdk.Keypair.random();
       this.keypair2 = StellarSdk.Keypair.random();
@@ -1587,7 +1587,7 @@ describe('Utils', function() {
         this.keypair2.publicKey(),
       ];
       expect(
-        StellarSdk.Utils.verifyTxMultiSignedBy(
+        StellarSdk.Utils.gatherTxSigners(
           this.transaction,
           this.keypair1.publicKey(),
           this.keypair2.publicKey(),
@@ -1610,7 +1610,7 @@ describe('Utils', function() {
         this.keypair2.publicKey(),
       ];
       expect(
-        StellarSdk.Utils.verifyTxMultiSignedBy(
+        StellarSdk.Utils.gatherTxSigners(
           this.transaction,
           this.keypair1.publicKey(),
           this.keypair2.publicKey(),
@@ -1628,16 +1628,16 @@ describe('Utils', function() {
       ];
 
       expect(
-        StellarSdk.Utils.verifyTxMultiSignedBy(
+        StellarSdk.Utils.gatherTxSigners(
           this.transaction,
           ...wrongSignatures,
         ),
       ).to.eql([]);
     });
 
-    it("calling verifyTxMultiSignedBy with an unsigned transaction will return an empty list", function() {
+    it("calling gatherTxSigners with an unsigned transaction will return an empty list", function() {
       expect(
-        StellarSdk.Utils.verifyTxMultiSignedBy(
+        StellarSdk.Utils.gatherTxSigners(
           this.transaction,
           this.keypair1.publicKey(),
           this.keypair2.publicKey(),

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -1676,5 +1676,27 @@ describe('Utils', function() {
         ]),
       ).to.eql([]);
     });
+
+    it("Raises an error in case one of the given signers is not a valid G signer", function() {
+      this.transaction.sign(this.keypair1, this.keypair2);
+      const preauthTxHash = "TAQCSRX2RIDJNHFIFHWD63X7D7D6TRT5Y2S6E3TEMXTG5W3OECHZ2OG4";
+      expect(
+        () => StellarSdk.Utils.gatherTxSigners(this.transaction, [preauthTxHash, this.keypair1.publicKey()]),
+      ).to.throw(
+        StellarSdk.InvalidSep10ChallengeError,
+        /Signer is not a valid address/
+      );
+    });
+
+    it("Raises an error in case one of the given signers is an invalid G signer", function() {
+      this.transaction.sign(this.keypair1, this.keypair2);
+      const invalidGHash = "GBDIT5GUJ7R5BXO3GJHFXJ6AZ5UQK6MNOIDMPQUSMXLIHTUNR2Q5CAAA";
+      expect(
+        () => StellarSdk.Utils.gatherTxSigners(this.transaction, [invalidGHash, this.keypair1.publicKey()]),
+      ).to.throw(
+        StellarSdk.InvalidSep10ChallengeError,
+        /Signer is not a valid address/
+      );
+    });
   });
 });

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -68,8 +68,8 @@ describe('Utils', function() {
     });
   });
 
-  describe('Utils.readChallengeTx', function() {
-    it('returns the transaction and the clientAccountID (client\'s pubKey) if the challenge was created successfully', function() {
+  describe("Utils.readChallengeTx", function() {
+    it("returns the transaction and the clientAccountID (client's pubKey) if the challenge was created successfully", function() {
       let serverKP = StellarSdk.Keypair.random();
       let clientKP = StellarSdk.Keypair.random();
 
@@ -78,43 +78,57 @@ describe('Utils', function() {
         clientKP.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
 
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
 
       expect(
-        StellarSdk.Utils.readChallengeTx(challenge, serverKP.publicKey(), StellarSdk.Networks.TESTNET)
-        ).to.eql({ 
-          tx: transaction, 
-          clientAccountID: clientKP.publicKey() 
-        });
+        StellarSdk.Utils.readChallengeTx(
+          challenge,
+          serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+        ),
+      ).to.eql({
+        tx: transaction,
+        clientAccountID: clientKP.publicKey(),
+      });
     });
 
-    it('throws an error if transaction sequenceNumber if different to zero', function() {
+    it("throws an error if transaction sequenceNumber if different to zero", function() {
       let keypair = StellarSdk.Keypair.random();
 
       const account = new StellarSdk.Account(keypair.publicKey(), "100");
-      const transaction = new StellarSdk.TransactionBuilder(account, txBuilderOpts)
-            .setTimeout(30)
-            .build();
+      const transaction = new StellarSdk.TransactionBuilder(
+        account,
+        txBuilderOpts,
+      )
+        .setTimeout(30)
+        .build();
 
       let challenge = transaction
-          .toEnvelope()
-          .toXDR("base64")
-          .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      expect(
-        () => StellarSdk.Utils.readChallengeTx(challenge, keypair.publicKey(), StellarSdk.Networks.TESTNET)
+      expect(() =>
+        StellarSdk.Utils.readChallengeTx(
+          challenge,
+          keypair.publicKey(),
+          StellarSdk.Networks.TESTNET,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /The transaction sequence number should be zero/
+        /The transaction sequence number should be zero/,
       );
     });
 
-    it('throws an error if transaction source account is different to server account id', function() {
+    it("throws an error if transaction source account is different to server account id", function() {
       let keypair = StellarSdk.Keypair.random();
 
       const challenge = StellarSdk.Utils.buildChallengeTx(
@@ -122,101 +136,126 @@ describe('Utils', function() {
         "GBDIT5GUJ7R5BXO3GJHFXJ6AZ5UQK6MNOIDMPQUSMXLIHTUNR2Q5CFNF",
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       let serverAccountId = StellarSdk.Keypair.random().publicKey();
 
-      expect(
-        () => StellarSdk.Utils.readChallengeTx(challenge, serverAccountId, StellarSdk.Networks.TESTNET)
+      expect(() =>
+        StellarSdk.Utils.readChallengeTx(
+          challenge,
+          serverAccountId,
+          StellarSdk.Networks.TESTNET,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /The transaction source account is not equal to the server's account/
+        /The transaction source account is not equal to the server's account/,
       );
     });
 
-    it('throws an error if transaction doestn\'t contain exactly one operation', function() {
+    it("throws an error if transaction doestn't contain exactly one operation", function() {
       let keypair = StellarSdk.Keypair.random();
       const account = new StellarSdk.Account(keypair.publicKey(), "-1");
-      const transaction = new StellarSdk.TransactionBuilder(account, txBuilderOpts)
-            .setTimeout(30)
-            .build();
+      const transaction = new StellarSdk.TransactionBuilder(
+        account,
+        txBuilderOpts,
+      )
+        .setTimeout(30)
+        .build();
 
       transaction.sign(keypair);
       const challenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      expect(
-        () => StellarSdk.Utils.readChallengeTx(challenge, keypair.publicKey(), StellarSdk.Networks.TESTNET)
+      expect(() =>
+        StellarSdk.Utils.readChallengeTx(
+          challenge,
+          keypair.publicKey(),
+          StellarSdk.Networks.TESTNET,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /The transaction should contain exactly one operation/
+        /The transaction should contain exactly one operation/,
       );
     });
 
-    it('throws an error if operation does not contain the source account', function() {
+    it("throws an error if operation does not contain the source account", function() {
       let keypair = StellarSdk.Keypair.random();
       const account = new StellarSdk.Account(keypair.publicKey(), "-1");
-      const transaction = new StellarSdk.TransactionBuilder(account, txBuilderOpts)
-            .addOperation(
-              StellarSdk.Operation.manageData({
-                name: 'SDF auth',
-                value: randomBytes(48).toString('base64')
-              })
-            )
-            .setTimeout(30)
-            .build();
+      const transaction = new StellarSdk.TransactionBuilder(
+        account,
+        txBuilderOpts,
+      )
+        .addOperation(
+          StellarSdk.Operation.manageData({
+            name: "SDF auth",
+            value: randomBytes(48).toString("base64"),
+          }),
+        )
+        .setTimeout(30)
+        .build();
 
       transaction.sign(keypair);
       const challenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      expect(
-        () => StellarSdk.Utils.readChallengeTx(challenge, keypair.publicKey(), StellarSdk.Networks.TESTNET)
+      expect(() =>
+        StellarSdk.Utils.readChallengeTx(
+          challenge,
+          keypair.publicKey(),
+          StellarSdk.Networks.TESTNET,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /The transaction\'s operation should contain a source account/
+        /The transaction\'s operation should contain a source account/,
       );
     });
 
-    it('throws an error if operation is not manage data', function() {
+    it("throws an error if operation is not manage data", function() {
       let keypair = StellarSdk.Keypair.random();
       const account = new StellarSdk.Account(keypair.publicKey(), "-1");
-      const transaction = new StellarSdk.TransactionBuilder(account, txBuilderOpts)
-            .addOperation(
-              StellarSdk.Operation.accountMerge({
-                destination: keypair.publicKey(),
-                source: keypair.publicKey()
-              })
-            )
-            .setTimeout(30)
-            .build();
+      const transaction = new StellarSdk.TransactionBuilder(
+        account,
+        txBuilderOpts,
+      )
+        .addOperation(
+          StellarSdk.Operation.accountMerge({
+            destination: keypair.publicKey(),
+            source: keypair.publicKey(),
+          }),
+        )
+        .setTimeout(30)
+        .build();
 
       transaction.sign(keypair);
       const challenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      expect(
-        () => StellarSdk.Utils.readChallengeTx(challenge, keypair.publicKey(), StellarSdk.Networks.TESTNET)
+      expect(() =>
+        StellarSdk.Utils.readChallengeTx(
+          challenge,
+          keypair.publicKey(),
+          StellarSdk.Networks.TESTNET,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /The transaction\'s operation type should be \'manageData\'/
+        /The transaction\'s operation type should be \'manageData\'/,
       );
     });
 
-    it('throws an error if transaction.timeBounds.maxTime is infinite', function() {
+    it("throws an error if transaction.timeBounds.maxTime is infinite", function() {
       let serverKeypair = StellarSdk.Keypair.random();
       let clientKeypair = StellarSdk.Keypair.random();
 
-      const anchorName = "SDF"
-      const networkPassphrase = StellarSdk.Networks.TESTNET
-      
+      const anchorName = "SDF";
+      const networkPassphrase = StellarSdk.Networks.TESTNET;
+
       const account = new StellarSdk.Account(serverKeypair.publicKey(), "-1");
       const now = Math.floor(Date.now() / 1000);
 
@@ -246,51 +285,65 @@ describe('Utils', function() {
         .toXDR("base64")
         .toString();
 
-      transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
+      transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
       transaction.sign(clientKeypair);
 
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      expect(
-        () => StellarSdk.Utils.readChallengeTx(signedChallenge, serverKeypair.publicKey(), StellarSdk.Networks.TESTNET)
+      expect(() =>
+        StellarSdk.Utils.readChallengeTx(
+          signedChallenge,
+          serverKeypair.publicKey(),
+          StellarSdk.Networks.TESTNET,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /The transaction requires non-infinite timebounds/
+        /The transaction requires non-infinite timebounds/,
       );
     });
 
-    it('throws an error if operation value is not a 64 bytes base64 string', function() {
+    it("throws an error if operation value is not a 64 bytes base64 string", function() {
       let keypair = StellarSdk.Keypair.random();
       const account = new StellarSdk.Account(keypair.publicKey(), "-1");
-      const transaction = new StellarSdk.TransactionBuilder(account, txBuilderOpts)
-            .addOperation(
-              StellarSdk.Operation.manageData({
-                name: 'SDF auth',
-                value: randomBytes(64),
-                source: 'GBDIT5GUJ7R5BXO3GJHFXJ6AZ5UQK6MNOIDMPQUSMXLIHTUNR2Q5CFNF'
-              })
-            )
-            .setTimeout(30)
-            .build();
+      const transaction = new StellarSdk.TransactionBuilder(
+        account,
+        txBuilderOpts,
+      )
+        .addOperation(
+          StellarSdk.Operation.manageData({
+            name: "SDF auth",
+            value: randomBytes(64),
+            source: "GBDIT5GUJ7R5BXO3GJHFXJ6AZ5UQK6MNOIDMPQUSMXLIHTUNR2Q5CFNF",
+          }),
+        )
+        .setTimeout(30)
+        .build();
 
       transaction.sign(keypair);
       const challenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      expect(
-        () => StellarSdk.Utils.readChallengeTx(challenge, keypair.publicKey(), StellarSdk.Networks.TESTNET)
+      expect(() =>
+        StellarSdk.Utils.readChallengeTx(
+          challenge,
+          keypair.publicKey(),
+          StellarSdk.Networks.TESTNET,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /The transaction\'s operation value should be a 64 bytes base64 random string/
+        /The transaction\'s operation value should be a 64 bytes base64 random string/,
       );
     });
 
-    it('throws an error if transaction does not contain valid timeBounds', function() {
+    it("throws an error if transaction does not contain valid timeBounds", function() {
       let keypair = StellarSdk.Keypair.random();
       let clientKeypair = StellarSdk.Keypair.random();
 
@@ -299,47 +352,54 @@ describe('Utils', function() {
         clientKeypair.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(350000);
 
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
       transaction.sign(clientKeypair);
 
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      expect(
-        () => StellarSdk.Utils.readChallengeTx(signedChallenge, keypair.publicKey(), StellarSdk.Networks.TESTNET)
+      expect(() =>
+        StellarSdk.Utils.readChallengeTx(
+          signedChallenge,
+          keypair.publicKey(),
+          StellarSdk.Networks.TESTNET,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /The transaction has expired/
+        /The transaction has expired/,
       );
     });
   });
 
-  describe('Utils.verifyChallengeTxThreshold', function() {
+  describe("Utils.verifyChallengeTxThreshold", function() {
     beforeEach(function() {
       this.serverKP = StellarSdk.Keypair.random();
       this.clientKP1 = StellarSdk.Keypair.random();
       this.clientKP2 = StellarSdk.Keypair.random();
       this.clientKP3 = StellarSdk.Keypair.random();
-      
+
       this.txAccount = new StellarSdk.Account(this.serverKP.publicKey(), "-1");
       this.opAccount = new StellarSdk.Account(this.clientKP1.publicKey(), "0");
 
       this.operation = StellarSdk.Operation.manageData({
         source: this.clientKP1.publicKey(),
-        name: 'SDF-test auth',
-        value: randomBytes(48).toString('base64')
+        name: "SDF-test auth",
+        value: randomBytes(48).toString("base64"),
       });
-      
+
       this.txBuilderOpts = {
         fee: 100,
-        networkPassphrase: StellarSdk.Networks.TESTNET
+        networkPassphrase: StellarSdk.Networks.TESTNET,
       };
     });
 
@@ -347,11 +407,14 @@ describe('Utils', function() {
       this.serverKP, this.clientKP1, this.clientKP2, this.txAccount, this.opAccount, this.operation = null;
     });
 
-    it('throws an error if the server hasn\'t signed the transaction', function() {
-      const transaction = new StellarSdk.TransactionBuilder(this.txAccount, this.txBuilderOpts)
-            .addOperation(this.operation)
-            .setTimeout(30)
-            .build();
+    it("throws an error if the server hasn't signed the transaction", function() {
+      const transaction = new StellarSdk.TransactionBuilder(
+        this.txAccount,
+        this.txBuilderOpts,
+      )
+        .addOperation(this.operation)
+        .setTimeout(30)
+        .build();
 
       const threshold = 1;
       const signerSummary = new Map();
@@ -360,64 +423,80 @@ describe('Utils', function() {
       transaction.sign(this.clientKP1);
 
       const challenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      expect(
-        () => StellarSdk.Utils.verifyChallengeTxThreshold(challenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, threshold, signerSummary)
+      expect(() =>
+        StellarSdk.Utils.verifyChallengeTxThreshold(
+          challenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          threshold,
+          signerSummary,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        "Transaction not signed by server: '" + this.serverKP.publicKey() + "'"
+        "Transaction not signed by server: '" + this.serverKP.publicKey() + "'",
       );
     });
 
-    it('successfully validates server and client key meeting threshold', function() {
+    it("successfully validates server and client key meeting threshold", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP1)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP1);
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       const threshold = 1;
       const signerSummary = new Map();
       signerSummary.set(this.clientKP1.publicKey(), 1);
 
       expect(
-        StellarSdk.Utils.verifyChallengeTxThreshold(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, threshold, signerSummary)
-      ).to.eql(
-        [this.clientKP1.publicKey()]
-      );
+        StellarSdk.Utils.verifyChallengeTxThreshold(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          threshold,
+          signerSummary,
+        ),
+      ).to.eql([this.clientKP1.publicKey()]);
     });
 
-    it('successfully validates server and multiple client keys, meeting threshold', function() {
+    it("successfully validates server and multiple client keys, meeting threshold", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP1, this.clientKP2)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP1, this.clientKP2);
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       const threshold = 3;
       const signerSummary = new Map();
@@ -425,29 +504,36 @@ describe('Utils', function() {
       signerSummary.set(this.clientKP2.publicKey(), 2);
 
       expect(
-        StellarSdk.Utils.verifyChallengeTxThreshold(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, threshold, signerSummary)
-      ).to.eql(
-        [this.clientKP1.publicKey(), this.clientKP2.publicKey()]
-      );
+        StellarSdk.Utils.verifyChallengeTxThreshold(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          threshold,
+          signerSummary,
+        ),
+      ).to.eql([this.clientKP1.publicKey(), this.clientKP2.publicKey()]);
     });
 
-    it('successfully validates server and multiple client keys, meeting threshold with more keys than needed', function() {
+    it("successfully validates server and multiple client keys, meeting threshold with more keys than needed", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP1, this.clientKP2)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP1, this.clientKP2);
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       const threshold = 3;
       const signerSummary = new Map();
@@ -456,33 +542,40 @@ describe('Utils', function() {
       signerSummary.set(this.clientKP3.publicKey(), 2);
 
       expect(
-        StellarSdk.Utils.verifyChallengeTxThreshold(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, threshold, signerSummary)
-      ).to.eql(
-        [this.clientKP1.publicKey(), this.clientKP2.publicKey()]
-      );
+        StellarSdk.Utils.verifyChallengeTxThreshold(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          threshold,
+          signerSummary,
+        ),
+      ).to.eql([this.clientKP1.publicKey(), this.clientKP2.publicKey()]);
     });
 
-    it('successfully validates server and multiple client keys, meeting threshold with more keys than needed but ignoring PreauthTxHash and XHash', function() {
+    it("successfully validates server and multiple client keys, meeting threshold with more keys than needed but ignoring PreauthTxHash and XHash", function() {
       const preauthTxHash = "TAQCSRX2RIDJNHFIFHWD63X7D7D6TRT5Y2S6E3TEMXTG5W3OECHZ2OG4";
-	    const xHash = "XDRPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD";
+      const xHash = "XDRPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD";
       const unknownSignerType = "?ARPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD";
-      
+
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP1, this.clientKP2)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP1, this.clientKP2);
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       const threshold = 3;
       const signerSummary = new Map();
@@ -494,29 +587,36 @@ describe('Utils', function() {
       signerSummary.set(unknownSignerType, 10);
 
       expect(
-        StellarSdk.Utils.verifyChallengeTxThreshold(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, threshold, signerSummary)
-      ).to.eql(
-        [this.clientKP1.publicKey(), this.clientKP2.publicKey()]
-      );
+        StellarSdk.Utils.verifyChallengeTxThreshold(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          threshold,
+          signerSummary,
+        ),
+      ).to.eql([this.clientKP1.publicKey(), this.clientKP2.publicKey()]);
     });
 
-    it('throws an error if multiple client keys were not enough to meet the threshold', function() {
+    it("throws an error if multiple client keys were not enough to meet the threshold", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP1, this.clientKP2)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP1, this.clientKP2);
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       const threshold = 10;
       const signerSummary = new Map();
@@ -524,93 +624,117 @@ describe('Utils', function() {
       signerSummary.set(this.clientKP2.publicKey(), 2);
       signerSummary.set(this.clientKP3.publicKey(), 2);
 
-      expect(
-        () => StellarSdk.Utils.verifyChallengeTxThreshold(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, threshold, signerSummary)
+      expect(() =>
+        StellarSdk.Utils.verifyChallengeTxThreshold(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          threshold,
+          signerSummary,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        `signers with weight 3 do not meet threshold ${threshold}"`
+        `signers with weight 3 do not meet threshold ${threshold}"`,
       );
     });
 
-    it('throws an error if an unrecognized (not from the signerSummary) key has signed the transaction', function() {
+    it("throws an error if an unrecognized (not from the signerSummary) key has signed the transaction", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP1, this.clientKP2, this.clientKP3)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP1, this.clientKP2, this.clientKP3);
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       const threshold = 10;
       const signerSummary = new Map();
       signerSummary.set(this.clientKP1.publicKey(), 1);
       signerSummary.set(this.clientKP2.publicKey(), 2);
 
-      expect(
-        () => StellarSdk.Utils.verifyChallengeTxThreshold(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, threshold, signerSummary)
+      expect(() =>
+        StellarSdk.Utils.verifyChallengeTxThreshold(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          threshold,
+          signerSummary,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /Transaction has unrecognized signatures/
+        /Transaction has unrecognized signatures/,
       );
     });
 
-    it('throws an error if the signerSummary is empty', function() {
+    it("throws an error if the signerSummary is empty", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP1, this.clientKP2, this.clientKP3)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP1, this.clientKP2, this.clientKP3);
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       const threshold = 10;
       const signerSummary = new Map();
 
-      expect(
-        () => StellarSdk.Utils.verifyChallengeTxThreshold(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, threshold, signerSummary)
+      expect(() =>
+        StellarSdk.Utils.verifyChallengeTxThreshold(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          threshold,
+          signerSummary,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /No verifiable client signers provided, at least one G... address must be provided/
+        /No verifiable client signers provided, at least one G... address must be provided/,
       );
     });
   });
 
-  describe('Utils.verifyChallengeTxSigners', function() {
+  describe("Utils.verifyChallengeTxSigners", function() {
     beforeEach(function() {
       this.serverKP = StellarSdk.Keypair.random();
       this.clientKP1 = StellarSdk.Keypair.random();
       this.clientKP2 = StellarSdk.Keypair.random();
-      
+
       this.txAccount = new StellarSdk.Account(this.serverKP.publicKey(), "-1");
       this.opAccount = new StellarSdk.Account(this.clientKP1.publicKey(), "0");
 
       this.operation = StellarSdk.Operation.manageData({
         source: this.clientKP1.publicKey(),
-        name: 'SDF-test auth',
-        value: randomBytes(48).toString('base64')
+        name: "SDF-test auth",
+        value: randomBytes(48).toString("base64"),
       });
-      
+
       this.txBuilderOpts = {
         fee: 100,
-        networkPassphrase: StellarSdk.Networks.TESTNET
+        networkPassphrase: StellarSdk.Networks.TESTNET,
       };
     });
 
@@ -618,408 +742,537 @@ describe('Utils', function() {
       this.serverKP, this.clientKP1, this.clientKP2, this.txAccount, this.opAccount, this.operation = null;
     });
 
-    it('successfully validates server and client master key signatures in the transaction', function() {
+    it("successfully validates server and client master key signatures in the transaction", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP1)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP1);
 
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       expect(
-        StellarSdk.Utils.verifyChallengeTxSigners(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, this.clientKP1.publicKey())
-        ).to.eql(
-          [this.clientKP1.publicKey()]
-        );
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          this.clientKP1.publicKey(),
+        ),
+      ).to.eql([this.clientKP1.publicKey()]);
     });
 
-    it('throws an error if the server hasn\'t signed the transaction', function() {
-      const transaction = new StellarSdk.TransactionBuilder(this.txAccount, this.txBuilderOpts)
-            .addOperation(this.operation)
-            .setTimeout(30)
-            .build();
+    it("throws an error if the server hasn't signed the transaction", function() {
+      const transaction = new StellarSdk.TransactionBuilder(
+        this.txAccount,
+        this.txBuilderOpts,
+      )
+        .addOperation(this.operation)
+        .setTimeout(30)
+        .build();
 
-      transaction.sign(StellarSdk.Keypair.random()); // Signing with another key pair instead of the server's 
+      transaction.sign(StellarSdk.Keypair.random()); // Signing with another key pair instead of the server's
 
       const invalidsServerSignedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      expect(
-        () => StellarSdk.Utils.verifyChallengeTxSigners(invalidsServerSignedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, this.clientKP1.publicKey())
+      expect(() =>
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          invalidsServerSignedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          this.clientKP1.publicKey(),
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        "Transaction not signed by server: '" + this.serverKP.publicKey() + "'"
+        "Transaction not signed by server: '" + this.serverKP.publicKey() + "'",
       );
     });
 
-    it('throws an error if there are no clients signing the Tx', function() {
+    it("throws an error if there are no clients signing the Tx", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
 
-      expect(
-        () => StellarSdk.Utils.verifyChallengeTxSigners(challenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET)
+      expect(() =>
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          challenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /No verifiable client signers provided, at least one G... address must be provided/
+        /No verifiable client signers provided, at least one G... address must be provided/,
       );
     });
 
-    it('throws an error if the challenge was signed by an unrecognized client', function() {
+    it("throws an error if the challenge was signed by an unrecognized client", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
       const unrecognizedKP = StellarSdk.Keypair.random();
-      transaction.sign(unrecognizedKP)
+      transaction.sign(unrecognizedKP);
 
-      expect(
-        () => StellarSdk.Utils.verifyChallengeTxSigners(challenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, this.clientKP1.publicKey())
+      expect(() =>
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          challenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          this.clientKP1.publicKey(),
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        "Transaction not signed by client(s): '" + this.clientKP1.publicKey() + "'"
+        "Transaction not signed by client(s): '" +
+          this.clientKP1.publicKey() +
+          "'",
       );
     });
 
-    it('successfully validates server and multiple client signers in the transaction', function() {
+    it("successfully validates server and multiple client signers in the transaction", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      const clientSigners = [this.clientKP1, this.clientKP2]
-      transaction.sign(...clientSigners)
-      const clientSignersPubKey = clientSigners.map((kp) => { return kp.publicKey() });
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      const clientSigners = [this.clientKP1, this.clientKP2];
+      transaction.sign(...clientSigners);
+      const clientSignersPubKey = clientSigners.map((kp) => {
+        return kp.publicKey();
+      });
 
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       expect(
-        StellarSdk.Utils.verifyChallengeTxSigners(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, ...clientSignersPubKey)
-      ).to.eql(
-        clientSignersPubKey
-      );
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          ...clientSignersPubKey,
+        ),
+      ).to.eql(clientSignersPubKey);
     });
 
-    it('successfully validates server and multiple client signers, in reverse order', function() {
+    it("successfully validates server and multiple client signers, in reverse order", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      const clientSigners = [this.clientKP1, this.clientKP2]
-      transaction.sign(...clientSigners.reverse())
-      const clientSignersPubKey = clientSigners.map((kp) => { return kp.publicKey() });
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      const clientSigners = [this.clientKP1, this.clientKP2];
+      transaction.sign(...clientSigners.reverse());
+      const clientSignersPubKey = clientSigners.map((kp) => {
+        return kp.publicKey();
+      });
 
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       expect(
-        StellarSdk.Utils.verifyChallengeTxSigners(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, ...clientSignersPubKey)
-      ).to.have.same.members(
-        clientSignersPubKey.reverse()
-      );
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          ...clientSignersPubKey,
+        ),
+      ).to.have.same.members(clientSignersPubKey.reverse());
     });
 
-    it('successfully validates server and non-masterkey client signer', function() {
+    it("successfully validates server and non-masterkey client signer", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP2)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP2);
 
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       expect(
-        StellarSdk.Utils.verifyChallengeTxSigners(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, this.clientKP2.publicKey())
-      ).to.eql(
-        [this.clientKP2.publicKey()]
-      );
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          this.clientKP2.publicKey(),
+        ),
+      ).to.eql([this.clientKP2.publicKey()]);
     });
 
-    it('successfully validates server and non-masterkey client signer, ignoring extra server signature', function() {
+    it("successfully validates server and non-masterkey client signer, ignoring extra server signature", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP2)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP2);
 
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       expect(
-        StellarSdk.Utils.verifyChallengeTxSigners(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, this.clientKP2.publicKey(), this.serverKP.publicKey())
-      ).to.eql(
-        [this.clientKP2.publicKey()]
-      );
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          this.clientKP2.publicKey(),
+          this.serverKP.publicKey(),
+        ),
+      ).to.eql([this.clientKP2.publicKey()]);
     });
 
-    it('throws an error if no client but insted the server has signed the transaction', function() {
+    it("throws an error if no client but insted the server has signed the transaction", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.serverKP)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.serverKP);
 
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      expect(
-        () => StellarSdk.Utils.verifyChallengeTxSigners(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, this.clientKP2.publicKey(), this.serverKP.publicKey())
+      expect(() =>
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          this.clientKP2.publicKey(),
+          this.serverKP.publicKey(),
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        "Transaction not signed by client(s): '" + this.clientKP2.publicKey() + "'"
+        "Transaction not signed by client(s): '" +
+          this.clientKP2.publicKey() +
+          "'",
       );
     });
 
-    it('successfully validates server and non-masterkey client signer, ignoring duplicated client signers', function() {
+    it("successfully validates server and non-masterkey client signer, ignoring duplicated client signers", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP2)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP2);
 
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       expect(
-        StellarSdk.Utils.verifyChallengeTxSigners(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, this.clientKP2.publicKey(), this.clientKP2.publicKey())
-      ).to.eql(
-        [this.clientKP2.publicKey()]
-      );
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          this.clientKP2.publicKey(),
+          this.clientKP2.publicKey(),
+        ),
+      ).to.eql([this.clientKP2.publicKey()]);
     });
 
-    it('successfully validates server and non-masterkey client signer, ignoring preauthTxHash and xHash', function() {
+    it("successfully validates server and non-masterkey client signer, ignoring preauthTxHash and xHash", function() {
       const preauthTxHash = "TAQCSRX2RIDJNHFIFHWD63X7D7D6TRT5Y2S6E3TEMXTG5W3OECHZ2OG4";
-	    const xHash = "XDRPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD";
-	    const unknownSignerType = "?ARPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD";
+      const xHash = "XDRPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD";
+      const unknownSignerType = "?ARPF6NZRR7EEVO7ESIWUDXHAOMM2QSKIQQBJK6I2FB7YKDZES5UCLWD";
 
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP2)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP2);
 
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
       expect(
-        StellarSdk.Utils.verifyChallengeTxSigners(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, this.clientKP2.publicKey(), preauthTxHash, xHash, unknownSignerType)
-      ).to.eql(
-        [this.clientKP2.publicKey()]
-      );
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          this.clientKP2.publicKey(),
+          preauthTxHash,
+          xHash,
+          unknownSignerType,
+        ),
+      ).to.eql([this.clientKP2.publicKey()]);
     });
 
-    it('throws an error if the signers (duplicated) provided have not signed the actual transaction', function() {
+    it("throws an error if the signers (duplicated) provided have not signed the actual transaction", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP1)
 
-      expect(
-        () => StellarSdk.Utils.verifyChallengeTxSigners(challenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, this.clientKP2.publicKey(), this.clientKP2.publicKey())
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP1);
+
+      expect(() =>
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          challenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          this.clientKP2.publicKey(),
+          this.clientKP2.publicKey(),
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        "Transaction not signed by client(s): '" + this.clientKP2.publicKey() + "'"
+        "Transaction not signed by client(s): '" +
+          this.clientKP2.publicKey() +
+          "'",
       );
     });
 
-    it('throws an error if the same KP has signed the transaction more than once', function() {
+    it("throws an error if the same KP has signed the transaction more than once", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP2, this.clientKP2)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP2, this.clientKP2);
 
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      expect(
-        () => StellarSdk.Utils.verifyChallengeTxSigners(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, this.clientKP2.publicKey())
+      expect(() =>
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          this.clientKP2.publicKey(),
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /Transaction has unrecognized signatures/
+        /Transaction has unrecognized signatures/,
       );
     });
 
-    it('throws an error if the client attempts to verify the transaction with a Seed instead of the Public Key', function() {
+    it("throws an error if the client attempts to verify the transaction with a Seed instead of the Public Key", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP2, this.clientKP2)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP2, this.clientKP2);
 
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      expect(
-        () => StellarSdk.Utils.verifyChallengeTxSigners(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, this.clientKP2.secret())
+      expect(() =>
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          this.clientKP2.secret(),
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /No verifiable client signers provided, at least one G... address must be provided/
+        /No verifiable client signers provided, at least one G... address must be provided/,
       );
     });
 
-    it('throws an error if no client has signed the transaction', function() {
-      const transaction = new StellarSdk.TransactionBuilder(this.txAccount, this.txBuilderOpts)
-            .addOperation(this.operation)
-            .setTimeout(30)
-            .build();
+    it("throws an error if no client has signed the transaction", function() {
+      const transaction = new StellarSdk.TransactionBuilder(
+        this.txAccount,
+        this.txBuilderOpts,
+      )
+        .addOperation(this.operation)
+        .setTimeout(30)
+        .build();
 
-      transaction.sign(this.serverKP)
+      transaction.sign(this.serverKP);
       const challenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      const clientSigners = [this.clientKP1.publicKey(), this.clientKP2.publicKey()]
+      const clientSigners = [
+        this.clientKP1.publicKey(),
+        this.clientKP2.publicKey(),
+      ];
 
-      expect(
-        () => StellarSdk.Utils.verifyChallengeTxSigners(challenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET, ...clientSigners)
+      expect(() =>
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          challenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+          ...clientSigners,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        "Transaction not signed by client(s): '" + clientSigners.join() + "'"
+        "Transaction not signed by client(s): '" + clientSigners.join() + "'",
       );
     });
 
-    it('throws an error if no public keys were provided to verify signatires', function() {
+    it("throws an error if no public keys were provided to verify signatires", function() {
       const challenge = StellarSdk.Utils.buildChallengeTx(
         this.serverKP,
         this.clientKP1.publicKey(),
         "SDF",
         300,
-        StellarSdk.Networks.TESTNET
+        StellarSdk.Networks.TESTNET,
       );
 
       clock.tick(200);
-      
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-      transaction.sign(this.clientKP1)
+
+      const transaction = new StellarSdk.Transaction(
+        challenge,
+        StellarSdk.Networks.TESTNET,
+      );
+      transaction.sign(this.clientKP1);
 
       const signedChallenge = transaction
-            .toEnvelope()
-            .toXDR("base64")
-            .toString();
+        .toEnvelope()
+        .toXDR("base64")
+        .toString();
 
-      expect(
-        () => StellarSdk.Utils.verifyChallengeTxSigners(signedChallenge, this.serverKP.publicKey(), StellarSdk.Networks.TESTNET)
+      expect(() =>
+        StellarSdk.Utils.verifyChallengeTxSigners(
+          signedChallenge,
+          this.serverKP.publicKey(),
+          StellarSdk.Networks.TESTNET,
+        ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
-        /No verifiable client signers provided, at least one G... address must be provided/
+        /No verifiable client signers provided, at least one G... address must be provided/,
       );
     });
   });
@@ -1309,12 +1562,15 @@ describe('Utils', function() {
     });
   });
 
-  describe('Utils.verifyTxMultiSignedBy', function() {
+  describe("Utils.verifyTxMultiSignedBy", function() {
     beforeEach(function() {
       this.keypair1 = StellarSdk.Keypair.random();
       this.keypair2 = StellarSdk.Keypair.random();
       this.account = new StellarSdk.Account(this.keypair1.publicKey(), "-1");
-      this.transaction = new StellarSdk.TransactionBuilder(this.account, txBuilderOpts)
+      this.transaction = new StellarSdk.TransactionBuilder(
+        this.account,
+        txBuilderOpts,
+      )
         .setTimeout(30)
         .build();
     });
@@ -1323,30 +1579,70 @@ describe('Utils', function() {
       this.keypair1, this.keypair2, this.account, this.transaction = null;
     });
 
-    it('returns a list with the signatures used in the transaction', function() {
+    it("returns a list with the signatures used in the transaction", function() {
       this.transaction.sign(this.keypair1, this.keypair2);
 
-      const expectedSignatures = [this.keypair1.publicKey(), this.keypair2.publicKey()]
-      expect(StellarSdk.Utils.verifyTxMultiSignedBy(this.transaction, this.keypair1.publicKey(), this.keypair2.publicKey())).to.eql(expectedSignatures);
+      const expectedSignatures = [
+        this.keypair1.publicKey(),
+        this.keypair2.publicKey(),
+      ];
+      expect(
+        StellarSdk.Utils.verifyTxMultiSignedBy(
+          this.transaction,
+          this.keypair1.publicKey(),
+          this.keypair2.publicKey(),
+        ),
+      ).to.eql(expectedSignatures);
     });
 
-    it('returns a list with the signatures used in the transaction, removing duplicates', function() {
-      this.transaction.sign(this.keypair1, this.keypair1, this.keypair1, this.keypair2, this.keypair2, this.keypair2);
+    it("returns a list with the signatures used in the transaction, removing duplicates", function() {
+      this.transaction.sign(
+        this.keypair1,
+        this.keypair1,
+        this.keypair1,
+        this.keypair2,
+        this.keypair2,
+        this.keypair2,
+      );
 
-      const expectedSignatures = [this.keypair1.publicKey(), this.keypair2.publicKey()]
-      expect(StellarSdk.Utils.verifyTxMultiSignedBy(this.transaction, this.keypair1.publicKey(), this.keypair2.publicKey())).to.eql(expectedSignatures);
+      const expectedSignatures = [
+        this.keypair1.publicKey(),
+        this.keypair2.publicKey(),
+      ];
+      expect(
+        StellarSdk.Utils.verifyTxMultiSignedBy(
+          this.transaction,
+          this.keypair1.publicKey(),
+          this.keypair2.publicKey(),
+        ),
+      ).to.eql(expectedSignatures);
     });
 
-    it('returns an empty list if the transaction was not signed by the given accounts', function() {
+    it("returns an empty list if the transaction was not signed by the given accounts", function() {
       this.transaction.sign(this.keypair1, this.keypair2);
 
-      let wrongSignatures = [StellarSdk.Keypair.random().publicKey(), StellarSdk.Keypair.random().publicKey(), StellarSdk.Keypair.random().publicKey()];
+      let wrongSignatures = [
+        StellarSdk.Keypair.random().publicKey(),
+        StellarSdk.Keypair.random().publicKey(),
+        StellarSdk.Keypair.random().publicKey(),
+      ];
 
-      expect(StellarSdk.Utils.verifyTxMultiSignedBy(this.transaction, ...wrongSignatures)).to.eql([]);
+      expect(
+        StellarSdk.Utils.verifyTxMultiSignedBy(
+          this.transaction,
+          ...wrongSignatures,
+        ),
+      ).to.eql([]);
     });
 
-    it('calling verifyTxMultiSignedBy with an unsigned transaction will return an empty list', function() {
-      expect(StellarSdk.Utils.verifyTxMultiSignedBy(this.transaction, this.keypair1.publicKey(), this.keypair2.publicKey())).to.eql([]);
+    it("calling verifyTxMultiSignedBy with an unsigned transaction will return an empty list", function() {
+      expect(
+        StellarSdk.Utils.verifyTxMultiSignedBy(
+          this.transaction,
+          this.keypair1.publicKey(),
+          this.keypair2.publicKey(),
+        ),
+      ).to.eql([]);
     });
   });
 });

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -769,7 +769,7 @@ describe('Utils', function() {
           signedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          this.clientKP1.publicKey(),
+          [this.clientKP1.publicKey()],
         ),
       ).to.eql([this.clientKP1.publicKey()]);
     });
@@ -795,7 +795,7 @@ describe('Utils', function() {
           invalidsServerSignedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          this.clientKP1.publicKey(),
+          [this.clientKP1.publicKey()],
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
@@ -819,6 +819,7 @@ describe('Utils', function() {
           challenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
+          [],
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
@@ -849,7 +850,7 @@ describe('Utils', function() {
           challenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          this.clientKP1.publicKey(),
+          [this.clientKP1.publicKey()],
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
@@ -890,7 +891,7 @@ describe('Utils', function() {
           signedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          ...clientSignersPubKey,
+          clientSignersPubKey,
         ),
       ).to.eql(clientSignersPubKey);
     });
@@ -926,7 +927,7 @@ describe('Utils', function() {
           signedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          ...clientSignersPubKey,
+          clientSignersPubKey,
         ),
       ).to.have.same.members(clientSignersPubKey.reverse());
     });
@@ -958,7 +959,7 @@ describe('Utils', function() {
           signedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          this.clientKP2.publicKey(),
+          [this.clientKP2.publicKey()],
         ),
       ).to.eql([this.clientKP2.publicKey()]);
     });
@@ -990,8 +991,7 @@ describe('Utils', function() {
           signedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          this.clientKP2.publicKey(),
-          this.serverKP.publicKey(),
+          [this.clientKP2.publicKey(), this.serverKP.publicKey()],
         ),
       ).to.eql([this.clientKP2.publicKey()]);
     });
@@ -1023,8 +1023,7 @@ describe('Utils', function() {
           signedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          this.clientKP2.publicKey(),
-          this.serverKP.publicKey(),
+          [this.clientKP2.publicKey(), this.serverKP.publicKey()],
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
@@ -1061,8 +1060,7 @@ describe('Utils', function() {
           signedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          this.clientKP2.publicKey(),
-          this.clientKP2.publicKey(),
+          [this.clientKP2.publicKey(), this.clientKP2.publicKey()],
         ),
       ).to.eql([this.clientKP2.publicKey()]);
     });
@@ -1098,10 +1096,7 @@ describe('Utils', function() {
           signedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          this.clientKP2.publicKey(),
-          preauthTxHash,
-          xHash,
-          unknownSignerType,
+          [this.clientKP2.publicKey(), preauthTxHash, xHash, unknownSignerType],
         ),
       ).to.eql([this.clientKP2.publicKey()]);
     });
@@ -1128,8 +1123,7 @@ describe('Utils', function() {
           challenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          this.clientKP2.publicKey(),
-          this.clientKP2.publicKey(),
+          [this.clientKP2.publicKey(), this.clientKP2.publicKey()],
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
@@ -1166,7 +1160,7 @@ describe('Utils', function() {
           signedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          this.clientKP2.publicKey(),
+          [this.clientKP2.publicKey()],
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
@@ -1201,7 +1195,7 @@ describe('Utils', function() {
           signedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          this.clientKP2.secret(),
+          [this.clientKP2.secret()],
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
@@ -1234,7 +1228,7 @@ describe('Utils', function() {
           challenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
-          ...clientSigners,
+          clientSigners,
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
@@ -1269,6 +1263,7 @@ describe('Utils', function() {
           signedChallenge,
           this.serverKP.publicKey(),
           StellarSdk.Networks.TESTNET,
+          [],
         ),
       ).to.throw(
         StellarSdk.InvalidSep10ChallengeError,
@@ -1587,11 +1582,10 @@ describe('Utils', function() {
         this.keypair2.publicKey(),
       ];
       expect(
-        StellarSdk.Utils.gatherTxSigners(
-          this.transaction,
+        StellarSdk.Utils.gatherTxSigners(this.transaction, [
           this.keypair1.publicKey(),
           this.keypair2.publicKey(),
-        ),
+        ]),
       ).to.eql(expectedSignatures);
     });
 
@@ -1610,11 +1604,10 @@ describe('Utils', function() {
         this.keypair2.publicKey(),
       ];
       expect(
-        StellarSdk.Utils.gatherTxSigners(
-          this.transaction,
+        StellarSdk.Utils.gatherTxSigners(this.transaction, [
           this.keypair1.publicKey(),
           this.keypair2.publicKey(),
-        ),
+        ]),
       ).to.eql(expectedSignatures);
     });
 
@@ -1628,20 +1621,16 @@ describe('Utils', function() {
       ];
 
       expect(
-        StellarSdk.Utils.gatherTxSigners(
-          this.transaction,
-          ...wrongSignatures,
-        ),
+        StellarSdk.Utils.gatherTxSigners(this.transaction, wrongSignatures),
       ).to.eql([]);
     });
 
     it("calling gatherTxSigners with an unsigned transaction will return an empty list", function() {
       expect(
-        StellarSdk.Utils.gatherTxSigners(
-          this.transaction,
+        StellarSdk.Utils.gatherTxSigners(this.transaction, [
           this.keypair1.publicKey(),
           this.keypair2.publicKey(),
-        ),
+        ]),
       ).to.eql([]);
     });
   });


### PR DESCRIPTION
### Summary
This PR updates the challenge transaction verifiers to accept multiple signatures, according to the issue https://github.com/stellar/js-stellar-sdk/issues/483

### What
Add new challenge transactions helpers to `utils` to support verifying a challenge transaction that has multiple signatures. Three new functions were added and an existent function was deprecated:

- `readChallengeTx`: reads the challenge details to parse the transaction and the client account ID out of the transaction.
- `verifyChallengeTxSigners`: verify that the signers of the transaction are a subset of a list of public keys passes as arguments.
- `verifyChallengeTxThreshold`: verify that the signers of the transaction are a subset of a list of signers that meet a required threshold.
- Deprecate ~~`verifyChallengeTx`~~.

### Why
The [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md) change that was merged in [stellar/stellar-protocol#489](https://github.com/stellar/stellar-protocol/pull/489) clarifies how an implementer should verify that signers of the transaction are signers on the account and that accounts may have multiple signers.

An implementer needs to read out of the transaction the client account before verifying the transaction and then its threshold. For that reason we need three steps: 

1. Read out details we need before verification (`readChallengeTx`)
2. Verify the signatures (`verifyChallengeTxSigners`)
3. Verify if the signatures meet the given threshold (`verifyChallengeTxThreshold`)

The read call also validates the server signature because no challenge transaction would ever be valid to read if it wasn't signed by the server.

_For further info, please refer to the [SEP-10](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md) protocol._