### PR TITLE
Add Protocol 14 support. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+- Add support for claimable balances ([#572]https://github.com/stellar/js-stellar-sdk/pull/572)).
+Extend server class to allow loading claimable balances from Horizon. The following functions are available:
+
+```
+server.claimableBalances();
+server.claimableBalances().claimant(claimant);
+server.claimableBalances().sponsor(sponsorID);
+server.claimableBalances().asset(asset);
+server.claimableBalances().claimableBalance(balanceID);
+```
+-  Add the following attributes to `AccountResponse` ([#572]https://github.com/stellar/js-stellar-sdk/pull/572)):
+  - `sponsor?: string`
+  - `num_sponsoring: number`
+  - `num_sponsored: number`
+
+- Add the optional attribute `sponsor` to `AccountSigner`, `BalanceLineAsset`, `ClaimableBalanceRecord`, and `OfferRecord` ([#572]https://github.com/stellar/js-stellar-sdk/pull/572)).
+
 ## [v5.0.4](https://github.com/stellar/js-stellar-sdk/compare/v5.0.3...v5.0.4)
 
 ### Update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
-- Add support for claimable balances ([#572]https://github.com/stellar/js-stellar-sdk/pull/572)).
+- Add support for claimable balances ([#572](https://github.com/stellar/js-stellar-sdk/pull/572)).
 Extend server class to allow loading claimable balances from Horizon. The following functions are available:
 
 ```
@@ -14,18 +14,18 @@ server.claimableBalances().sponsor(sponsorID);
 server.claimableBalances().asset(asset);
 server.claimableBalances().claimableBalance(balanceID);
 ```
--  Add the following attributes to `AccountResponse` ([#572]https://github.com/stellar/js-stellar-sdk/pull/572)):
-  - `sponsor?: string`
-  - `num_sponsoring: number`
-  - `num_sponsored: number`
+-  Add the following attributes to `AccountResponse` ([#572](https://github.com/stellar/js-stellar-sdk/pull/572)):
+    * `sponsor?: string`
+    * `num_sponsoring: number`
+    * `num_sponsored: number`
 
-- Add the optional attribute `sponsor` to `AccountSigner`, `BalanceLineAsset`, `ClaimableBalanceRecord`, and `OfferRecord` ([#572]https://github.com/stellar/js-stellar-sdk/pull/572)).
+- Add the optional attribute `sponsor` to `AccountSigner`, `BalanceLineAsset`, `ClaimableBalanceRecord`, and `OfferRecord` ([#572](https://github.com/stellar/js-stellar-sdk/pull/572)).
 
-- Add `sponsor` filtering support for `offers` and `accounts` ([#572]https://github.com/stellar/js-stellar-sdk/pull/572)).
-  - `server.offers().sponsor(accountID)` 
-  - `server.accounts().sponsor(accountID)`
+- Add `sponsor` filtering support for `offers` and `accounts` ([#572](https://github.com/stellar/js-stellar-sdk/pull/572)).
+    * `server.offers().sponsor(accountID)`
+    * `server.accounts().sponsor(accountID)`
 
-- Extend operation responses to support new operations ([#572]https://github.com/stellar/js-stellar-sdk/pull/572)).
+- Extend operation responses to support new operations ([#572](https://github.com/stellar/js-stellar-sdk/pull/572)).
     * `create_claimable_balance` with the following fields:
         * `asset` - asset available to be claimed (in canonical form),
         * `amount` - amount available to be claimed,
@@ -50,7 +50,7 @@ server.claimableBalances().claimableBalance(balanceID);
         * `signer_account_id` - if signer sponsorship was revoked,
         * `signer_key` - if signer sponsorship was revoked.
 
-- Extend effect responses to support new effects ([#572]https://github.com/stellar/js-stellar-sdk/pull/572)).
+- Extend effect responses to support new effects ([#572](https://github.com/stellar/js-stellar-sdk/pull/572)).
     * `claimable_balance_created` with the following fields:
         * `balance_id` - unique ID of claimable balance,
         * `asset` - asset available to be claimed (in canonical form),
@@ -70,31 +70,30 @@ server.claimableBalances().claimableBalance(balanceID);
         * `new_sponsor` - new sponsor of an account,
         * `former_sponsor` - former sponsor of an account.
     * `account_sponsorship_removed` with the following fields:
-        * `former_sponsor` - former sponsor of an account. 
+        * `former_sponsor` - former sponsor of an account.
     * `trustline_sponsorship_created` with the following fields:
         * `sponsor` - sponsor of a trustline.
     * `trustline_sponsorship_updated` with the following fields:
         * `new_sponsor` - new sponsor of a trustline,
         * `former_sponsor` - former sponsor of a trustline.
     * `trustline_sponsorship_removed` with the following fields:
-        * `former_sponsor` - former sponsor of a trustline. 
+        * `former_sponsor` - former sponsor of a trustline.
     * `claimable_balance_sponsorship_created` with the following fields:
         * `sponsor` - sponsor of a claimable balance.
     * `claimable_balance_sponsorship_updated` with the following fields:
         * `new_sponsor` - new sponsor of a claimable balance,
         * `former_sponsor` - former sponsor of a claimable balance.
     * `claimable_balance_sponsorship_removed` with the following fields:
-        * `former_sponsor` - former sponsor of a claimable balance. 
+        * `former_sponsor` - former sponsor of a claimable balance.
     * `signer_sponsorship_created` with the following fields:
-        * `signer` - signer being sponsored. 
-        * `sponsor` - signer sponsor. 
+        * `signer` - signer being sponsored.
+        * `sponsor` - signer sponsor.
     * `signer_sponsorship_updated` with the following fields:
-        * `signer` - signer being sponsored. 
-        * `former_sponsor` - the former sponsor of the signer. 
-        * `new_sponsor` - the new sponsor of the signer. 
+        * `signer` - signer being sponsored.
+        * `former_sponsor` - the former sponsor of the signer.
+        * `new_sponsor` - the new sponsor of the signer.
     * `signer_sponsorship_removed` with the following fields:
-        * `former_sponsor` - former sponsor of a signer. 
-
+        * `former_sponsor` - former sponsor of a signer.
 
 
 ## [v5.0.4](https://github.com/stellar/js-stellar-sdk/compare/v5.0.3...v5.0.4)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,82 @@ server.claimableBalances().claimableBalance(balanceID);
 
 - Add the optional attribute `sponsor` to `AccountSigner`, `BalanceLineAsset`, `ClaimableBalanceRecord`, and `OfferRecord` ([#572]https://github.com/stellar/js-stellar-sdk/pull/572)).
 
+- Add `sponsor` filtering support for `offers` and `accounts` ([#572]https://github.com/stellar/js-stellar-sdk/pull/572)).
+  - `server.offers().sponsor(accountID)` 
+  - `server.accounts().sponsor(accountID)`
+
+- Extend operation responses to support new operations ([#572]https://github.com/stellar/js-stellar-sdk/pull/572)).
+    * `create_claimable_balance` with the following fields:
+        * `asset` - asset available to be claimed (in canonical form),
+        * `amount` - amount available to be claimed,
+        * `claimants` - list of claimants with predicates (see below):
+            * `destination` - destination account ID,
+            * `predicate` - predicate required to claim a balance (see below).
+    * `claim_claimable_balance` with the following fields:
+        * `balance_id` - unique ID of balance to be claimed,
+        * `claimant` - account ID of a claimant.
+    * `begin_sponsoring_future_reserves` with the following fields:
+        * `sponsored_id` - account ID for which future reserves will be sponsored.
+    * `end_sponsoring_future_reserves` with the following fields:
+        * `begin_sponsor` - account sponsoring reserves.
+    * `revoke_sponsorship` with the following fields:
+        * `account_id` - if account sponsorship was revoked,
+        * `claimable_balance_id` - if claimable balance sponsorship was revoked,
+        * `data_account_id` - if account data sponsorship was revoked,
+        * `data_name` - if account data sponsorship was revoked,
+        * `offer_id` - if offer sponsorship was revoked,
+        * `trustline_account_id` - if trustline sponsorship was revoked,
+        * `trustline_asset` - if trustline sponsorship was revoked,
+        * `signer_account_id` - if signer sponsorship was revoked,
+        * `signer_key` - if signer sponsorship was revoked.
+
+- Extend effect responses to support new effects ([#572]https://github.com/stellar/js-stellar-sdk/pull/572)).
+    * `claimable_balance_created` with the following fields:
+        * `balance_id` - unique ID of claimable balance,
+        * `asset` - asset available to be claimed (in canonical form),
+        * `amount` - amount available to be claimed.
+    * `claimable_balance_claimant_created` with the following fields:
+        * `balance_id` - unique ID of a claimable balance,
+        * `asset` - asset available to be claimed (in canonical form),
+        * `amount` - amount available to be claimed,
+        * `predicate` - predicate required to claim a balance (see below).
+    * `claimable_balance_claimed` with the following fields:
+        * `balance_id` - unique ID of a claimable balance,
+        * `asset` - asset available to be claimed (in canonical form),
+        * `amount` - amount available to be claimed,
+    * `account_sponsorship_created` with the following fields:
+        * `sponsor` - sponsor of an account.
+    * `account_sponsorship_updated` with the following fields:
+        * `new_sponsor` - new sponsor of an account,
+        * `former_sponsor` - former sponsor of an account.
+    * `account_sponsorship_removed` with the following fields:
+        * `former_sponsor` - former sponsor of an account. 
+    * `trustline_sponsorship_created` with the following fields:
+        * `sponsor` - sponsor of a trustline.
+    * `trustline_sponsorship_updated` with the following fields:
+        * `new_sponsor` - new sponsor of a trustline,
+        * `former_sponsor` - former sponsor of a trustline.
+    * `trustline_sponsorship_removed` with the following fields:
+        * `former_sponsor` - former sponsor of a trustline. 
+    * `claimable_balance_sponsorship_created` with the following fields:
+        * `sponsor` - sponsor of a claimable balance.
+    * `claimable_balance_sponsorship_updated` with the following fields:
+        * `new_sponsor` - new sponsor of a claimable balance,
+        * `former_sponsor` - former sponsor of a claimable balance.
+    * `claimable_balance_sponsorship_removed` with the following fields:
+        * `former_sponsor` - former sponsor of a claimable balance. 
+    * `signer_sponsorship_created` with the following fields:
+        * `signer` - signer being sponsored. 
+        * `sponsor` - signer sponsor. 
+    * `signer_sponsorship_updated` with the following fields:
+        * `signer` - signer being sponsored. 
+        * `former_sponsor` - the former sponsor of the signer. 
+        * `new_sponsor` - the new sponsor of the signer. 
+    * `signer_sponsorship_removed` with the following fields:
+        * `former_sponsor` - former sponsor of a signer. 
+
+
+
 ## [v5.0.4](https://github.com/stellar/js-stellar-sdk/compare/v5.0.3...v5.0.4)
 
 ### Update

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "eventsource": "^1.0.7",
     "lodash": "^4.17.11",
     "randombytes": "^2.1.0",
-    "stellar-base": "^3.0.3",
+    "stellar-base": "^4.0.0",
     "toml": "^2.3.0",
     "tslib": "^1.10.0",
     "urijs": "^1.19.1",

--- a/src/account_call_builder.ts
+++ b/src/account_call_builder.ts
@@ -56,4 +56,15 @@ export class AccountCallBuilder extends CallBuilder<
     this.url.setQuery("asset", `${asset}`);
     return this;
   }
+
+  /**
+   * This endpoint filters accounts where the given account is sponsoring the account or any of its sub-entries..
+   * @see [Accounts](https://www.stellar.org/developers/horizon/reference/endpoints/accounts.html)
+   * @param {string} value For example: `GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD`
+   * @returns {AccountCallBuilder} current AccountCallBuilder instance
+   */
+  public sponsor(id: string): this {
+    this.url.setQuery("sponsor", id);
+    return this;
+  }
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -4,4 +4,4 @@ module.exports = require("./index");
 module.exports.axios = require("axios");
 module.exports.StellarBase = require("stellar-base");
 
-export { };
+export {};

--- a/src/claimable_balances_call_builder.ts
+++ b/src/claimable_balances_call_builder.ts
@@ -1,0 +1,75 @@
+import { Asset } from "stellar-base";
+import { CallBuilder } from "./call_builder";
+import { ServerApi } from "./server_api";
+
+/**
+ * Creates a new {@link ClaimableBalanceCallBuilder} pointed to server defined by serverUrl.
+ * Do not create this object directly, use {@link Server#claimableBalances}.
+ *
+ * @see [Claimable Balances](https://developers.stellar.org/api/resources/claimablebalances/)
+ * @class ClaimableBalanceCallBuilder
+ * @constructor
+ * @extends CallBuilder
+ * @param {string} serverUrl Horizon server URL.
+ */
+export class ClaimableBalanceCallBuilder extends CallBuilder<
+  ServerApi.CollectionPage<ServerApi.ClaimableBalanceRecord>
+> {
+  constructor(serverUrl: URI) {
+    super(serverUrl);
+    this.url.segment("claimable_balances");
+  }
+
+  /**
+   * The claimable balance details endpoint provides information on a single claimable balance.
+   *
+   * @see [Claimable Balance Details](https://developers.stellar.org/api/resources/claimablebalances/single/)
+   * @param {string} claimableBalanceId Claimable balance ID
+   * @returns {CallBuilder<ServerApi.ClaimableBalanceRecord>} CallBuilder<ServerApi.ClaimableBalanceRecord> OperationCallBuilder instance
+   */
+  public claimableBalance(
+    claimableBalanceId: string,
+  ): CallBuilder<ServerApi.ClaimableBalanceRecord> {
+    const builder = new CallBuilder<ServerApi.ClaimableBalanceRecord>(
+      this.url.clone(),
+    );
+    builder.filter.push([claimableBalanceId]);
+    return builder;
+  }
+
+  /**
+   * Returns all claimable balances which are sponsored by the given account ID.
+   *
+   * @see [Claimable Balances](https://developers.stellar.org/api/resources/claimablebalances/list/)
+   * @param {string} sponsor For example: `GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD`
+   * @returns {ClaimableBalanceCallBuilder} current ClaimableBalanceCallBuilder instance
+   */
+  public sponsor(sponsor: string): this {
+    this.url.setQuery("sponsor", sponsor);
+    return this;
+  }
+
+  /**
+   * Returns all claimable balances which can be claimed by the given account ID.
+   *
+   * @see [Claimable Balances](https://developers.stellar.org/api/resources/claimablebalances/list/)
+   * @param {string} claimant For example: `GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD`
+   * @returns {ClaimableBalanceCallBuilder} current ClaimableBalanceCallBuilder instance
+   */
+  public claimant(claimant: string): this {
+    this.url.setQuery("claimant", claimant);
+    return this;
+  }
+
+  /**
+   * Returns all claimable balances which provide a balance for the given asset.
+   *
+   * @see [Claimable Balances](https://developers.stellar.org/api/resources/claimablebalances/list/)
+   * @param {string} claimant For example: `GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD`
+   * @returns {ClaimableBalanceCallBuilder} current ClaimableBalanceCallBuilder instance
+   */
+  public asset(asset: Asset): this {
+    this.url.setQuery("asset", asset.toString());
+    return this;
+  }
+}

--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -78,6 +78,7 @@ export namespace Horizon {
     last_modified_ledger: number;
     is_authorized: boolean;
     is_authorized_to_maintain_liabilities: boolean;
+    sponsor?: string;
   }
   export type BalanceLine<
     T extends AssetType = AssetType
@@ -111,6 +112,7 @@ export namespace Horizon {
     key: string;
     weight: number;
     type: string;
+    sponsor?: string;
   }
   export interface AccountResponse
     extends BaseResponse<
@@ -134,6 +136,9 @@ export namespace Horizon {
     data: {
       [key: string]: string;
     };
+    sponsor?: string;
+    num_sponsoring: number;
+    num_sponsored: number;
   }
 
   export enum OperationResponseType {

--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -156,6 +156,11 @@ export namespace Horizon {
     bumpSequence = "bump_sequence",
     manageBuyOffer = "manage_buy_offer",
     pathPaymentStrictSend = "path_payment_strict_send",
+    createClaimableBalance = "create_claimable_balance",
+    claimClaimableBalance = "claim_claimable_balance",
+    beginSponsoringFutureReserves = "begin_sponsoring_future_reserves",
+    endSponsoringFutureReserves = "end_sponsoring_future_reserves",
+    revokeSponsorship = "revoke_sponsorship",
   }
   export enum OperationResponseTypeI {
     createAccount = 0,
@@ -172,6 +177,11 @@ export namespace Horizon {
     bumpSequence = 11,
     manageBuyOffer = 12,
     pathPaymentStrictSend = 13,
+    createClaimableBalance = 14,
+    claimClaimableBalance = 15,
+    beginSponsoringFutureReserves = 16,
+    endSponsoringFutureReserves = 17,
+    revokeSponsorship = 18,
   }
   export interface BaseOperationResponse<
     T extends OperationResponseType = OperationResponseType,
@@ -350,6 +360,70 @@ export namespace Horizon {
       OperationResponseTypeI.bumpSequence
     > {
     bump_to: string;
+  }
+  export interface Predicate {
+    and?: Predicate[];
+    or?: Predicate[];
+    not?: Predicate;
+    absBefore?: string;
+    relBefore?: string;
+  }
+
+  export interface Claimant {
+    destination: string;
+    predicate: Predicate;
+  }
+
+  export interface CreateClaimableBalanceOperationResponse
+    extends BaseOperationResponse<
+      OperationResponseType.createClaimableBalance,
+      OperationResponseTypeI.createClaimableBalance
+    > {
+    asset: string;
+    amount: string;
+    sponsor: string;
+    claimants: Claimant[];
+  }
+
+  export interface ClaimClaimableBalanceOperationResponse
+    extends BaseOperationResponse<
+      OperationResponseType.claimClaimableBalance,
+      OperationResponseTypeI.claimClaimableBalance
+    > {
+    balance_id: string;
+    claimant: string;
+  }
+
+  export interface BeginSponsoringFutureReservesOperationResponse
+    extends BaseOperationResponse<
+      OperationResponseType.beginSponsoringFutureReserves,
+      OperationResponseTypeI.beginSponsoringFutureReserves
+    > {
+    sponsored_id: string;
+  }
+
+  export interface EndSponsoringFutureReservesOperationResponse
+    extends BaseOperationResponse<
+      OperationResponseType.endSponsoringFutureReserves,
+      OperationResponseTypeI.endSponsoringFutureReserves
+    > {
+    begin_sponsor: string;
+  }
+
+  export interface RevokeSponsorshipOperationResponse
+    extends BaseOperationResponse<
+      OperationResponseType.revokeSponsorship,
+      OperationResponseTypeI.revokeSponsorship
+    > {
+    account_id?: string;
+    claimable_balance_id?: string;
+    data_account_id?: string;
+    data_name?: string;
+    offer_id?: string;
+    trustline_account_id?: string;
+    trustline_asset?: string;
+    signer_account_id?: string;
+    signer_key?: string;
   }
 
   export interface ResponseCollection<T extends BaseResponse = BaseResponse> {

--- a/src/offer_call_builder.ts
+++ b/src/offer_call_builder.ts
@@ -80,4 +80,15 @@ export class OfferCallBuilder extends CallBuilder<
     }
     return this;
   }
+
+  /**
+   * This endpoint filters offers where the given account is sponsoring the offer entry.
+   * @see [Offers](https://www.stellar.org/developers/horizon/reference/endpoints/offers.html)
+   * @param {string} value For example: `GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD`
+   * @returns {OfferCallBuilder} current OfferCallBuilder instance
+   */
+  public sponsor(id: string): this {
+    this.url.setQuery("sponsor", id);
+    return this;
+  }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ import {
 import { AccountCallBuilder } from "./account_call_builder";
 import { AccountResponse } from "./account_response";
 import { AssetsCallBuilder } from "./assets_call_builder";
+import { ClaimableBalanceCallBuilder } from "./claimable_balances_call_builder";
 import { EffectCallBuilder } from "./effect_call_builder";
 import { FriendbotBuilder } from "./friendbot_builder";
 import { Horizon } from "./horizon_api";
@@ -482,6 +483,13 @@ export class Server {
    */
   public accounts(): AccountCallBuilder {
     return new AccountCallBuilder(URI(this.serverURL as any));
+  }
+
+  /**
+   * @returns {ClaimableBalanceCallBuilder} New {@link ClaimableBalanceCallBuilder} object configured by a current Horizon server configuration.
+   */
+  public claimableBalances(): ClaimableBalanceCallBuilder {
+    return new ClaimableBalanceCallBuilder(URI(this.serverURL as any));
   }
 
   /**

--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -57,6 +57,29 @@ export namespace ServerApi {
     trades: CallCollectionFunction<TradeRecord>;
   }
 
+  export interface Predicate {
+    and?: Predicate[];
+    or?: Predicate[];
+    not?: Predicate;
+    absBefore?: string;
+    relBefore?: string;
+  }
+
+  export interface Claimant {
+    destination: string;
+    predicate: Predicate;
+  }
+
+  export interface ClaimableBalanceRecord extends Horizon.BaseResponse {
+    id: string;
+    paging_token: string;
+    asset: string;
+    amount: string;
+    sponsor?: string;
+    last_modified_ledger: number;
+    claimants: Claimant[];
+  }
+
   export interface EffectRecord extends Horizon.BaseResponse {
     account: string;
     paging_token: string;

--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -47,6 +47,9 @@ export namespace ServerApi {
     data_attr: {
       [key: string]: string;
     };
+    sponsor?: string;
+    num_sponsoring: number;
+    num_sponsored: number;
     effects: CallCollectionFunction<EffectRecord>;
     offers: CallCollectionFunction<OfferRecord>;
     operations: CallCollectionFunction<OperationRecord>;
@@ -161,6 +164,7 @@ export namespace ServerApi {
     price: string;
     last_modified_ledger: number;
     last_modified_time: string;
+    sponsor?: string;
   }
 
   import OperationResponseType = Horizon.OperationResponseType;

--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -57,19 +57,6 @@ export namespace ServerApi {
     trades: CallCollectionFunction<TradeRecord>;
   }
 
-  export interface Predicate {
-    and?: Predicate[];
-    or?: Predicate[];
-    not?: Predicate;
-    absBefore?: string;
-    relBefore?: string;
-  }
-
-  export interface Claimant {
-    destination: string;
-    predicate: Predicate;
-  }
-
   export interface ClaimableBalanceRecord extends Horizon.BaseResponse {
     id: string;
     paging_token: string;
@@ -77,7 +64,7 @@ export namespace ServerApi {
     amount: string;
     sponsor?: string;
     last_modified_ledger: number;
-    claimants: Claimant[];
+    claimants: Horizon.Claimant[];
   }
 
   export interface EffectRecord extends Horizon.BaseResponse {
@@ -284,6 +271,36 @@ export namespace ServerApi {
         OperationResponseTypeI.bumpSequence
       >,
       Horizon.BumpSequenceOperationResponse {}
+  export interface CreateClaimableBalanceOperationRecord
+    extends BaseOperationRecord<
+        OperationResponseType.createClaimableBalance,
+        OperationResponseTypeI.createClaimableBalance
+      >,
+      Horizon.CreateClaimableBalanceOperationResponse {}
+  export interface ClaimClaimableBalanceOperationRecord
+    extends BaseOperationRecord<
+        OperationResponseType.claimClaimableBalance,
+        OperationResponseTypeI.claimClaimableBalance
+      >,
+      Horizon.ClaimClaimableBalanceOperationResponse {}
+  export interface BeginSponsoringFutureReservesOperationRecord
+    extends BaseOperationRecord<
+        OperationResponseType.beginSponsoringFutureReserves,
+        OperationResponseTypeI.beginSponsoringFutureReserves
+      >,
+      Horizon.BeginSponsoringFutureReservesOperationResponse {}
+  export interface EndSponsoringFutureReservesOperationRecord
+    extends BaseOperationRecord<
+        OperationResponseType.endSponsoringFutureReserves,
+        OperationResponseTypeI.endSponsoringFutureReserves
+      >,
+      Horizon.EndSponsoringFutureReservesOperationResponse {}
+  export interface RevokeSponsorshipOperationRecord
+    extends BaseOperationRecord<
+        OperationResponseType.revokeSponsorship,
+        OperationResponseTypeI.revokeSponsorship
+      >,
+      Horizon.RevokeSponsorshipOperationResponse {}
 
   export type OperationRecord =
     | CreateAccountOperationRecord
@@ -298,7 +315,12 @@ export namespace ServerApi {
     | InflationOperationRecord
     | ManageDataOperationRecord
     | BumpSequenceOperationRecord
-    | PathPaymentStrictSendOperationRecord;
+    | PathPaymentStrictSendOperationRecord
+    | CreateClaimableBalanceOperationRecord
+    | ClaimClaimableBalanceOperationRecord
+    | BeginSponsoringFutureReservesOperationRecord
+    | EndSponsoringFutureReservesOperationRecord
+    | RevokeSponsorshipOperationRecord;
 
   export interface TradeRecord extends Horizon.BaseResponse {
     id: string;

--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -126,6 +126,35 @@ export namespace ServerApi {
     // trustline authorized / deauthorized
     trustor?: string;
 
+    // claimable_balance_created
+    // claimable_balance_claimant_created
+    // claimable_balance_claimed
+    balance_id?: string;
+    asset?: string;
+    predicate?: Horizon.Predicate;
+
+    // account_sponsorship_created
+    // trustline_sponsorship_created
+    // claimable_balance_sponsorship_created
+    // signer_sponsorship_created
+    // data_sponsorship_created
+    sponsor?: string;
+    signer?: string;
+    data_name?: string;
+
+    // account_sponsorship_updated
+    // account_sponsorship_removed
+    // trustline_sponsorship_updated
+    // trustline_sponsorship_removed
+    // claimable_balance_sponsorship_updated
+    // claimable_balance_sponsorship_removed
+    // signer_sponsorship_updated
+    // signer_sponsorship_removed
+    // data_sponsorship_updated
+    // data_sponsorship_removed
+    new_sponsor?: string;
+    former_sponsor?: string;
+
     operation?: CallFunction<OperationRecord>;
     precedes?: CallFunction<EffectRecord>;
     succeeds?: CallFunction<EffectRecord>;

--- a/test/unit/server/claimable_balances.js
+++ b/test/unit/server/claimable_balances.js
@@ -1,0 +1,193 @@
+const MockAdapter = require('axios-mock-adapter');
+
+describe('Adolfo ClaimableBalanceCallBuilder', function() {
+    beforeEach(function() {
+        this.server = new StellarSdk.Server(
+          'https://horizon-live.stellar.org:1337'
+        );
+        this.axiosMock = sinon.mock(HorizonAxiosClient);
+        StellarSdk.Config.setDefault();
+      });
+    
+      afterEach(function() {
+        this.axiosMock.verify();
+        this.axiosMock.restore();
+      });
+    
+    it('requests the correct endpoint', function(done) {
+      let singleBalanceResponse = {
+        '_links': {
+          'self': {
+            'href': 'horizon-live.stellar.org:1337/claimable_balances/00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf5491072'
+          }
+        },
+        'id': '00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf5491072',
+        'asset': 'native',
+        'amount': '200.0000000',
+        'sponsor': 'GBVFLWXYCIGPO3455XVFIKHS66FCT5AI64ZARKS7QJN4NF7K5FOXTJNL',
+        'last_modified_ledger': 38888,
+        'claimants': [
+          {
+            'destination': 'GBVFLWXYCIGPO3455XVFIKHS66FCT5AI64ZARKS7QJN4NF7K5FOXTJNL',
+            'predicate': {
+              'unconditional': true
+            }
+          }
+        ],
+        'paging_token': '38888-00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf5491072'
+      };
+
+      this.axiosMock
+        .expects('get')
+        .withArgs(
+          sinon.match(
+            'https://horizon-live.stellar.org:1337/claimable_balances/00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf5491072'
+          )
+        )
+        .returns(Promise.resolve({ data: singleBalanceResponse }));
+
+      this.server
+        .claimableBalances()
+        .claimableBalance('00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf5491072')
+        .call()
+        .then(function(response) {
+          expect(response).to.be.deep.equal(singleBalanceResponse);
+          done();
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
+
+    it('adds a "sponsor" query to the endpoint', function(done) {
+        const data = {
+            '_links': {
+              'self': {
+                'href': 'https://horizon-live.stellar.org:1337/claimable_balances?sponsor=GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD&cursor=&limit=10&order=asc'
+              },
+              'next': {
+                'href': 'https://horizon-live.stellar.org:1337/claimable_balances?sponsor=GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD&cursor=&limit=10&order=asc'
+              },
+              'prev': {
+                'href': 'https://horizon-live.stellar.org:1337/claimable_balances?sponsor=GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD&cursor=&limit=10&order=desc'
+              }
+            },
+            '_embedded': {
+              'records': [
+                
+              ]
+            }
+          };
+
+
+      this.axiosMock
+        .expects('get')
+        .withArgs(
+          sinon.match(
+            'https://horizon-live.stellar.org:1337/claimable_balances?sponsor=GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD'
+          )
+        )
+        .returns(Promise.resolve({ data }));
+
+      this.server
+        .claimableBalances()
+        .sponsor('GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD')
+        .call()
+        .then(function(response) {
+          expect(response.next).to.be.function;
+          expect(response.prev).to.be.function;
+          done();
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
+
+    it('adds a "claimant" query to the endpoint', function(done) {
+        const data = {
+            '_links': {
+              'self': {
+                'href': 'https://horizon-live.stellar.org:1337/claimable_balances?claimant=GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD&cursor=&limit=10&order=asc'
+              },
+              'next': {
+                'href': 'https://horizon-live.stellar.org:1337/claimable_balances?claimant=GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD&cursor=&limit=10&order=asc'
+              },
+              'prev': {
+                'href': 'https://horizon-live.stellar.org:1337/claimable_balances?claimant=GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD&cursor=&limit=10&order=desc'
+              }
+            },
+            '_embedded': {
+              'records': [
+                
+              ]
+            }
+          };
+
+
+      this.axiosMock
+        .expects('get')
+        .withArgs(
+          sinon.match(
+            'https://horizon-live.stellar.org:1337/claimable_balances?claimant=GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD'
+          )
+        )
+        .returns(Promise.resolve({ data }));
+
+      this.server
+        .claimableBalances()
+        .claimant('GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD')
+        .call()
+        .then(function(response) {
+          expect(response.next).to.be.function;
+          expect(response.prev).to.be.function;
+          done();
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
+
+    it('adds an "asset" query to the endpoint', function(done) {
+        const data = {
+            '_links': {
+              'self': {
+                'href': 'https://horizon-live.stellar.org:1337/claimable_balances?asset=USD%3AGDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD&cursor=&limit=10&order=asc'
+              },
+              'next': {
+                'href': 'https://horizon-live.stellar.org:1337/claimable_balances?asset=USD%3AGDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD&cursor=&limit=10&order=asc'
+              },
+              'prev': {
+                'href': 'https://horizon-live.stellar.org:1337/claimable_balances?asset=USD%3AGDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD&cursor=&limit=10&order=desc'
+              }
+            },
+            '_embedded': {
+              'records': [
+                
+              ]
+            }
+          };
+
+
+      this.axiosMock
+        .expects('get')
+        .withArgs(
+          sinon.match(
+            'https://horizon-live.stellar.org:1337/claimable_balances?asset=USD%3AGDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD'
+          )
+        )
+        .returns(Promise.resolve({ data }));
+
+      this.server
+        .claimableBalances()
+        .asset(new StellarSdk.Asset('USD','GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD'))
+        .call()
+        .then(function(response) {
+          expect(response.next).to.be.function;
+          expect(response.prev).to.be.function;
+          done();
+        })
+        .catch(function(err) {
+          done(err);
+        });
+    });
+});

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -1185,6 +1185,132 @@ describe('server.js non-transaction tests', function() {
           });
       });
 
+      it('adds a "sponsor" query to the endpoint', function(done) {
+        let accountsForSponsor = {
+          _links: {
+            self: {
+              href: '/accounts?cursor=&limit=10&order=asc&sponsor=GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42'
+            },
+            next: {
+              href: '/accounts?cursor=GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42&limit=10&order=asc&sponsor=GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42'
+            },
+            prev: {
+              href: '/accounts?cursor=GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42&limit=10&order=desc&sponsor=GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42'
+            }
+          },
+          _embedded: {
+            records: [
+              {
+                _links: {
+                  self: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42'
+                  },
+                  transactions: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/transactions{?cursor,limit,order}',
+                    templated: true
+                  },
+                  operations: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/operations{?cursor,limit,order}',
+                    templated: true
+                  },
+                  payments: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/payments{?cursor,limit,order}',
+                    templated: true
+                  },
+                  effects: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/effects{?cursor,limit,order}',
+                    templated: true
+                  },
+                  offers: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/offers{?cursor,limit,order}',
+                    templated: true
+                  },
+                  trades: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/trades{?cursor,limit,order}',
+                    templated: true
+                  },
+                  data: {
+                    href: '/accounts/GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42/data/{key}',
+                    templated: true
+                  }
+                },
+                id: 'GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42',
+                account_id: 'GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42',
+                sequence: '4233832731508737',
+                subentry_count: 1,
+                last_modified_ledger: 986912,
+                thresholds: {
+                  low_threshold: 0,
+                  med_threshold: 0,
+                  high_threshold: 0
+                },
+                flags: {
+                  auth_required: false,
+                  auth_revocable: false,
+                  auth_immutable: false
+                },
+                balances: [
+                  {
+                    balance: '0.0000000',
+                    limit: '450.0000000',
+                    buying_liabilities: '0.0000000',
+                    selling_liabilities: '0.0000000',
+                    last_modified_ledger: 986912,
+                    is_authorized: true,
+                    asset_type: 'credit_alphanum4',
+                    asset_code: 'USD',
+                    asset_issuer: 'GDUEG67IE5TJUVWRRTMXDP3Q6EMMZJ6HL5OMWLBYOIUIZEUW2T2PBPJH',
+                    sponsor: "GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42"
+                  },
+                  {
+                    balance: '9999.9999900',
+                    buying_liabilities: '0.0000000',
+                    selling_liabilities: '0.0000000',
+                    asset_type: 'native',
+                  }
+                ],
+                signers: [
+                  {
+                    weight: 1,
+                    key: 'GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42',
+                    type: 'ed25519_public_key'
+                  }
+                ],
+                data: {},
+                paging_token: 'GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42',
+                num_sponsoring: 0,
+                num_sponsored: 3,
+              }
+            ]
+          }
+        };
+
+        this.axiosMock
+          .expects('get')
+          .withArgs(
+            sinon.match(
+              'https://horizon-live.stellar.org:1337/accounts?sponsor=GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42'
+            )
+          )
+          .returns(Promise.resolve({ data: accountsForSponsor }));
+
+        this.server
+          .accounts()
+          .sponsor('GBCR5OVQ54S2EKHLBZMK6VYMTXZHXN3T45Y6PRX4PX4FXDMJJGY4FD42')
+          .call()
+          .then(function(response) {
+            expect(response.records).to.be.deep.equal(
+              accountsForSponsor._embedded.records
+            );
+            expect(response.next).to.be.function;
+            expect(response.prev).to.be.function;
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+
     });
 
     describe('OfferCallBuilder', function() {
@@ -1367,6 +1493,33 @@ describe('server.js non-transaction tests', function() {
         this.server
           .offers()
           .buying(buying)
+          .order('asc')
+          .call()
+          .then(function(response) {
+            expect(response.records).to.be.deep.equal(
+              offersResponse._embedded.records
+            );
+            expect(response.next).to.be.function;
+            expect(response.prev).to.be.function;
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
+      it('sponsor requests the correct endpoint', function(done) {
+        this.axiosMock
+          .expects('get')
+          .withArgs(
+            sinon.match(
+              'https://horizon-live.stellar.org:1337/offers?sponsor=GDVDKQFP665JAO7A2LSHNLQIUNYNAAIGJ6FYJVMG4DT3YJQQJSRBLQDG&order=asc'
+            )
+          )
+          .returns(Promise.resolve({ data: offersResponse }));
+
+        this.server
+          .offers()
+          .sponsor("GDVDKQFP665JAO7A2LSHNLQIUNYNAAIGJ6FYJVMG4DT3YJQQJSRBLQDG")
           .order('asc')
           .call()
           .then(function(response) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7717,10 +7717,10 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stellar-base@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-3.0.3.tgz#e4b033d113f11e9239ce4fe8ead6e9a791f04f14"
-  integrity sha512-Kb79uQOmlMhGw96rg5qRA+rxK58N2eH+q8OuqVgQr85t5l/+p35BFKVl2yW3xN/OVwY7NrAjFn/KJmoxjcTfeg==
+stellar-base@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-4.0.0.tgz#5eb314c76a2054b4df8bcec1278b78172b0fe663"
+  integrity sha512-isn7FoecIcr6lr38oT132UkrYPOEsZy/XAkXteClZpuBBK2aZn0qjyyX4WAoA6cQhnJw/lQQwND+qfijRETvyg==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^4.0.0"


### PR DESCRIPTION
This pull request add support for protocol 14 operations, effects, and new Horizon end-points.

- Add support for claimable balances.
Extend server class to allow loading claimable balances from Horizon. The following functions are available:

```
server.claimableBalances();
server.claimableBalances().claimant(claimant);
server.claimableBalances().sponsor(sponsorID);
server.claimableBalances().asset(asset);
server.claimableBalances().claimableBalance(balanceID);
```
-  Add the following attributes to `AccountResponse` :
    * `sponsor?: string`
    * `num_sponsoring: number`
    * `num_sponsored: number`

- Add the optional attribute `sponsor` to `AccountSigner`, `BalanceLineAsset`, `ClaimableBalanceRecord`, and `OfferRecord` .

- Add `sponsor` filtering support for `offers` and `accounts` .
    * `server.offers().sponsor(accountID)` 
    * `server.accounts().sponsor(accountID)`

- Extend operation responses to support new operations .
    * `create_claimable_balance` with the following fields:
        * `asset` - asset available to be claimed (in canonical form),
        * `amount` - amount available to be claimed,
        * `claimants` - list of claimants with predicates (see below):
            * `destination` - destination account ID,
            * `predicate` - predicate required to claim a balance (see below).
    * `claim_claimable_balance` with the following fields:
        * `balance_id` - unique ID of balance to be claimed,
        * `claimant` - account ID of a claimant.
    * `begin_sponsoring_future_reserves` with the following fields:
        * `sponsored_id` - account ID for which future reserves will be sponsored.
    * `end_sponsoring_future_reserves` with the following fields:
        * `begin_sponsor` - account sponsoring reserves.
    * `revoke_sponsorship` with the following fields:
        * `account_id` - if account sponsorship was revoked,
        * `claimable_balance_id` - if claimable balance sponsorship was revoked,
        * `data_account_id` - if account data sponsorship was revoked,
        * `data_name` - if account data sponsorship was revoked,
        * `offer_id` - if offer sponsorship was revoked,
        * `trustline_account_id` - if trustline sponsorship was revoked,
        * `trustline_asset` - if trustline sponsorship was revoked,
        * `signer_account_id` - if signer sponsorship was revoked,
        * `signer_key` - if signer sponsorship was revoked.

- Extend effect responses to support new effects .
    * `claimable_balance_created` with the following fields:
        * `balance_id` - unique ID of claimable balance,
        * `asset` - asset available to be claimed (in canonical form),
        * `amount` - amount available to be claimed.
    * `claimable_balance_claimant_created` with the following fields:
        * `balance_id` - unique ID of a claimable balance,
        * `asset` - asset available to be claimed (in canonical form),
        * `amount` - amount available to be claimed,
        * `predicate` - predicate required to claim a balance (see below).
    * `claimable_balance_claimed` with the following fields:
        * `balance_id` - unique ID of a claimable balance,
        * `asset` - asset available to be claimed (in canonical form),
        * `amount` - amount available to be claimed,
    * `account_sponsorship_created` with the following fields:
        * `sponsor` - sponsor of an account.
    * `account_sponsorship_updated` with the following fields:
        * `new_sponsor` - new sponsor of an account,
        * `former_sponsor` - former sponsor of an account.
    * `account_sponsorship_removed` with the following fields:
        * `former_sponsor` - former sponsor of an account. 
    * `trustline_sponsorship_created` with the following fields:
        * `sponsor` - sponsor of a trustline.
    * `trustline_sponsorship_updated` with the following fields:
        * `new_sponsor` - new sponsor of a trustline,
        * `former_sponsor` - former sponsor of a trustline.
    * `trustline_sponsorship_removed` with the following fields:
        * `former_sponsor` - former sponsor of a trustline. 
    * `claimable_balance_sponsorship_created` with the following fields:
        * `sponsor` - sponsor of a claimable balance.
    * `claimable_balance_sponsorship_updated` with the following fields:
        * `new_sponsor` - new sponsor of a claimable balance,
        * `former_sponsor` - former sponsor of a claimable balance.
    * `claimable_balance_sponsorship_removed` with the following fields:
        * `former_sponsor` - former sponsor of a claimable balance. 
    * `signer_sponsorship_created` with the following fields:
        * `signer` - signer being sponsored. 
        * `sponsor` - signer sponsor. 
    * `signer_sponsorship_updated` with the following fields:
        * `signer` - signer being sponsored. 
        * `former_sponsor` - the former sponsor of the signer. 
        * `new_sponsor` - the new sponsor of the signer. 
    * `signer_sponsorship_removed` with the following fields:
        * `former_sponsor` - former sponsor of a signer. 
