### PR TITLE
Use /accounts/id/offers in offer().forAccount().

### DIFF
--- a/src/offer_call_builder.ts
+++ b/src/offer_call_builder.ts
@@ -41,13 +41,13 @@ export class OfferCallBuilder extends CallBuilder<
    * @returns {OfferCallBuilder} current OfferCallBuilder instance
    */
   public forAccount(id: string): this {
-    this.url.setQuery("seller", id);
+    this.filter.push(["accounts", id, "offers"]);
     return this;
   }
 
   /**
    * Returns all offers buying an asset.
-   * @see [Offers](https://www.stellar.org/developers/horizon/reference/endpoints/offers.html)
+   * @see [Offers](https://www.stellar.org/developers/horizon/reference/endpoints/offers-for-account.html)
    * @see Asset
    * @param {Asset} value For example: `new Asset('USD','GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD')`
    * @returns {OfferCallBuilder} current OfferCallBuilder instance

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -1293,7 +1293,7 @@ describe('server.js non-transaction tests', function() {
           .expects('get')
           .withArgs(
             sinon.match(
-              'https://horizon-live.stellar.org:1337/offers?seller=GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K&order=asc'
+              'https://horizon-live.stellar.org:1337/accounts/GBS43BF24ENNS3KPACUZVKK2VYPOZVBQO2CISGZ777RYGOPYC2FT6S3K/offers?order=asc'
             )
           )
           .returns(Promise.resolve({ data: offersResponse }));


### PR DESCRIPTION
This allows streaming offers for a given account. Trying to stream through `/offers` is not supported at the moment.

Fix #552