### PR TITLE
Define the operation responses and new flags for CAP-35.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,7 +12,6 @@ module.exports = function(config) {
       "dist/stellar-sdk.js",
       "test/test-browser.js",
       "test/unit/**/*.js",
-      "test/integration/server_test.js",
     ],
 
     preprocessors: {

--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -118,6 +118,7 @@ export namespace Horizon {
     auth_immutable: boolean;
     auth_required: boolean;
     auth_revocable: boolean;
+    auth_clawback_enabled: boolean;
   }
   export interface AccountSigner {
     key: string;
@@ -172,6 +173,9 @@ export namespace Horizon {
     beginSponsoringFutureReserves = "begin_sponsoring_future_reserves",
     endSponsoringFutureReserves = "end_sponsoring_future_reserves",
     revokeSponsorship = "revoke_sponsorship",
+    clawback = "clawback",
+    clawbackClaimableBalance = "clawback_claimable_balance",
+    setTrustLineFlags = "set_trust_line_flags",
   }
   export enum OperationResponseTypeI {
     createAccount = 0,
@@ -193,6 +197,9 @@ export namespace Horizon {
     beginSponsoringFutureReserves = 16,
     endSponsoringFutureReserves = 17,
     revokeSponsorship = 18,
+    clawback = 19,
+    clawbackClaimableBalance = 20,
+    setTrustLineFlags = 21,
   }
   export interface BaseOperationResponse<
     T extends OperationResponseType = OperationResponseType,
@@ -315,10 +322,18 @@ export namespace Horizon {
     med_threshold?: number;
     high_threshold?: number;
     home_domain?: string;
-    set_flags: Array<1 | 2>;
-    set_flags_s: Array<"auth_required_flag" | "auth_revocable_flag">;
-    clear_flags: Array<1 | 2>;
-    clear_flags_s: Array<"auth_required_flag" | "auth_revocable_flag">;
+    set_flags: Array<1 | 2 | 4>;
+    set_flags_s: Array<
+      | "auth_required_flag"
+      | "auth_revocable_flag"
+      | "auth_clawback_enabled_flag"
+    >;
+    clear_flags: Array<1 | 2 | 4>;
+    clear_flags_s: Array<
+      | "auth_required_flag"
+      | "auth_revocable_flag"
+      | "auth_clawback_enabled_flag"
+    >;
   }
   export interface ChangeTrustOperationResponse
     extends BaseOperationResponse<
@@ -435,6 +450,39 @@ export namespace Horizon {
     trustline_asset?: string;
     signer_account_id?: string;
     signer_key?: string;
+  }
+
+  export interface ClawbackOperationResponse
+    extends BaseOperationResponse<
+      OperationResponseType.clawback,
+      OperationResponseTypeI.clawback
+    > {
+    asset_type: AssetType;
+    asset_code: string;
+    asset_issuer: string;
+    from: string;
+    amount: string;
+  }
+
+  export interface ClawbackClaimableBalanceOperationResponse
+    extends BaseOperationResponse<
+      OperationResponseType.clawbackClaimableBalance,
+      OperationResponseTypeI.clawbackClaimableBalance
+    > {
+    balance_id: string;
+  }
+
+  export interface SetTrustLineFlagsOperationResponse
+    extends BaseOperationResponse<
+      OperationResponseType.setTrustLineFlags,
+      OperationResponseTypeI.setTrustLineFlags
+    > {
+    asset_type: AssetType;
+    asset_code: string;
+    asset_issuer: string;
+    trustor: string;
+    set_flags: Array<1 | 2 | 4>;
+    clear_flags: Array<1 | 2 | 4>;
   }
 
   export interface ResponseCollection<T extends BaseResponse = BaseResponse> {

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -272,7 +272,9 @@ describe('server.js non-transaction tests', function() {
       },
       "flags": {
         "auth_required": false,
-        "auth_revocable": false
+        "auth_revocable": false,
+        "auth_immutable": false,
+        "auth_clawback_enabled": false
       },
       "balances": [
         {
@@ -333,6 +335,7 @@ describe('server.js non-transaction tests', function() {
           expect(response.payments).to.be.function;
           expect(response.effects).to.be.function;
           expect(response.offers).to.be.function;
+          expect(Object.keys(response.flags).length).to.be.equal(4);
           // AccountResponse methods
           expect(response.sequenceNumber()).to.be.equal('5387216134078475');
           expect(response.sequence).to.be.equal('5387216134078475');
@@ -832,7 +835,7 @@ describe('server.js non-transaction tests', function() {
             "pfzlCzxO0N4pJsCGHhAhbcVR+K4fJZpOOuUCyHhxHhHG2IWk34H3vFQMCrGH+GKivmCokoiNAaiSg6+gniN0CQ=="
           ]
         };
-        
+
         this.axiosMock
           .expects('get')
           .withArgs(
@@ -1088,7 +1091,9 @@ describe('server.js non-transaction tests', function() {
           },
           flags: {
             auth_required: false,
-            auth_revocable: false
+            auth_revocable: false,
+            auth_immutable: false,
+            auth_clawback_enabled: false
           },
           balances: [
             {
@@ -1189,7 +1194,8 @@ describe('server.js non-transaction tests', function() {
                 flags: {
                   auth_required: false,
                   auth_revocable: false,
-                  auth_immutable: false
+                  auth_immutable: false,
+                  auth_clawback_enabled: false
                 },
                 balances: [
                   {
@@ -1312,7 +1318,8 @@ describe('server.js non-transaction tests', function() {
                 flags: {
                   auth_required: false,
                   auth_revocable: false,
-                  auth_immutable: false
+                  auth_immutable: false,
+                  auth_clawback_enabled: false
                 },
                 balances: [
                   {
@@ -1435,7 +1442,8 @@ describe('server.js non-transaction tests', function() {
                 flags: {
                   auth_required: false,
                   auth_revocable: false,
-                  auth_immutable: false
+                  auth_immutable: false,
+                  auth_clawback_enabled: false
                 },
                 balances: [
                   {
@@ -1578,7 +1586,7 @@ describe('server.js non-transaction tests', function() {
           "last_modified_ledger": 28285404,
           "last_modified_time": "2020-02-18T17:00:56Z"
         };
-  
+
         this.axiosMock
           .expects('get')
           .withArgs(
@@ -3160,6 +3168,8 @@ describe('server.js non-transaction tests', function() {
                 flags: {
                   auth_required: false,
                   auth_revocable: false,
+                  auth_immutable: false,
+                  auth_clawback_enabled: false
                 },
               },
             ]
@@ -3235,6 +3245,8 @@ describe('server.js non-transaction tests', function() {
                 flags: {
                   auth_required: false,
                   auth_revocable: false,
+                  auth_immutable: false,
+                  auth_clawback_enabled: false
                 },
               },
             ]
@@ -3312,6 +3324,8 @@ describe('server.js non-transaction tests', function() {
                 flags: {
                   auth_required: false,
                   auth_revocable: false,
+                  auth_immutable: false,
+                  auth_clawback_enabled: false
                 },
               },
             ]
@@ -3388,6 +3402,8 @@ describe('server.js non-transaction tests', function() {
               flags: {
                 auth_required: true,
                 auth_revocable: true,
+                auth_immutable: false,
+                auth_clawback_enabled: false
               },
             },
           ]


### PR DESCRIPTION
Exposes CAP-35 support:
 - Updates the `/accounts/:id` response with the new `auth_clawback_enabled` flag
 - Defines operation responses for `clawback`, `clawbackClaimableBalance`, and `setTrustLineFlags`
 - Updates SetOptions to allow setting & clearing the `auth_clawback_enabled` flag
