### PR TITLE
Update predicate fields to match the upcoming Horizon release.

### DIFF
--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -365,8 +365,8 @@ export namespace Horizon {
     and?: Predicate[];
     or?: Predicate[];
     not?: Predicate;
-    absBefore?: string;
-    relBefore?: string;
+    abs_before?: string;
+    rel_before?: string;
   }
 
   export interface Claimant {


### PR DESCRIPTION
Horizon 1.10 will change the fields in this PR to use underscore instead of camelcase 

See https://github.com/stellar/go/pull/3086