### PR TITLE
Update SEP-10 Utils

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,9 +74,9 @@ export namespace Utils {
       } catch (e) {
         throw Error(`Invalid homeDomain: ${e.message}`);
       }
-      manageDataKey = `${uri.domain()} auth`;
+      manageDataKey = uri.authority();
     } else {
-      manageDataKey = `${anchorName} auth`;
+      manageDataKey = anchorName;
     }
 
     const transaction = new TransactionBuilder(account, {

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -35,46 +35,16 @@ describe('Utils', function() {
         /Invalid clientAccountID: multiplexed accounts are not supported./
       );
     });
-    it('returns challenge which follows SEP0010 <2.0 spec', function() {
+
+    it('returns challenge which follows SEP0010 spec', function() {
       let keypair = StellarSdk.Keypair.random();
 
       const challenge = StellarSdk.Utils.buildChallengeTx(
         keypair,
         "GBDIT5GUJ7R5BXO3GJHFXJ6AZ5UQK6MNOIDMPQUSMXLIHTUNR2Q5CFNF",
-        "SDF",
+        "testanchor.stellar.org",
         300,
         StellarSdk.Networks.TESTNET
-      );
-
-      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
-
-      expect(transaction.sequence).to.eql("0");
-      expect(transaction.source).to.eql(keypair.publicKey());
-      expect(transaction.operations.length).to.eql(1);
-
-      const { maxTime, minTime } = transaction.timeBounds;
-
-      expect(parseInt(maxTime) - parseInt(minTime)).to.eql(300);
-
-      const [ operation ] =  transaction.operations;
-
-      expect(operation.name).to.eql("SDF auth");
-      expect(operation.source).to.eql("GBDIT5GUJ7R5BXO3GJHFXJ6AZ5UQK6MNOIDMPQUSMXLIHTUNR2Q5CFNF");
-      expect(operation.type).to.eql("manageData");
-      expect(operation.value.length).to.eql(64);
-      expect(Buffer.from(operation.value.toString(), 'base64').length).to.eql(48);
-    });
-
-    it('returns challenge which follows SEP0010 ==2.0 spec', function() {
-      let keypair = StellarSdk.Keypair.random();
-
-      const challenge = StellarSdk.Utils.buildChallengeTx(
-        keypair,
-        "GBDIT5GUJ7R5BXO3GJHFXJ6AZ5UQK6MNOIDMPQUSMXLIHTUNR2Q5CFNF",
-        null,
-        300,
-        StellarSdk.Networks.TESTNET,
-        "https://testanchor.stellar.org"
       );
 
       const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -35,7 +35,7 @@ describe('Utils', function() {
         /Invalid clientAccountID: multiplexed accounts are not supported./
       );
     });
-    it('returns challenge which follows SEP0010 spec', function() {
+    it('returns challenge which follows SEP0010 <2.0 spec', function() {
       let keypair = StellarSdk.Keypair.random();
 
       const challenge = StellarSdk.Utils.buildChallengeTx(
@@ -59,6 +59,37 @@ describe('Utils', function() {
       const [ operation ] =  transaction.operations;
 
       expect(operation.name).to.eql("SDF auth");
+      expect(operation.source).to.eql("GBDIT5GUJ7R5BXO3GJHFXJ6AZ5UQK6MNOIDMPQUSMXLIHTUNR2Q5CFNF");
+      expect(operation.type).to.eql("manageData");
+      expect(operation.value.length).to.eql(64);
+      expect(Buffer.from(operation.value.toString(), 'base64').length).to.eql(48);
+    });
+
+    it('returns challenge which follows SEP0010 ==2.0 spec', function() {
+      let keypair = StellarSdk.Keypair.random();
+
+      const challenge = StellarSdk.Utils.buildChallengeTx(
+        keypair,
+        "GBDIT5GUJ7R5BXO3GJHFXJ6AZ5UQK6MNOIDMPQUSMXLIHTUNR2Q5CFNF",
+        null,
+        300,
+        StellarSdk.Networks.TESTNET,
+        "https://testanchor.stellar.org"
+      );
+
+      const transaction = new StellarSdk.Transaction(challenge, StellarSdk.Networks.TESTNET);
+
+      expect(transaction.sequence).to.eql("0");
+      expect(transaction.source).to.eql(keypair.publicKey());
+      expect(transaction.operations.length).to.eql(1);
+
+      const { maxTime, minTime } = transaction.timeBounds;
+
+      expect(parseInt(maxTime) - parseInt(minTime)).to.eql(300);
+
+      const [ operation ] =  transaction.operations;
+
+      expect(operation.name).to.eql("testanchor.stellar.org auth");
       expect(operation.source).to.eql("GBDIT5GUJ7R5BXO3GJHFXJ6AZ5UQK6MNOIDMPQUSMXLIHTUNR2Q5CFNF");
       expect(operation.type).to.eql("manageData");
       expect(operation.value.length).to.eql(64);


### PR DESCRIPTION
resolves stellar/integration-meta#193

Adds the optional `homeDomain` argument to `buildChallengeTx()` and `readChallengeTx()`.

The change to `buildChallengeTx()` will allow anchors to build challenge transactions with their service's home domain included in Manage Data operation. 

**Note that this is not the home domain of the server that returns and verifies the challenge transaction.** The home domain referenced in the changes here is in reference to the home domain that hosts the service's [stellar.toml](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md) file.

The change to `readChallengeTx()` will allow clients to verify that the challenge transaction received includes the home domain of the service hosting the same TOML file used to fetch the endpoint for the authentication request. Anchors can also verify this field to ensure clients do not send challenges received from other anchors.

These SDK changes do not guarantee the challenge transaction originated from the same service that hosts the TOML file used. For that, clients must verify the following:
- the home domain of the service that hosts the TOML file used is included in the challenge's Manage Data operation
    - This is enabled with the changes introduced in this PR
- the challenge is signed by the `SIGNING_KEY` listed in the same [stellar.toml](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md) file

