### PR TITLE
Allow max_fee and fee_charged to be a string in TransactionResponse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Breaking changes 
+- The attributes `max_fee` and `fee_charged` in `TransactionResponse` can be now a `number` or a `string`. 
+  Update your code to handle both types since Horizon will start sending `string` in version `1.3.0`.
+
 ## [v5.0.0-alpha.2](https://github.com/stellar/js-stellar-sdk/compare/v5.0.0-alpha.1..v5.0.0-alpha.2)
 
 ### Update

--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -30,8 +30,8 @@ export namespace Horizon {
       > {
     created_at: string;
     fee_meta_xdr: string;
-    fee_charged: number;
-    max_fee: number;
+    fee_charged: number | string;
+    max_fee: number | string;
     id: string;
     memo_type: MemoType;
     memo?: string;


### PR DESCRIPTION
The attributes `max_fee` and `fee_charged` in `TransactionResponse` can be now a `number` or a `string`.  Horizon will start sending `string` in version `1.3.0`.