### PR TITLE
Add SEP0029 memo required check.

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -67,6 +67,15 @@ export class InvalidSep10ChallengeError extends Error {
   }
 }
 
+/**
+ * AccountRequiresMemoError is raised when a transaction is trying to submit a
+ * payment like operation to an account which requires a memo. See
+ * [SEP0029](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0029.md)
+ * for more information.
+ * @class AccountRequiresMemoError
+ * @hideconstructor
+ *
+ */
 export class AccountRequiresMemoError extends Error {
   public __proto__: AccountRequiresMemoError;
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -66,3 +66,15 @@ export class InvalidSep10ChallengeError extends Error {
     this.name = "InvalidSep10ChallengeError";
   }
 }
+
+export class AccountRequiresMemoError extends Error {
+  public __proto__: AccountRequiresMemoError;
+
+  constructor(message: string) {
+    const trueProto = new.target.prototype;
+    super(message);
+    this.__proto__ = trueProto;
+    this.constructor = AccountRequiresMemoError;
+    this.name = "AccountRequiresMemoError";
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -68,8 +68,8 @@ export class InvalidSep10ChallengeError extends Error {
 }
 
 /**
- * AccountRequiresMemoError is raised when a transaction is trying to submit a
- * payment like operation to an account which requires a memo. See
+ * AccountRequiresMemoError is raised when a transaction is trying to submit an
+ * operation to an account which requires a memo. See
  * [SEP0029](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0029.md)
  * for more information.
  * @class AccountRequiresMemoError
@@ -78,12 +78,16 @@ export class InvalidSep10ChallengeError extends Error {
  */
 export class AccountRequiresMemoError extends Error {
   public __proto__: AccountRequiresMemoError;
+  public accountId: string;
+  public operationIndex: number;
 
-  constructor(message: string) {
+  constructor(message: string, accountId: string, operationIndex: number) {
     const trueProto = new.target.prototype;
     super(message);
     this.__proto__ = trueProto;
     this.constructor = AccountRequiresMemoError;
     this.name = "AccountRequiresMemoError";
+    this.accountId = accountId;
+    this.operationIndex = operationIndex;
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -72,15 +72,33 @@ export class InvalidSep10ChallengeError extends Error {
  * operation to an account which requires a memo. See
  * [SEP0029](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0029.md)
  * for more information.
- * @class AccountRequiresMemoError
- * @hideconstructor
+ *
+ * This error contains two attributes to help you identify the account requiring
+ * the memo and the operation where the account is the destination
+ *
+ * ```
+ * console.log('The following account requires a memo ', err.accountId)
+ * console.log('The account is used in operation: ', err.operationIndex)
+ * ```
  *
  */
 export class AccountRequiresMemoError extends Error {
   public __proto__: AccountRequiresMemoError;
+  /**
+   * accountId account which requires a memo.
+   */
   public accountId: string;
+  /**
+   * operationIndex operation where accountId is the destination.
+   */
   public operationIndex: number;
 
+  /**
+   * Create an AccountRequiresMemoError
+   * @param {message} message - error message
+   * @param {string} accountId - The account which requires a memo.
+   * @param {number} operationIndex - The index of the operation where `accountId` is the destination.
+   */
   constructor(message: string, accountId: string, operationIndex: number) {
     const trueProto = new.target.prototype;
     super(message);

--- a/src/server.ts
+++ b/src/server.ts
@@ -271,11 +271,18 @@ export class Server {
    *
    * @see [Post Transaction](https://www.stellar.org/developers/horizon/reference/endpoints/transactions-create.html)
    * @param {Transaction} transaction - The transaction to submit.
+   * @param {Server.SubmitTransactionOptions} options.
    * @returns {Promise} Promise that resolves or rejects with response from horizon.
    */
   public async submitTransaction(
     transaction: Transaction,
+    opts: Server.SubmitTransactionOptions = { skipMemoRequiredCheck: false },
   ): Promise<Horizon.SubmitTransactionResponse> {
+    // only check for memo required if skipMemoRequiredCheck is false and the transaction doesn't include a memo.
+    if (!opts.skipMemoRequiredCheck && transaction.memo.type === "none") {
+      await this.checkMemoRequired(transaction);
+    }
+
     const tx = encodeURIComponent(
       transaction
         .toEnvelope()
@@ -776,5 +783,9 @@ export namespace Server {
   export interface Timebounds {
     minTime: number;
     maxTime: number;
+  }
+
+  export interface SubmitTransactionOptions {
+    skipMemoRequiredCheck?: boolean;
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -766,7 +766,11 @@ export class Server {
         if (
           account.data_attr["config.memo_required"] === ACCOUNT_REQUIRES_MEMO
         ) {
-          throw new AccountRequiresMemoError(`operation[${i}]`);
+          throw new AccountRequiresMemoError(
+            "account requires memo",
+            destination,
+            i,
+          );
         }
       } catch (e) {
         if (e instanceof AccountRequiresMemoError) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -733,6 +733,9 @@ export class Server {
    * It will load each account which is the destination and check if it has the
    * data field `config.memo_required` set to `"MQ=="`.
    *
+   * Each account is checked sequentially instead of loading multiple accounts
+   * at the same time from Horizon.
+   *
    * @see
    * [SEP0029](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0029.md)
    * @param {Transaction} transaction - The transaction to check.

--- a/src/server.ts
+++ b/src/server.ts
@@ -288,7 +288,7 @@ export class Server {
     opts: Server.SubmitTransactionOptions = { skipMemoRequiredCheck: false },
   ): Promise<Horizon.SubmitTransactionResponse> {
     // only check for memo required if skipMemoRequiredCheck is false and the transaction doesn't include a memo.
-    if (!opts.skipMemoRequiredCheck && transaction.memo.type === "none") {
+    if (!opts.skipMemoRequiredCheck) {
       await this.checkMemoRequired(transaction);
     }
 
@@ -741,6 +741,10 @@ export class Server {
    * @throws  {AccountRequiresMemoError}
    */
   public async checkMemoRequired(transaction: Transaction): Promise<void> {
+    if (transaction.memo.type !== "none") {
+      return;
+    }
+
     const destinations = new Set<string>();
 
     for (let i = 0; i < transaction.operations.length; i++) {

--- a/test/unit/horizon_path_test.js
+++ b/test/unit/horizon_path_test.js
@@ -142,7 +142,7 @@ describe('horizon path tests', function() {
         .returns(Promise.resolve(randomResult));
 
       server
-        .submitTransaction(fakeTransaction)
+        .submitTransaction(fakeTransaction, {skipMemoRequiredCheck: true})
         .should.eventually.deep.equal(randomResult.data)
         .notify(done);
     });

--- a/test/unit/server_check_memo_required_test.js
+++ b/test/unit/server_check_memo_required_test.js
@@ -1,10 +1,12 @@
-function buildTransaction(destination, operations = []) {
-  let keypair = StellarSdk.Keypair.random();
-  let account = new StellarSdk.Account(keypair.publicKey(), "56199647068161");
-  let transaction = new StellarSdk.TransactionBuilder(account, {
+function buildTransaction(destination, operations = [], builderOpts = {}) {
+  let txBuilderOpts = {
     fee: 100,
     networkPassphrase: StellarSdk.Networks.TESTNET
-  })
+  };
+  Object.assign(txBuilderOpts, builderOpts);
+  let keypair = StellarSdk.Keypair.random();
+  let account = new StellarSdk.Account(keypair.publicKey(), "56199647068161");
+  let transaction = new StellarSdk.TransactionBuilder(account, txBuilderOpts)
     .addOperation(
       StellarSdk.Operation.payment({
         destination: destination,
@@ -246,6 +248,17 @@ describe("server.js check-memo-required", function() {
           done(err);
         });
     });
-
-  });
-  
+    it('checks for memo required by default', function(done) {
+      let accountId = "GAYHAAKPAQLMGIJYMIWPDWCGUCQ5LAWY4Q7Q3IKSP57O7GUPD3NEOSEA";
+      let memo = StellarSdk.Memo.text('42');
+      let transaction = buildTransaction(accountId, [], { memo });
+      this.server
+        .checkMemoRequired(transaction)
+        .then(function() {
+          done();
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
+});

--- a/test/unit/server_check_memo_required_test.js
+++ b/test/unit/server_check_memo_required_test.js
@@ -106,7 +106,7 @@ describe("server.js check-memo-required", function() {
     it("fails if memo is required", function(done) {
       let accountId = "GAYHAAKPAQLMGIJYMIWPDWCGUCQ5LAWY4Q7Q3IKSP57O7GUPD3NEOSEA";
       mockAccountRequest(this.axiosMock, accountId, 200, { "config.memo_required": "MQ==" });
-      let transaction = buildTransaction("GAYHAAKPAQLMGIJYMIWPDWCGUCQ5LAWY4Q7Q3IKSP57O7GUPD3NEOSEA");
+      let transaction = buildTransaction(accountId);
 
       this.server
         .checkMemoRequired(transaction)
@@ -114,7 +114,8 @@ describe("server.js check-memo-required", function() {
           expect.fail("promise should have failed");
         }, function(err) {
           expect(err).to.be.instanceOf(StellarSdk.AccountRequiresMemoError);
-          expect(err.toString()).to.eq("AccountRequiresMemoError: operation[0]");
+          expect(err.accountId).to.eq(accountId);
+          expect(err.operationIndex).to.eq(0);
           done();
         })
         .catch(function(err) {
@@ -129,8 +130,7 @@ describe("server.js check-memo-required", function() {
 
       this.server
         .checkMemoRequired(transaction)
-        .then(function(memoRequired) {
-          expect(memoRequired).to.be.false
+        .then(function() {
           done();
         })
         .catch(function(err) {
@@ -145,8 +145,7 @@ describe("server.js check-memo-required", function() {
 
       this.server
         .checkMemoRequired(transaction)
-        .then(function(memoRequired) {
-          expect(memoRequired).to.be.false
+        .then(function() {
           done();
         })
         .catch(function(err) {
@@ -188,8 +187,7 @@ describe("server.js check-memo-required", function() {
       
       this.server
         .checkMemoRequired(transaction)
-        .then(function(memoRequired) {
-          expect(memoRequired).to.be.false
+        .then(function() {
           done();
         })
         .catch(function(err) {
@@ -241,8 +239,7 @@ describe("server.js check-memo-required", function() {
       
       this.server
         .checkMemoRequired(transaction)
-        .then(function(memoRequired) {
-          expect(memoRequired).to.be.false
+        .then(function() {
           done();
         })
         .catch(function(err) {

--- a/test/unit/server_check_memo_required_test.js
+++ b/test/unit/server_check_memo_required_test.js
@@ -1,0 +1,254 @@
+function buildTransaction(destination, operations = []) {
+  let keypair = StellarSdk.Keypair.random();
+  let account = new StellarSdk.Account(keypair.publicKey(), "56199647068161");
+  let transaction = new StellarSdk.TransactionBuilder(account, {
+    fee: 100,
+    networkPassphrase: StellarSdk.Networks.TESTNET
+  })
+    .addOperation(
+      StellarSdk.Operation.payment({
+        destination: destination,
+        asset: StellarSdk.Asset.native(),
+        amount: "100.50"
+      })
+    )
+
+  operations.forEach(op => transaction = transaction.addOperation(op))
+  
+  transaction = transaction.
+    setTimeout(StellarSdk.TimeoutInfinite)
+    .build();
+  transaction.sign(keypair);
+
+  return transaction;
+}
+
+function buildAccount(id, data = {}) {
+  return {
+    "_links": {
+      "data": {
+        "href": `https://horizon-testnet.stellar.org/accounts/${id}/data/{key}`,
+        "templated": true
+      }
+    },
+    "id": id,
+    "account_id": id,
+    "sequence": "3298702387052545",
+    "subentry_count": 1,
+    "last_modified_ledger": 768061,
+    "thresholds": {
+      "low_threshold": 0,
+      "med_threshold": 0,
+      "high_threshold": 0
+    },
+    "flags": {
+      "auth_required": false,
+      "auth_revocable": false,
+      "auth_immutable": false
+    },
+    "balances": [
+      {
+        "balance": "9999.9999900",
+        "buying_liabilities": "0.0000000",
+        "selling_liabilities": "0.0000000",
+        "asset_type": "native"
+      }
+    ],
+    "signers": [
+      {
+        "weight": 1,
+        "key": id,
+        "type": "ed25519_public_key"
+      }
+    ],
+    "data": data
+  };
+}
+
+function mockAccountRequest(axiosMock, id, status, data = {}) {
+  let response;
+
+  switch (status) {
+    case 404:
+      response = Promise.reject({ response: { status: 404, statusText: "NotFound", data: {} } });
+      break;
+    case 400:
+      response = Promise.reject({ response: { status: 400, statusText: "BadRequestError", data: {} } });
+      break;
+    default:
+      response = Promise.resolve({data: buildAccount(id, data)});
+      break;
+  }
+
+  axiosMock.expects("get") 
+    .withArgs(
+      sinon.match(
+        `https://horizon-testnet.stellar.org/accounts/${id}`
+      )
+    )
+    .returns(response)
+    .once();
+}
+
+describe("server.js check-memo-required", function() {    
+    beforeEach(function() {
+      this.server = new StellarSdk.Server(
+        "https://horizon-testnet.stellar.org"
+      );
+      this.axiosMock = sinon.mock(HorizonAxiosClient);
+    });
+  
+    afterEach(function() {
+      this.axiosMock.verify();
+      this.axiosMock.restore();
+    });
+    
+    it("fails if memo is required", function(done) {
+      let accountId = "GAYHAAKPAQLMGIJYMIWPDWCGUCQ5LAWY4Q7Q3IKSP57O7GUPD3NEOSEA";
+      mockAccountRequest(this.axiosMock, accountId, 200, { "config.memo_required": "MQ==" });
+      let transaction = buildTransaction("GAYHAAKPAQLMGIJYMIWPDWCGUCQ5LAWY4Q7Q3IKSP57O7GUPD3NEOSEA");
+
+      this.server
+        .checkMemoRequired(transaction)
+        .then(function() {
+          expect.fail("promise should have failed");
+        }, function(err) {
+          expect(err).to.be.instanceOf(StellarSdk.AccountRequiresMemoError);
+          expect(err.toString()).to.eq("AccountRequiresMemoError: operation[0]");
+          done();
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
+
+    it("returns false if account doesn't exist", function(done) {
+      let accountId = "GAYHAAKPAQLMGIJYMIWPDWCGUCQ5LAWY4Q7Q3IKSP57O7GUPD3NEOSEA";
+      mockAccountRequest(this.axiosMock, accountId, 404, {});
+      let transaction = buildTransaction(accountId);
+
+      this.server
+        .checkMemoRequired(transaction)
+        .then(function(memoRequired) {
+          expect(memoRequired).to.be.false
+          done();
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
+
+    it("returns false if data field is not present", function(done) {
+      let accountId = "GAYHAAKPAQLMGIJYMIWPDWCGUCQ5LAWY4Q7Q3IKSP57O7GUPD3NEOSEA";
+      mockAccountRequest(this.axiosMock, accountId, 200, {});
+      let transaction = buildTransaction(accountId);
+
+      this.server
+        .checkMemoRequired(transaction)
+        .then(function(memoRequired) {
+          expect(memoRequired).to.be.false
+          done();
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
+
+    it("returns err with client errors", function(done) {
+      let accountId = "GAYHAAKPAQLMGIJYMIWPDWCGUCQ5LAWY4Q7Q3IKSP57O7GUPD3NEOSEA";
+      mockAccountRequest(this.axiosMock, accountId, 400, {});
+      let transaction = buildTransaction(accountId);
+
+      this.server
+        .checkMemoRequired(transaction)
+        .then(function() {
+          expect.fail("promise should have failed");
+        }, function(err) {
+          expect(err).to.be.instanceOf(StellarSdk.NetworkError);
+          done();
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
+
+    it("doesn't repeat account check if the destination is more than once", function(done) {
+      let accountId = "GAYHAAKPAQLMGIJYMIWPDWCGUCQ5LAWY4Q7Q3IKSP57O7GUPD3NEOSEA";
+      mockAccountRequest(this.axiosMock, accountId, 200, {});
+
+      let operations = [
+        StellarSdk.Operation.payment({
+          destination: accountId,
+          asset: StellarSdk.Asset.native(),
+          amount: "100.50"
+        })
+      ];
+      
+      let transaction = buildTransaction(accountId, operations);
+      
+      this.server
+        .checkMemoRequired(transaction)
+        .then(function(memoRequired) {
+          expect(memoRequired).to.be.false
+          done();
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
+
+    it("other operations", function(done) {
+      let accountId = "GAYHAAKPAQLMGIJYMIWPDWCGUCQ5LAWY4Q7Q3IKSP57O7GUPD3NEOSEA";
+      mockAccountRequest(this.axiosMock, accountId, 200, {});
+
+      const destinations = [
+        "GASGNGGXDNJE5C2O7LDCATIVYSSTZKB24SHYS6F4RQT4M4IGNYXB4TIV",
+        "GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB",
+        "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ"
+      ];
+
+      const usd = new StellarSdk.Asset("USD", "GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB");
+      const eur = new StellarSdk.Asset("EUR", "GDTNXRLOJD2YEBPKK7KCMR7J33AAG5VZXHAJTHIG736D6LVEFLLLKPDL");
+
+      let operations = [
+        StellarSdk.Operation.accountMerge({ 
+          destination: destinations[0]
+        }),
+        StellarSdk.Operation.pathPaymentStrictReceive({
+          sendAsset: StellarSdk.Asset.native(),
+          sendMax: "5.0000000",
+          destination: destinations[1],
+          destAsset: StellarSdk.Asset.native(),
+          destAmount: "5.50",
+          path: [usd, eur]
+        }),
+        StellarSdk.Operation.pathPaymentStrictSend({
+          sendAsset: StellarSdk.Asset.native(),
+          sendAmount: "5.0000000",
+          destination: destinations[2],
+          destAsset: StellarSdk.Asset.native(),
+          destMin: "5.50",
+          path: [usd,eur]
+        }),
+        StellarSdk.Operation.changeTrust({ 
+          asset: usd
+        })
+      ];
+
+      destinations.forEach(d => mockAccountRequest(this.axiosMock, d, 200, {}))
+      
+      let transaction = buildTransaction(accountId, operations);
+      
+      this.server
+        .checkMemoRequired(transaction)
+        .then(function(memoRequired) {
+          expect(memoRequired).to.be.false
+          done();
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
+
+  });
+  

--- a/test/unit/server_transaction_test.js
+++ b/test/unit/server_transaction_test.js
@@ -351,38 +351,4 @@ describe('server.js transaction tests', function() {
         done(err);
       });
   });
-  it('skips memo required if the transaction has a memo', function(done) {
-    this.axiosMock
-      .expects('post')
-      .withArgs(
-        'https://horizon-live.stellar.org:1337/transactions'
-      )
-      .returns(Promise.resolve({ data: {} }));
-
-    let memo = StellarSdk.Memo.text('42');
-    let transaction = new StellarSdk.TransactionBuilder(account, {
-      memo,
-      fee: 100,
-      networkPassphrase: StellarSdk.Networks.TESTNET
-    })
-      .addOperation(
-        StellarSdk.Operation.payment({
-          destination:
-            'GASOCNHNNLYFNMDJYQ3XFMI7BYHIOCFW3GJEOWRPEGK2TDPGTG2E5EDW',
-          asset: StellarSdk.Asset.native(),
-          amount: '100.50'
-        })
-      )
-      .setTimeout(StellarSdk.TimeoutInfinite)
-      .build();
-
-    this.server
-      .submitTransaction(transaction)
-      .then(function() {
-        done();
-      })
-      .catch(function(err) {
-        done(err);
-      });
-  });
 });

--- a/test/unit/server_transaction_test.js
+++ b/test/unit/server_transaction_test.js
@@ -351,7 +351,7 @@ describe('server.js transaction tests', function() {
         done(err);
       });
   });
-  it('skips memo required is the transaction has a memo', function(done) {
+  it('skips memo required if the transaction has a memo', function(done) {
     this.axiosMock
       .expects('post')
       .withArgs(

--- a/test/unit/server_transaction_test.js
+++ b/test/unit/server_transaction_test.js
@@ -1,12 +1,12 @@
 describe('server.js transaction tests', function() {
+  let keypair = StellarSdk.Keypair.random();
+  let account = new StellarSdk.Account(keypair.publicKey(), '56199647068161');
+  
   beforeEach(function() {
     this.server = new StellarSdk.Server(
       'https://horizon-live.stellar.org:1337'
     );
     this.axiosMock = sinon.mock(HorizonAxiosClient);
-    StellarSdk.Config.setDefault();
-    let keypair = StellarSdk.Keypair.random();
-    let account = new StellarSdk.Account(keypair.publicKey(), '56199647068161');
     let transaction = new StellarSdk.TransactionBuilder(account, {
       fee: 100,
       networkPassphrase: StellarSdk.Networks.TESTNET
@@ -36,6 +36,7 @@ describe('server.js transaction tests', function() {
     this.axiosMock.verify();
     this.axiosMock.restore();
   });
+  
   it('sends a transaction', function(done) {
     this.axiosMock
       .expects('post')
@@ -46,7 +47,7 @@ describe('server.js transaction tests', function() {
       .returns(Promise.resolve({ data: {} }));
 
     this.server
-      .submitTransaction(this.transaction)
+      .submitTransaction(this.transaction, {skipMemoRequiredCheck: true})
       .then(function() {
         done();
       })
@@ -80,7 +81,7 @@ describe('server.js transaction tests', function() {
       .returns(Promise.resolve({ data: response }));
 
     this.server
-      .submitTransaction(this.transaction)
+      .submitTransaction(this.transaction, {skipMemoRequiredCheck: true})
       .then(function(res) {
         expect(res.offerResults).to.be.an.instanceOf(Array);
         expect(res.offerResults[0].offersClaimed).to.be.an.instanceOf(Array);
@@ -127,7 +128,7 @@ describe('server.js transaction tests', function() {
       .returns(Promise.resolve({ data: response }));
 
     this.server
-      .submitTransaction(this.transaction)
+      .submitTransaction(this.transaction, {skipMemoRequiredCheck: true})
       .then(function(res) {
         expect(res.offerResults).to.be.an.instanceOf(Array);
         expect(res.offerResults[0].offersClaimed).to.be.an.instanceOf(Array);
@@ -172,7 +173,7 @@ describe('server.js transaction tests', function() {
       .returns(Promise.resolve({ data: response }));
 
     this.server
-      .submitTransaction(this.transaction)
+      .submitTransaction(this.transaction, {skipMemoRequiredCheck: true})
       .then(function(res) {
         expect(res.offerResults).to.be.an.instanceOf(Array);
         expect(res.offerResults[0].offersClaimed).to.be.an.instanceOf(Array);
@@ -217,7 +218,7 @@ describe('server.js transaction tests', function() {
       .returns(Promise.resolve({ data: response }));
 
     this.server
-      .submitTransaction(this.transaction)
+      .submitTransaction(this.transaction, {skipMemoRequiredCheck: true})
       .then(function(res) {
         expect(res.offerResults).to.be.an.instanceOf(Array);
         expect(res.offerResults[0].offersClaimed).to.be.an.instanceOf(Array);
@@ -272,7 +273,7 @@ describe('server.js transaction tests', function() {
       .returns(Promise.resolve({ data: response }));
 
     this.server
-      .submitTransaction(this.transaction)
+      .submitTransaction(this.transaction, {skipMemoRequiredCheck: true})
       .then(function(res) {
         expect(res.offerResults).to.be.undefined;
         done();
@@ -308,7 +309,7 @@ describe('server.js transaction tests', function() {
       .returns(Promise.resolve({ data: response }));
 
     this.server
-      .submitTransaction(this.transaction)
+      .submitTransaction(this.transaction, {skipMemoRequiredCheck: true})
       .then(function(res) {
         expect(res.offerResults).to.be.an.instanceOf(Array);
         expect(res.offerResults).to.have.lengthOf(2);
@@ -318,6 +319,66 @@ describe('server.js transaction tests', function() {
         expect(res.offerResults[1].offersClaimed).to.be.an.instanceOf(Array);
         expect(typeof res.offerResults[1].effect).to.equal('string');
         expect(res.offerResults[1].operationIndex).to.equal(3);
+        done();
+      })
+      .catch(function(err) {
+        done(err);
+      });
+  });
+  it('checks for memo required by default', function(done) {
+    this.axiosMock
+      .expects('post')
+      .withArgs(
+        'https://horizon-live.stellar.org:1337/transactions',
+        `tx=${this.blob}`
+      )
+      .returns(Promise.resolve({ data: {} }));
+    this.axiosMock.expects("get") 
+      .withArgs(
+        sinon.match(
+          'https://horizon-live.stellar.org:1337/accounts/GASOCNHNNLYFNMDJYQ3XFMI7BYHIOCFW3GJEOWRPEGK2TDPGTG2E5EDW'
+        )
+      )
+      .returns(Promise.reject({ response: { status: 404, statusText: "NotFound", data: {} } }))
+      .once();
+
+    this.server
+      .submitTransaction(this.transaction, {skipMemoRequiredCheck: false})
+      .then(function() {
+        done();
+      })
+      .catch(function(err) {
+        done(err);
+      });
+  });
+  it('skips memo required is the transaction has a memo', function(done) {
+    this.axiosMock
+      .expects('post')
+      .withArgs(
+        'https://horizon-live.stellar.org:1337/transactions'
+      )
+      .returns(Promise.resolve({ data: {} }));
+
+    let memo = StellarSdk.Memo.text('42');
+    let transaction = new StellarSdk.TransactionBuilder(account, {
+      memo,
+      fee: 100,
+      networkPassphrase: StellarSdk.Networks.TESTNET
+    })
+      .addOperation(
+        StellarSdk.Operation.payment({
+          destination:
+            'GASOCNHNNLYFNMDJYQ3XFMI7BYHIOCFW3GJEOWRPEGK2TDPGTG2E5EDW',
+          asset: StellarSdk.Asset.native(),
+          amount: '100.50'
+        })
+      )
+      .setTimeout(StellarSdk.TimeoutInfinite)
+      .build();
+
+    this.server
+      .submitTransaction(transaction)
+      .then(function() {
         done();
       })
       .catch(function(err) {


### PR DESCRIPTION
This PR extends `server.submitTransaction` to always run a memo required check before sending the transaction.  Users can opt-out by setting `skipMemoRequiredCheck` to `true`:

```
server.submitTransaction(tx, {skipMemoRequiredCheck: true})
```

The check is only run if any of the operations included in transaction is of type 
 - `payment`
 - `pathPaymentStrictReceive`
 - `pathPaymentStrictSend`
 - `mergeAccount`

If the transaction includes a memo, then memo required checked is skipped.

See [SEP0029](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0029.md) for more information.


