### PR TITLE
Add yarn test:watch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,6 +79,10 @@ gulp.task(
   )
 );
 
+gulp.task('test:watch', function() {
+  return gulp.watch(['src/**/*', 'test/unit/**/*.js'], gulp.series(['clear-screen', 'test:unit']));
+})
+
 gulp.task(
   'test:unit',
   gulp.series('build:node', function testUnit() {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "prepare": "gulp build",
     "test": "babel-node ./node_modules/.bin/gulp test",
+    "test:watch": "babel-node ./node_modules/.bin/gulp test:watch",
     "build:docs": "gulp build:docs",
     "docs": "yarn build:docs && jsdoc -c .jsdoc.json",
     "dtslint": "dtslint test/types",


### PR DESCRIPTION
Running `yarn test:watch` will start a watcher which runs the test every time a file changes in `src/` or `test/`.

This helps a lot during development.