### PR TITLE
Don't test Adolfo

### DIFF
--- a/test/unit/server/claimable_balances.js
+++ b/test/unit/server/claimable_balances.js
@@ -1,6 +1,6 @@
 const MockAdapter = require('axios-mock-adapter');
 
-describe('Adolfo ClaimableBalanceCallBuilder', function() {
+describe('ClaimableBalanceCallBuilder', function() {
     beforeEach(function() {
         this.server = new StellarSdk.Server(
           'https://horizon-live.stellar.org:1337'


### PR DESCRIPTION
### What
Remove Adolfo as the type being tested in the claimable balance tests.

### Why
I'm pretty sure we don't need to test @abuiles 😄. Looks like it got accidentally committed.