### PR TITLE
Fix URI TypeScript reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@types/eventsource": "^1.1.2",
     "@types/node": ">= 8",
     "@types/randombytes": "^2.0.0",
-    "@types/urijs": "^1.19.2",
+    "@types/urijs": "^1.19.6",
     "axios": "^0.19.0",
     "bignumber.js": "^4.0.0",
     "detect-node": "^2.0.4",

--- a/src/account_call_builder.ts
+++ b/src/account_call_builder.ts
@@ -15,7 +15,7 @@ import { ServerApi } from "./server_api";
 export class AccountCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.AccountRecord>
 > {
-  constructor(serverUrl: uri.URI) {
+  constructor(serverUrl: URI) {
     super(serverUrl);
     this.url.segment("accounts");
   }

--- a/src/assets_call_builder.ts
+++ b/src/assets_call_builder.ts
@@ -13,7 +13,7 @@ import { ServerApi } from "./server_api";
 export class AssetsCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.AssetRecord>
 > {
-  constructor(serverUrl: uri.URI) {
+  constructor(serverUrl: URI) {
     super(serverUrl);
     this.url.segment("assets");
   }

--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -47,11 +47,11 @@ export class CallBuilder<
     | Horizon.BaseResponse
     | ServerApi.CollectionPage<Horizon.BaseResponse>
 > {
-  protected url: uri.URI;
+  protected url: URI;
   public filter: string[][];
   protected originalSegments: string[];
 
-  constructor(serverUrl: uri.URI) {
+  constructor(serverUrl: URI) {
     this.url = serverUrl.clone();
     this.filter = [];
     this.originalSegments = this.url.segment() || [];
@@ -301,7 +301,7 @@ export class CallBuilder<
     return json;
   }
 
-  private async _sendNormalRequest(initialUrl: uri.URI) {
+  private async _sendNormalRequest(initialUrl: URI) {
     let url = initialUrl;
 
     if (url.authority() === "") {

--- a/src/effect_call_builder.ts
+++ b/src/effect_call_builder.ts
@@ -14,7 +14,7 @@ import { ServerApi } from "./server_api";
 export class EffectCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.EffectRecord>
 > {
-  constructor(serverUrl: uri.URI) {
+  constructor(serverUrl: URI) {
     super(serverUrl);
     this.url.segment("effects");
   }

--- a/src/federation_server.ts
+++ b/src/federation_server.ts
@@ -27,7 +27,7 @@ export class FederationServer {
    *
    * @memberof FederationServer
    */
-  private readonly serverURL: uri.URI; // TODO: public or private? readonly?
+  private readonly serverURL: URI; // TODO: public or private? readonly?
   /**
    * Domain this server represents.
    *
@@ -210,7 +210,7 @@ export class FederationServer {
     return this._sendRequest(url);
   }
 
-  private async _sendRequest(url: uri.URI) {
+  private async _sendRequest(url: URI) {
     const timeout = this.timeout;
 
     return axios

--- a/src/friendbot_builder.ts
+++ b/src/friendbot_builder.ts
@@ -1,7 +1,7 @@
 import { CallBuilder } from "./call_builder";
 
 export class FriendbotBuilder extends CallBuilder<any> {
-  constructor(serverUrl: uri.URI, address: string) {
+  constructor(serverUrl: URI, address: string) {
     super(serverUrl);
     this.url.segment("friendbot");
     this.url.setQuery("addr", address);

--- a/src/ledger_call_builder.ts
+++ b/src/ledger_call_builder.ts
@@ -14,7 +14,7 @@ import { ServerApi } from "./server_api";
 export class LedgerCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.LedgerRecord>
 > {
-  constructor(serverUrl: uri.URI) {
+  constructor(serverUrl: URI) {
     super(serverUrl);
     this.url.segment("ledgers");
   }

--- a/src/offer_call_builder.ts
+++ b/src/offer_call_builder.ts
@@ -15,7 +15,7 @@ import { ServerApi } from "./server_api";
 export class OfferCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.OfferRecord>
 > {
-  constructor(serverUrl: uri.URI) {
+  constructor(serverUrl: URI) {
     super(serverUrl);
     this.url.segment("offers");
   }

--- a/src/operation_call_builder.ts
+++ b/src/operation_call_builder.ts
@@ -14,7 +14,7 @@ import { ServerApi } from "./server_api";
 export class OperationCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.OperationRecord>
 > {
-  constructor(serverUrl: uri.URI) {
+  constructor(serverUrl: URI) {
     super(serverUrl);
     this.url.segment("operations");
   }

--- a/src/orderbook_call_builder.ts
+++ b/src/orderbook_call_builder.ts
@@ -14,7 +14,7 @@ import { ServerApi } from "./server_api";
 export class OrderbookCallBuilder extends CallBuilder<
   ServerApi.OrderbookRecord
 > {
-  constructor(serverUrl: uri.URI, selling: Asset, buying: Asset) {
+  constructor(serverUrl: URI, selling: Asset, buying: Asset) {
     super(serverUrl);
     this.url.segment("order_book");
     if (!selling.isNative()) {

--- a/src/path_call_builder.ts
+++ b/src/path_call_builder.ts
@@ -30,7 +30,7 @@ export class PathCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.PaymentPathRecord>
 > {
   constructor(
-    serverUrl: uri.URI,
+    serverUrl: URI,
     source: string,
     destination: string,
     destinationAsset: Asset,

--- a/src/payment_call_builder.ts
+++ b/src/payment_call_builder.ts
@@ -13,7 +13,7 @@ import { ServerApi } from "./server_api";
 export class PaymentCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.PaymentOperationRecord>
 > {
-  constructor(serverUrl: uri.URI) {
+  constructor(serverUrl: URI) {
     super(serverUrl);
     this.url.segment("payments");
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,7 +56,7 @@ export class Server {
    *
    * TODO: Solve `URI(this.serverURL as any)`.
    */
-  public readonly serverURL: uri.URI;
+  public readonly serverURL: URI;
 
   constructor(serverURL: string, opts: Server.Options = {}) {
     this.serverURL = URI(serverURL);

--- a/src/strict_receive_path_call_builder.ts
+++ b/src/strict_receive_path_call_builder.ts
@@ -33,7 +33,7 @@ export class StrictReceivePathCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.PaymentPathRecord>
 > {
   constructor(
-    serverUrl: uri.URI,
+    serverUrl: URI,
     source: string | Asset[],
     destinationAsset: Asset,
     destinationAmount: string,

--- a/src/strict_send_path_call_builder.ts
+++ b/src/strict_send_path_call_builder.ts
@@ -33,7 +33,7 @@ export class StrictSendPathCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.PaymentPathRecord>
 > {
   constructor(
-    serverUrl: uri.URI,
+    serverUrl: URI,
     sourceAsset: Asset,
     sourceAmount: string,
     destination: string | Asset[],

--- a/src/trade_aggregation_call_builder.ts
+++ b/src/trade_aggregation_call_builder.ts
@@ -33,7 +33,7 @@ export class TradeAggregationCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<TradeAggregationRecord>
 > {
   constructor(
-    serverUrl: uri.URI,
+    serverUrl: URI,
     base: Asset,
     counter: Asset,
     start_time: number,

--- a/src/trades_call_builder.ts
+++ b/src/trades_call_builder.ts
@@ -15,7 +15,7 @@ import { ServerApi } from "./server_api";
 export class TradesCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.TradeRecord>
 > {
-  constructor(serverUrl: uri.URI) {
+  constructor(serverUrl: URI) {
     super(serverUrl);
     this.url.segment("trades");
   }

--- a/src/transaction_call_builder.ts
+++ b/src/transaction_call_builder.ts
@@ -14,7 +14,7 @@ import { ServerApi } from "./server_api";
 export class TransactionCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.TransactionRecord>
 > {
-  constructor(serverUrl: uri.URI) {
+  constructor(serverUrl: URI) {
     super(serverUrl);
     this.url.segment("transactions");
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,10 +197,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/urijs@^1.19.2":
-  version "1.19.5"
-  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.5.tgz#f2083392f5859be59cbba0b1d463b922c8aef842"
-  integrity sha512-LAyzQkr9rZDoHrv8xRcHStLo8Z4PbP3ZHMqw8WRr1T7Jn4O1z13Qkv+ed9e12pBXWaaqsBj1l4ADU/FlA/jn3w==
+"@types/urijs@^1.19.6":
+  version "1.19.6"
+  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.6.tgz#4cee39e4e5ad8d276d617d159ffcb423ca2fd9f1"
+  integrity sha512-kdnK+JtEiUgnpB7r99SAZjjz9nhZ/7MWo/hxTSNfvslAa4r8jpDXDEJ2cQrjemes4eX2Y5Om3udmcc8QalPzOA==
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"


### PR DESCRIPTION
It appears `@types/urijs` released a breaking change in the typings changing the `uri` namespace that will break the TypeScript builds.