### PR TITLE
Reduce example tx amount

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -117,7 +117,7 @@ const server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
             StellarSdk.Operation.payment({
                 destination: "GASOCNHNNLYFNMDJYQ3XFMI7BYHIOCFW3GJEOWRPEGK2TDPGTG2E5EDW",
                 asset: StellarSdk.Asset.native(),
-                amount: "20000000"
+                amount: "2"
             })
         )
         .setTimeout(30)


### PR DESCRIPTION
Any reason this is so high? It could be confused with stroops. I think a lower amount better illustrates that we are talking lumens here.