### PR TITLE
Removed non-null constraint for manageData op values, added test

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -248,7 +248,7 @@ export namespace Utils {
       if (op.name === "web_auth_domain") {
         if (op.value === undefined) {
           throw new InvalidSep10ChallengeError(
-            "The transaction's operation values should not be null",
+            "'web_auth_domain' operation value should not be null",
           );
         }
         if (op.value.compare(Buffer.from(webAuthDomain))) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -245,13 +245,9 @@ export namespace Utils {
           "The transaction has operations that are unrecognized",
         );
       }
-      if (op.value === undefined) {
-        throw new InvalidSep10ChallengeError(
-          "The transaction's operation values should not be null",
-        );
-      }
       if (
         op.name === "web_auth_domain" &&
+        op.value &&
         op.value.compare(Buffer.from(webAuthDomain))
       ) {
         throw new InvalidSep10ChallengeError(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -245,14 +245,17 @@ export namespace Utils {
           "The transaction has operations that are unrecognized",
         );
       }
-      if (
-        op.name === "web_auth_domain" &&
-        op.value &&
-        op.value.compare(Buffer.from(webAuthDomain))
-      ) {
-        throw new InvalidSep10ChallengeError(
-          `'web_auth_domain' operation value does not match ${webAuthDomain}`,
-        );
+      if (op.name === "web_auth_domain") {
+        if (op.value === undefined) {
+          throw new InvalidSep10ChallengeError(
+            "The transaction's operation values should not be null",
+          );
+        }
+        if (op.value.compare(Buffer.from(webAuthDomain))) {
+          throw new InvalidSep10ChallengeError(
+            `'web_auth_domain' operation value does not match ${webAuthDomain}`,
+          );
+        }
       }
     }
 


### PR DESCRIPTION
@overcat caught a bug in the SEP-10 v3.1 commit that disallowed null/undefined values in subsequence ManageData operations within challenge transactions. This change updates the `readChallengeTx()` function to allow such cases and adds a test case to ensure it.