### PR TITLE
Release v8.1.1, updating stellar-base to expose CAP-35 to Typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 
+## [v8.1.1](https://github.com/stellar/js-stellar-sdk/compare/v8.1.0...v8.1.1)
+
+### Fix
+
+- Upgraded `js-stellar-base` package to version `^5.1.0` from `^5.0.0` to expose the Typescript hints for CAP-35 operations [(#TODO)](https://github.com/stellar/js-stellar-sdk/pull/TODO).
+
+
 ## [v8.1.0](https://github.com/stellar/js-stellar-sdk/compare/v8.0.0...v8.1.0)
 
 ### Update

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-sdk",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "stellar-sdk is a library for working with the Stellar Horizon server.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -137,7 +137,7 @@
     "eventsource": "^1.0.7",
     "lodash": "^4.17.11",
     "randombytes": "^2.1.0",
-    "stellar-base": "^5.0.0",
+    "stellar-base": "^5.1.0",
     "toml": "^2.3.0",
     "tslib": "^1.10.0",
     "urijs": "^1.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7777,10 +7777,10 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stellar-base@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-5.0.0.tgz#c1af4a077ebed6c2febb7bd9b576463fef6e3387"
-  integrity sha512-JQSGdMlqlZYXrggmle6Qa+0YOcrBa9Mt50YHil5474nFUnEr0BFcNjyVoEPG3Z7liujHeUq5NtkQi79xEto5YQ==
+stellar-base@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-5.1.0.tgz#7c2d2c9fe7ec8781df41514bc351e8c749888278"
+  integrity sha512-J0hdF2UGKlRmwaQCpL5IedetJMDBvxTmoFEnvwHMxZBeSNfGt3+pjLi+dghURiWyuBOF9ZeyS8lUBeOhy/tOpA==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^4.0.0"


### PR DESCRIPTION
 Mergeable once stellar/js-stellar-base#408 is merged.