### PR TITLE
v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ A breaking change will get clearly marked in this log.
    - `pathPaymentStrictSend`
    - `mergeAccount`
 
-  If the transaction includes a memo, then memo required checked is skipped.
+  If the transaction includes a memo, then memo required checking is skipped.
 
   See [SEP0029](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0029.md) for more information about memo required check.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ A breaking change will get clearly marked in this log.
 - Add SEP0029 support. ([#516](https://github.com/stellar/js-stellar-sdk/issues/516))
 
   Extends `server.submitTransaction` to always run a memo required check before
-  sending the transaction, if any of the destinations requires a memo and the
+  sending the transaction.  If any of the destinations require a memo and the
   transaction doesn't include one, then an `AccountRequiresMemoError` will be thrown.  
 
   You can skip this check by passing `{skipMemoRequiredCheck: true}` to `server.submitTransaction`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ A breaking change will get clearly marked in this log.
 ## [v4.1.0](https://github.com/stellar/js-stellar-sdk/compare/v4.0.2...v4.1.0)
 
 ### Add
-- Add SEP0029 support. ([#516](https://github.com/stellar/js-stellar-sdk/issues/516))
+- Add SEP0029 (memo required) support. ([#516](https://github.com/stellar/js-stellar-sdk/issues/516))
 
   Extends `server.submitTransaction` to always run a memo required check before
   sending the transaction.  If any of the destinations require a memo and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+## [v4.1.0](https://github.com/stellar/js-stellar-sdk/compare/v4.0.2...v4.1.0)
+
+### Add
+- Add SEP0029 support. ([#516](https://github.com/stellar/js-stellar-sdk/issues/516))
+
+  Extends `server.submitTransaction` to always run a memo required check before
+  sending the transaction, if any of the destinations requires a memo and the
+  transaction doesn't include one, then an `AccountRequiresMemoError` will be thrown.  
+
+  You can skip this check by passing `{skipMemoRequiredCheck: true}` to `server.submitTransaction`:
+
+  ```
+  server.submitTransaction(tx, {skipMemoRequiredCheck: true})
+  ```
+
+  The check runs for each operation of type:
+   - `payment`
+   - `pathPaymentStrictReceive`
+   - `pathPaymentStrictSend`
+   - `mergeAccount`
+
+  If the transaction includes a memo, then memo required checked is skipped.
+
+  See [SEP0029](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0029.md) for more information about memo required check.
+
 ## [v4.0.2](https://github.com/stellar/js-stellar-sdk/compare/v4.0.1...v4.0.2)
 
 ### Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-sdk",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "stellar-sdk is a library for working with the Stellar Horizon server.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
### Add
- Add SEP0029 support. ([#516](https://github.com/stellar/js-stellar-sdk/issues/516))

Extends `server.submitTransaction` to always run a memo required check before
sending the transaction, if any of the destinations requires a memo and the
transaction doesn't include one, then an `AccountRequiresMemoError` will be thrown.

You can skip this check by passing `{skipMemoRequiredCheck: true}` to `server.submitTransaction`:

```
server.submitTransaction(tx, {skipMemoRequiredCheck: true})
```

The check runs for each operation of type:
 - `payment`
 - `pathPaymentStrictReceive`
 - `pathPaymentStrictSend`
 - `mergeAccount`

If the transaction includes a memo, then memo required checked is skipped.

See [SEP0029](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0029.md) for more information about memo required check.