### PR TITLE
README: Update URL of Stellar logo image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<img alt="Stellar" src="https://assets-global.website-files.com/5deac75ecad2173c2ccccbc7/5dec8960504967fd31147f62_Stellar_lockup_black_RGB.svg" width="558" />
+<img alt="Stellar" src="https://github.com/stellar/.github/raw/master/stellar-logo.png" width="558" />
 <br/>
 <strong>Creating equitable access to the global financial system</strong>
 <h1>js-stellar-sdk</h1>


### PR DESCRIPTION
### What
Update the URL for the Stellar logo image displayed at the top of the
README.

### Why
A new version of the stellar.org website was deployed and the image we
were using is no longer available there. In stellar/js-stellar-sdk#496
@tyvdh fixed the broken link. In stellar/.github#9 we added the logo to
a GitHub repository so that we could reference it from one location that
won't be affected by website changes that is easily accessible by any
dev. Other repositories (stellar/stellar-protocol#569,
stellar/stellar-core#2459, stellar/go#2363) are going to use the image
from that central location and we should update this README to use the
same one too.