### PR TITLE
Add home_domain to types

### DIFF
--- a/src/account_response.ts
+++ b/src/account_response.ts
@@ -22,7 +22,8 @@ export class AccountResponse {
   public readonly account_id!: string;
   public sequence!: string;
   public readonly subentry_count!: number;
-  public readonly inflation_destination!: string;
+  public readonly home_domain?: string;
+  public readonly inflation_destination?: string;
   public readonly last_modified_ledger!: number;
   public readonly thresholds!: Horizon.AccountThresholds;
   public readonly flags!: Horizon.Flags;


### PR DESCRIPTION
AccountResponse type definition was missing home_domain as an optional property.  It also marked inflation_destination as a non-optional property, but it is in fact optional (see https://github.com/stellar/go/blob/master/protocols/horizon/main.go#L45)

This adds home_domain and makes inflation_destination optional.