### PR TITLE
Skip memo required check for multiplexed accounts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Update
+
+- Skip SEP0029 (memo required check) for multiplexed accounts ([#538](https://github.com/stellar/js-stellar-sdk/pull/538)).
+
 ## [v5.0.0](https://github.com/stellar/js-stellar-sdk/compare/v4.1.0...v5.0.0)
 
 ### Add

--- a/src/server.ts
+++ b/src/server.ts
@@ -738,6 +738,11 @@ export class Server {
       }
       destinations.add(destination);
 
+      // skip M account checks since it implies a memo
+      if (destination.startsWith("M")) {
+        continue;
+      }
+
       try {
         const account = await this.loadAccount(destination);
         if (

--- a/test/unit/server_check_memo_required_test.js
+++ b/test/unit/server_check_memo_required_test.js
@@ -291,4 +291,19 @@ describe("server.js check-memo-required", function() {
           done(err);
         });
     });
+    it("skips memo require check for M accounts", function(done) {
+      let accountId = "MAAAAAAAAAAAAAB7BQ2L7E5NBWMXDUCMZSIPOBKRDSBYVLMXGSSKF6YNPIB7Y77ITLVL6";
+      let transaction = buildTransaction(accountId);
+
+      this.server
+        .checkMemoRequired(transaction)
+        .then(function() {
+          done();
+        }, function(err) {
+          done(err);
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
 });


### PR DESCRIPTION
As discussed here https://github.com/stellar/js-stellar-sdk/pull/535/files#r416675569, we'll skip SEP0029 - memo required check, for multiplexed accounts.
