### PR TITLE
Add tx_set_operation_count to ledgers resource.

### DIFF
--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -126,6 +126,7 @@ export namespace ServerApi {
     sequence: number;
     transaction_count: number;
     operation_count: number;
+    tx_set_operation_count: number | null;
     closed_at: string;
     total_coins: string;
     fee_pool: string;

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -378,6 +378,7 @@ describe('server.js non-transaction tests', function() {
               sequence: 1,
               transaction_count: 0,
               operation_count: 0,
+              tx_set_operation_count: 0,
               closed_at: '1970-01-01T00:00:00Z'
             }
           ]
@@ -506,6 +507,7 @@ describe('server.js non-transaction tests', function() {
         sequence: 1,
         transaction_count: 0,
         operation_count: 0,
+        tx_set_operation_count: 0,
         closed_at: '1970-01-01T00:00:00Z'
       };
 


### PR DESCRIPTION
[Horizon 1.5.0](https://github.com/stellar/go/releases/tag/horizon-v1.5.0) added a new field to the ledgers resource called `tx_set_operation_count`, this PR adds support for this new attribute.



Fix #560