### PR TITLE
Issue #299: Types provided for effects, with Go Package being the ref…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ A breaking change will get clearly marked in this log.
 
 - Added TransactionCallBuilder.forClaimableBalance(), and OperationCallBuilder.forClaimableBalance().
 - Added support for new `accounts`, `balances`, `claimable_balances_amount`, and `num_claimable_balances` fields on Assets.
+- Added types for all Effects supported as an enum, and moved Trade, Asset, Offer, and Account types to separate files. [(#635)](https://github.com/stellar/js-stellar-sdk/pull/635)
 
 
 ## [v8.1.1](https://github.com/stellar/js-stellar-sdk/compare/v8.1.0...v8.1.1)

--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -1,9 +1,58 @@
-import { Asset, AssetType } from "stellar-base";
+import { Asset } from "stellar-base";
 import { Omit } from "utility-types";
 import { Horizon } from "./horizon_api";
 
+// more types
+import { AccountRecordSigners as AccountRecordSignersType } from "./types/account";
+import { AssetRecord as AssetRecordType } from "./types/assets";
+import {
+  AccountCreated,
+  // Types of effects
+  AccountCredited,
+  AccountDebited,
+  AccountFlagsUpdated,
+  AccountHomeDomainUpdated,
+  AccountSponsporshipCreated,
+  AccountSponsporshipRemoved,
+  AccountSponsporshipUpdated,
+  AccountThresholdsUpdated,
+  BaseEffectRecord,
+  ClaimableBalanceClaimantCreated,
+  ClaimableBalanceClaimed,
+  ClaimableBalanceCreated,
+  ClaimableBalanceSponsorshipCreated,
+  ClaimableBalanceSponsorshipRemoved,
+  ClaimableBalanceSponsorshipUpdated,
+  DataCreated,
+  DataRemoved,
+  DataUpdated,
+  DateSponsporshipCreated,
+  DateSponsporshipRemoved,
+  DateSponsporshipUpdated,
+  SequenceBumped,
+  SignerCreated,
+  SignerRemoved,
+  SignerSponsorshipCreated,
+  SignerSponsorshipRemoved,
+  SignerSponsorshipUpdated,
+  SignerUpdated,
+  TrustlineAuthorized,
+  TrustlineAutorizedToMaintainLiabilities,
+  TrustlineCreated,
+  TrustlineDeautorized,
+  TrustlineRemoved,
+  TrustlineSponsporshipCreated,
+  TrustlineSponsporshipRemoved,
+  TrustlineSponsporshipUpdated,
+  TrustlineUpdated,
+} from "./types/effects";
+import { OfferRecord as OfferRecordType } from "./types/offer";
+
 /* tslint:disable-next-line: no-namespace */
 export namespace ServerApi {
+  export type OfferRecord = OfferRecordType;
+  export type AccountRecordSigners = AccountRecordSignersType;
+  export type AssetRecord = AssetRecordType;
   export interface CollectionPage<
     T extends Horizon.BaseResponse = Horizon.BaseResponse
   > {
@@ -25,10 +74,54 @@ export namespace ServerApi {
     T extends Horizon.BaseResponse = Horizon.BaseResponse
   > = (options?: CallFunctionTemplateOptions) => Promise<CollectionPage<T>>;
 
-  export interface AccountRecordSigners {
-    key: string;
-    weight: number;
-    type: string;
+  type BaseEffectRecordFromTypes =
+    | AccountCreated
+    | AccountCredited
+    | AccountDebited
+    | AccountThresholdsUpdated
+    | AccountHomeDomainUpdated
+    | AccountFlagsUpdated
+    | DataCreated
+    | DataRemoved
+    | DataUpdated
+    | SequenceBumped
+    | SignerCreated
+    | SignerRemoved
+    | SignerUpdated
+    | TrustlineCreated
+    | TrustlineRemoved
+    | TrustlineUpdated
+    | TrustlineAuthorized
+    | TrustlineDeautorized
+    | TrustlineAutorizedToMaintainLiabilities
+    | ClaimableBalanceCreated
+    | ClaimableBalanceClaimed
+    | ClaimableBalanceClaimantCreated
+    | AccountSponsporshipCreated
+    | AccountSponsporshipRemoved
+    | AccountSponsporshipUpdated
+    | TrustlineSponsporshipCreated
+    | TrustlineSponsporshipUpdated
+    | TrustlineSponsporshipRemoved
+    | DateSponsporshipCreated
+    | DateSponsporshipUpdated
+    | DateSponsporshipRemoved
+    | ClaimableBalanceSponsorshipCreated
+    | ClaimableBalanceSponsorshipRemoved
+    | ClaimableBalanceSponsorshipUpdated
+    | SignerSponsorshipCreated
+    | SignerSponsorshipUpdated
+    | SignerSponsorshipRemoved;
+
+  export type EffectRecord = BaseEffectRecordFromTypes & EffectRecordMethods;
+  export interface ClaimableBalanceRecord extends Horizon.BaseResponse {
+    id: string;
+    paging_token: string;
+    asset: string;
+    amount: string;
+    sponsor?: string;
+    last_modified_ledger: number;
+    claimants: Horizon.Claimant[];
   }
   export interface AccountRecord extends Horizon.BaseResponse {
     id: string;
@@ -56,110 +149,11 @@ export namespace ServerApi {
     payments: CallCollectionFunction<PaymentOperationRecord>;
     trades: CallCollectionFunction<TradeRecord>;
   }
-
-  export interface ClaimableBalanceRecord extends Horizon.BaseResponse {
-    id: string;
-    paging_token: string;
-    asset: string;
-    amount: string;
-    sponsor?: string;
-    last_modified_ledger: number;
-    claimants: Horizon.Claimant[];
-  }
-
-  export interface EffectRecord extends Horizon.BaseResponse {
-    account: string;
-    paging_token: string;
-    type_i: string;
-    type: string;
-    created_at: string;
-    id: string;
-
-    // account_debited / credited / trustline_created
-    amount?: any;
-    asset_type?: string;
-    asset_code?: string;
-    asset_issuer?: string;
-
-    // trustline_created / removed
-    limit?: string;
-
-    // signer_created
-    public_key?: string;
-
-    // trade
-    offer_id?: number | string;
-    bought_amount?: string;
-    bought_asset_type?: string;
-    bought_asset_code?: string;
-    bought_asset_issuer?: string;
-    sold_amount?: string;
-    sold_asset_type?: string;
-    sold_asset_code?: string;
-    sold_asset_issuer?: string;
-
-    // account_created
-    starting_balance?: string;
-
-    // These were retrieved from the go repo, not through direct observation
-    // so they could be wrong!
-
-    // account thresholds updated
-    low_threshold?: number;
-    med_threshold?: number;
-    high_threshold?: number;
-
-    // home domain updated
-    home_domain?: string;
-
-    // account flags updated
-    auth_required_flag?: boolean;
-    auth_revokable_flag?: boolean;
-
-    // seq bumped
-    new_seq?: number | string;
-
-    // signer created / removed / updated
-    weight?: number;
-    key?: string;
-
-    // trustline authorized / deauthorized
-    trustor?: string;
-
-    // claimable_balance_created
-    // claimable_balance_claimant_created
-    // claimable_balance_claimed
-    balance_id?: string;
-    asset?: string;
-    predicate?: Horizon.Predicate;
-
-    // account_sponsorship_created
-    // trustline_sponsorship_created
-    // claimable_balance_sponsorship_created
-    // signer_sponsorship_created
-    // data_sponsorship_created
-    sponsor?: string;
-    signer?: string;
-    data_name?: string;
-
-    // account_sponsorship_updated
-    // account_sponsorship_removed
-    // trustline_sponsorship_updated
-    // trustline_sponsorship_removed
-    // claimable_balance_sponsorship_updated
-    // claimable_balance_sponsorship_removed
-    // signer_sponsorship_updated
-    // signer_sponsorship_removed
-    // data_sponsorship_updated
-    // data_sponsorship_removed
-    new_sponsor?: string;
-    former_sponsor?: string;
-
+  interface EffectRecordMethods {
     operation?: CallFunction<OperationRecord>;
     precedes?: CallFunction<EffectRecord>;
     succeeds?: CallFunction<EffectRecord>;
   }
-
   export interface LedgerRecord extends Horizon.BaseResponse {
     id: string;
     paging_token: string;
@@ -186,26 +180,6 @@ export namespace ServerApi {
     transactions: CallCollectionFunction<TransactionRecord>;
   }
 
-  export interface OfferAsset {
-    asset_type: AssetType;
-    asset_code?: string;
-    asset_issuer?: string;
-  }
-
-  export interface OfferRecord extends Horizon.BaseResponse {
-    id: number | string;
-    paging_token: string;
-    seller: string;
-    selling: OfferAsset;
-    buying: OfferAsset;
-    amount: string;
-    price_r: Horizon.PriceRShorthand;
-    price: string;
-    last_modified_ledger: number;
-    last_modified_time: string;
-    sponsor?: string;
-  }
-
   import OperationResponseType = Horizon.OperationResponseType;
   import OperationResponseTypeI = Horizon.OperationResponseTypeI;
   export interface BaseOperationRecord<
@@ -218,7 +192,6 @@ export namespace ServerApi {
     effects: CallCollectionFunction<EffectRecord>;
     transaction: CallFunction<TransactionRecord>;
   }
-
   export interface CreateAccountOperationRecord
     extends BaseOperationRecord<
         OperationResponseType.createAccount,
@@ -350,7 +323,6 @@ export namespace ServerApi {
     | BeginSponsoringFutureReservesOperationRecord
     | EndSponsoringFutureReservesOperationRecord
     | RevokeSponsorshipOperationRecord;
-
   export interface TradeRecord extends Horizon.BaseResponse {
     id: string;
     paging_token: string;
@@ -374,7 +346,6 @@ export namespace ServerApi {
     counter: CallFunction<AccountRecord>;
     operation: CallFunction<OperationRecord>;
   }
-
   export interface TransactionRecord
     extends Omit<Horizon.TransactionResponse, "ledger"> {
     ledger_attr: Horizon.TransactionResponse["ledger"];
@@ -387,21 +358,6 @@ export namespace ServerApi {
     self: CallFunction<TransactionRecord>;
     succeeds: CallFunction<TransactionRecord>;
   }
-
-  export interface AssetRecord extends Horizon.BaseResponse {
-    asset_type: AssetType.credit4 | AssetType.credit12;
-    asset_code: string;
-    asset_issuer: string;
-    paging_token: string;
-    accounts: Horizon.AssetAccounts;
-    num_claimable_balances: number;
-    balances: Horizon.AssetBalances;
-    claimable_balances_amount: string;
-    amount: string;
-    num_accounts: number;
-    flags: Horizon.Flags;
-  }
-
   export interface OrderbookRecord extends Horizon.BaseResponse {
     bids: Array<{
       price_r: {
@@ -422,7 +378,6 @@ export namespace ServerApi {
     base: Asset;
     counter: Asset;
   }
-
   export interface PaymentPathRecord extends Horizon.BaseResponse {
     path: Array<{
       asset_code: string;

--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -7,7 +7,6 @@ import { AccountRecordSigners as AccountRecordSignersType } from "./types/accoun
 import { AssetRecord as AssetRecordType } from "./types/assets";
 import {
   AccountCreated,
-  // Types of effects
   AccountCredited,
   AccountDebited,
   AccountFlagsUpdated,
@@ -16,7 +15,6 @@ import {
   AccountSponsporshipRemoved,
   AccountSponsporshipUpdated,
   AccountThresholdsUpdated,
-  BaseEffectRecord,
   ClaimableBalanceClaimantCreated,
   ClaimableBalanceClaimed,
   ClaimableBalanceCreated,

--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -53,8 +53,8 @@ export namespace ServerApi {
     | Effects.TrustlineRemoved
     | Effects.TrustlineUpdated
     | Effects.TrustlineAuthorized
-    | Effects.TrustlineDeautorized
-    | Effects.TrustlineAutorizedToMaintainLiabilities
+    | Effects.TrustlineDeauthorized
+    | Effects.TrustlineAuthorizedToMaintainLiabilities
     | Effects.ClaimableBalanceCreated
     | Effects.ClaimableBalanceClaimed
     | Effects.ClaimableBalanceClaimantCreated

--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -5,45 +5,7 @@ import { Horizon } from "./horizon_api";
 // more types
 import { AccountRecordSigners as AccountRecordSignersType } from "./types/account";
 import { AssetRecord as AssetRecordType } from "./types/assets";
-import {
-  AccountCreated,
-  AccountCredited,
-  AccountDebited,
-  AccountFlagsUpdated,
-  AccountHomeDomainUpdated,
-  AccountSponsporshipCreated,
-  AccountSponsporshipRemoved,
-  AccountSponsporshipUpdated,
-  AccountThresholdsUpdated,
-  ClaimableBalanceClaimantCreated,
-  ClaimableBalanceClaimed,
-  ClaimableBalanceCreated,
-  ClaimableBalanceSponsorshipCreated,
-  ClaimableBalanceSponsorshipRemoved,
-  ClaimableBalanceSponsorshipUpdated,
-  DataCreated,
-  DataRemoved,
-  DataUpdated,
-  DateSponsporshipCreated,
-  DateSponsporshipRemoved,
-  DateSponsporshipUpdated,
-  SequenceBumped,
-  SignerCreated,
-  SignerRemoved,
-  SignerSponsorshipCreated,
-  SignerSponsorshipRemoved,
-  SignerSponsorshipUpdated,
-  SignerUpdated,
-  TrustlineAuthorized,
-  TrustlineAutorizedToMaintainLiabilities,
-  TrustlineCreated,
-  TrustlineDeautorized,
-  TrustlineRemoved,
-  TrustlineSponsporshipCreated,
-  TrustlineSponsporshipRemoved,
-  TrustlineSponsporshipUpdated,
-  TrustlineUpdated,
-} from "./types/effects";
+import * as Effects from "./types/effects";
 import { OfferRecord as OfferRecordType } from "./types/offer";
 import { Trade } from "./types/trade";
 
@@ -74,43 +36,43 @@ export namespace ServerApi {
   > = (options?: CallFunctionTemplateOptions) => Promise<CollectionPage<T>>;
 
   type BaseEffectRecordFromTypes =
-    | AccountCreated
-    | AccountCredited
-    | AccountDebited
-    | AccountThresholdsUpdated
-    | AccountHomeDomainUpdated
-    | AccountFlagsUpdated
-    | DataCreated
-    | DataRemoved
-    | DataUpdated
-    | SequenceBumped
-    | SignerCreated
-    | SignerRemoved
-    | SignerUpdated
-    | TrustlineCreated
-    | TrustlineRemoved
-    | TrustlineUpdated
-    | TrustlineAuthorized
-    | TrustlineDeautorized
-    | TrustlineAutorizedToMaintainLiabilities
-    | ClaimableBalanceCreated
-    | ClaimableBalanceClaimed
-    | ClaimableBalanceClaimantCreated
-    | AccountSponsporshipCreated
-    | AccountSponsporshipRemoved
-    | AccountSponsporshipUpdated
-    | TrustlineSponsporshipCreated
-    | TrustlineSponsporshipUpdated
-    | TrustlineSponsporshipRemoved
-    | DateSponsporshipCreated
-    | DateSponsporshipUpdated
-    | DateSponsporshipRemoved
-    | ClaimableBalanceSponsorshipCreated
-    | ClaimableBalanceSponsorshipRemoved
-    | ClaimableBalanceSponsorshipUpdated
-    | SignerSponsorshipCreated
-    | SignerSponsorshipUpdated
-    | SignerSponsorshipRemoved
+    | Effects.AccountCreated
+    | Effects.AccountCredited
+    | Effects.AccountDebited
+    | Effects.AccountThresholdsUpdated
+    | Effects.AccountHomeDomainUpdated
+    | Effects.AccountFlagsUpdated
+    | Effects.DataCreated
+    | Effects.DataRemoved
+    | Effects.DataUpdated
+    | Effects.SequenceBumped
+    | Effects.SignerCreated
+    | Effects.SignerRemoved
+    | Effects.SignerUpdated
+    | Effects.TrustlineCreated
+    | Effects.TrustlineRemoved
+    | Effects.TrustlineUpdated
+    | Effects.TrustlineAuthorized
+    | Effects.TrustlineDeautorized
+    | Effects.TrustlineAutorizedToMaintainLiabilities
+    | Effects.ClaimableBalanceCreated
+    | Effects.ClaimableBalanceClaimed
+    | Effects.ClaimableBalanceClaimantCreated
+    | Effects.AccountSponsorshipCreated
+    | Effects.AccountSponsorshipRemoved
+    | Effects.AccountSponsorshipUpdated
+    | Effects.TrustlineSponsorshipCreated
+    | Effects.TrustlineSponsorshipUpdated
+    | Effects.TrustlineSponsorshipRemoved
+    | Effects.DateSponsorshipCreated
+    | Effects.DateSponsorshipUpdated
+    | Effects.DateSponsorshipRemoved
+    | Effects.ClaimableBalanceSponsorshipCreated
+    | Effects.ClaimableBalanceSponsorshipRemoved
+    | Effects.ClaimableBalanceSponsorshipUpdated
+    | Effects.SignerSponsorshipCreated
+    | Effects.SignerSponsorshipUpdated
+    | Effects.SignerSponsorshipRemoved
     | Trade;
 
   export type EffectRecord = BaseEffectRecordFromTypes & EffectRecordMethods;

--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -45,6 +45,7 @@ import {
   TrustlineUpdated,
 } from "./types/effects";
 import { OfferRecord as OfferRecordType } from "./types/offer";
+import { Trade } from "./types/trade";
 
 /* tslint:disable-next-line: no-namespace */
 export namespace ServerApi {
@@ -109,7 +110,8 @@ export namespace ServerApi {
     | ClaimableBalanceSponsorshipUpdated
     | SignerSponsorshipCreated
     | SignerSponsorshipUpdated
-    | SignerSponsorshipRemoved;
+    | SignerSponsorshipRemoved
+    | Trade;
 
   export type EffectRecord = BaseEffectRecordFromTypes & EffectRecordMethods;
   export interface ClaimableBalanceRecord extends Horizon.BaseResponse {

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -1,0 +1,5 @@
+export interface AccountRecordSigners {
+  key: string;
+  weight: number;
+  type: string;
+}

--- a/src/types/assets.ts
+++ b/src/types/assets.ts
@@ -1,0 +1,22 @@
+import { AssetType } from "stellar-base";
+import { Horizon } from "./../horizon_api";
+
+export interface OfferAsset {
+  asset_type: AssetType;
+  asset_code?: string;
+  asset_issuer?: string;
+}
+
+export interface AssetRecord extends Horizon.BaseResponse {
+  asset_type: AssetType.credit4 | AssetType.credit12;
+  asset_code: string;
+  asset_issuer: string;
+  paging_token: string;
+  accounts: Horizon.AssetAccounts;
+  num_claimable_balances: number;
+  balances: Horizon.AssetBalances;
+  claimable_balances_amount: string;
+  amount: string;
+  num_accounts: number;
+  flags: Horizon.Flags;
+}

--- a/src/types/assets.ts
+++ b/src/types/assets.ts
@@ -1,12 +1,5 @@
 import { AssetType } from "stellar-base";
 import { Horizon } from "./../horizon_api";
-
-export interface OfferAsset {
-  asset_type: AssetType;
-  asset_code?: string;
-  asset_issuer?: string;
-}
-
 export interface AssetRecord extends Horizon.BaseResponse {
   asset_type: AssetType.credit4 | AssetType.credit12;
   asset_code: string;

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -168,52 +168,51 @@ interface SponsershipFields {
   new_sponsor: string;
   former_sponsor: string;
 }
-interface AccountSponsporshipEvents
+interface AccountSponsorshipEvents
   extends BaseEffectRecord,
     SponsershipFields {}
 
-export type AccountSponsporshipCreated = Omit<
-  AccountSponsporshipEvents,
+export type AccountSponsorshipCreated = Omit<
+  AccountSponsorshipEvents,
   "new_sponsor" | "former_sponsor"
 > & { type_i: EffectType.account_sponsorship_created };
-export type AccountSponsporshipUpdated = Omit<
-  AccountSponsporshipEvents,
+export type AccountSponsorshipUpdated = Omit<
+  AccountSponsorshipEvents,
   "sponsor"
 > & { type_i: EffectType.account_sponsorship_updated };
-export type AccountSponsporshipRemoved = Omit<
-  AccountSponsporshipEvents,
+export type AccountSponsorshipRemoved = Omit<
+  AccountSponsorshipEvents,
   "new_sponsor" | "sponsor"
 > & { type_i: EffectType.account_sponsorship_removed };
-interface TrustlineSponsporshipEvents
+interface TrustlineSponsorshipEvents
   extends BaseEffectRecord,
     SponsershipFields {
   asset: string;
 }
-export type TrustlineSponsporshipCreated = Omit<
-  TrustlineSponsporshipEvents,
+export type TrustlineSponsorshipCreated = Omit<
+  TrustlineSponsorshipEvents,
   "new_sponsor" | "former_sponsor"
 > & { type_i: EffectType.trustline_sponsorship_created };
-export type TrustlineSponsporshipUpdated = Omit<
-  TrustlineSponsporshipEvents,
+export type TrustlineSponsorshipUpdated = Omit<
+  TrustlineSponsorshipEvents,
   "sponsor"
 > & { type_i: EffectType.trustline_sponsorship_updated };
-export type TrustlineSponsporshipRemoved = Omit<
-  TrustlineSponsporshipEvents,
+export type TrustlineSponsorshipRemoved = Omit<
+  TrustlineSponsorshipEvents,
   "new_sponsor" | "sponsor"
 > & { type_i: EffectType.trustline_sponsorship_removed };
-interface DataSponsporshipEvents extends BaseEffectRecord, SponsershipFields {
+interface DataSponsorshipEvents extends BaseEffectRecord, SponsershipFields {
   data_name: string;
 }
-export type DateSponsporshipCreated = Omit<
-  DataSponsporshipEvents,
+export type DateSponsorshipCreated = Omit<
+  DataSponsorshipEvents,
   "new_sponsor" | "former_sponsor"
 > & { type_i: EffectType.data_sponsorship_created };
-export type DateSponsporshipUpdated = Omit<
-  DataSponsporshipEvents,
-  "sponsor"
-> & { type_i: EffectType.data_sponsorship_updated };
-export type DateSponsporshipRemoved = Omit<
-  DataSponsporshipEvents,
+export type DateSponsorshipUpdated = Omit<DataSponsorshipEvents, "sponsor"> & {
+  type_i: EffectType.data_sponsorship_updated;
+};
+export type DateSponsorshipRemoved = Omit<
+  DataSponsorshipEvents,
   "new_sponsor" | "sponsor"
 > & { type_i: EffectType.data_sponsorship_removed };
 interface ClaimableBalanceSponsorshipEvents

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -1,5 +1,5 @@
 import { Horizon } from "./../horizon_api";
-import { OfferAsset } from "./assets";
+import { OfferAsset } from "./offer";
 
 // Reference: GO SDK https://github.com/stellar/go/blob/ec5600bd6b2b6900d26988ff670b9ca7992313b8/services/horizon/internal/resourceadapter/effects.go
 export enum EffectType {
@@ -140,11 +140,11 @@ export interface TrustlineAuthorized extends BaseEffectRecord {
   asset_code: OfferAsset["asset_code"];
   trustor: string;
 }
-export interface TrustlineDeautorized
+export interface TrustlineDeauthorized
   extends Omit<TrustlineAuthorized, "type_i"> {
   type_i: EffectType.trustline_deauthorized;
 }
-export interface TrustlineAutorizedToMaintainLiabilities
+export interface TrustlineAuthorizedToMaintainLiabilities
   extends Omit<TrustlineAuthorized, "type_i"> {
   type_i: EffectType.trustline_authorized_to_maintain_liabilities;
 }

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -3,213 +3,237 @@ import { OfferAsset } from "./assets";
 
 // Reference: GO SDK https://github.com/stellar/go/blob/ec5600bd6b2b6900d26988ff670b9ca7992313b8/services/horizon/internal/resourceadapter/effects.go
 export enum EffectType {
-  "account_created",
-  "account_removed",
-  "account_credited",
-  "account_debited",
-  "account_thresholds_updated",
-  "account_home_domain_updated",
-  "account_flags_updated",
-  "account_inflation_destination_updated",
-  "signer_created",
-  "signer_removed",
-  "signer_updated",
-  "trustline_created",
-  "trustline_removed",
-  "trustline_updated",
-  "trustline_authorized",
-  "trustline_authorized_to_maintain_liabilities",
-  "trustline_deauthorized",
-  "trustline_flags_updated",
-  "offer_created",
-  "offer_removed",
-  "offer_updated",
-  "trade",
-  "data_created",
-  "data_removed",
-  "data_updated",
-  "sequence_bumped",
-  "claimable_balance_created",
-  "claimable_balance_claimant_created",
-  "claimable_balance_claimed",
-  "account_sponsorship_created",
-  "account_sponsorship_updated",
-  "account_sponsorship_removed",
-  "trustline_sponsorship_created",
-  "trustline_sponsorship_updated",
-  "trustline_sponsorship_removed",
-  "data_sponsorship_created",
-  "data_sponsorship_updated",
-  "data_sponsorship_removed",
-  "claimable_balance_sponsorship_created",
-  "claimable_balance_sponsorship_updated",
-  "claimable_balance_sponsorship_removed",
-  "signer_sponsorship_created",
-  "signer_sponsorship_updated",
-  "signer_sponsorship_removed",
-  "claimable_balance_clawed_back",
+  // account effects
+  account_created = 0,
+  account_removed = 1,
+  account_credited = 2,
+  account_debited = 3,
+  account_thresholds_updated = 4,
+  account_home_domain_updated = 5,
+  account_flags_updated = 6,
+  account_inflation_destination_updated = 7,
+  // signer effects
+  signer_created = 10,
+  signer_removed = 11,
+  signer_updated = 12,
+  // trustline effects
+  trustline_created = 20,
+  trustline_removed = 21,
+  trustline_updated = 22,
+  trustline_authorized = 23,
+  trustline_deauthorized = 24,
+  trustline_authorized_to_maintain_liabilities = 25, // deprecated, use trustline_flags_updated
+  trustline_flags_updated = 26,
+  // trading effects
+  offer_created = 30,
+  offer_removed = 31,
+  offer_updated = 32,
+  trade = 33,
+  // data effects
+  data_created = 40,
+  data_removed = 41,
+  data_updated = 42,
+  sequence_bumped = 43,
+  // claimable balance effects
+  claimable_balance_created = 50,
+  claimable_balance_claimant_created = 51,
+  claimable_balance_claimed = 52,
+  // sponsorship effects
+  account_sponsorship_created = 60,
+  account_sponsorship_updated = 61,
+  account_sponsorship_removed = 62,
+  trustline_sponsorship_created = 63,
+  trustline_sponsorship_updated = 64,
+  trustline_sponsorship_removed = 65,
+  data_sponsorship_created = 66,
+  data_sponsorship_updated = 67,
+  data_sponsorship_removed = 68,
+  claimable_balance_sponsorship_created = 69,
+  claimable_balance_sponsorship_updated = 70,
+  claimable_balance_sponsorship_removed = 71,
+  signer_sponsorship_created = 72,
+  signer_sponsorship_updated = 73,
+  signer_sponsorship_removed = 74,
+  claimable_balance_clawed_back = 80,
 }
-
 export interface BaseEffectRecord extends Horizon.BaseResponse {
   id: string;
   account: string;
   paging_token: string;
-  type_i: string;
-  type: EffectType;
+  type_i: EffectType;
+  type: string;
   created_at: string;
 }
-
 export interface AccountCreated extends BaseEffectRecord {
+  type_i: EffectType.account_created;
   starting_balance: string;
 }
-
 export interface AccountCredited extends BaseEffectRecord, OfferAsset {
+  type_i: EffectType.account_credited;
   amount: string;
 }
-
-export type AccountDebited = AccountCredited;
-
+export interface AccountDebited extends BaseEffectRecord {
+  type_i: EffectType.account_debited;
+  amount: string;
+}
 export interface AccountThresholdsUpdated extends BaseEffectRecord {
+  type_i: EffectType.account_thresholds_updated;
   low_threshold: number;
   med_threshold: number;
   high_threshold: number;
 }
-
 export interface AccountHomeDomainUpdated extends BaseEffectRecord {
+  type_i: EffectType.account_home_domain_updated;
   home_domain: string;
 }
-
 export interface AccountFlagsUpdated extends BaseEffectRecord {
+  type_i: EffectType.account_flags_updated;
   auth_required_flag: boolean;
   auth_revokable_flag: boolean;
 }
-
 interface DataEvents extends BaseEffectRecord {
   name: boolean;
   value: boolean;
 }
-
-export type DataCreated = DataEvents;
-export type DataUpdated = DataEvents;
-export type DataRemoved = DataEvents;
-
+export interface DataCreated extends DataEvents {
+  type_i: EffectType.data_created;
+}
+export interface DataUpdated extends DataEvents {
+  type_i: EffectType.data_updated;
+}
+export interface DataRemoved extends DataEvents {
+  type_i: EffectType.data_removed;
+}
 export interface SequenceBumped extends BaseEffectRecord {
+  type_i: EffectType.sequence_bumped;
   new_seq: number | string;
 }
-
 interface SignerEvents extends BaseEffectRecord {
   weight: number;
   key: string;
   public_key: string;
 }
-
-export type SignerCreated = SignerEvents;
-export type SignerRemoved = SignerEvents;
-export type SignerUpdated = SignerEvents;
-
+export interface SignerCreated extends SignerEvents {
+  type_i: EffectType.signer_created;
+}
+export interface SignerRemoved extends SignerEvents {
+  type_i: EffectType.signer_removed;
+}
+export interface SignerUpdated extends SignerEvents {
+  type_i: EffectType.signer_updated;
+}
 interface TrustlineEvents extends BaseEffectRecord, OfferAsset {
   limit: string;
 }
-
-export type TrustlineCreated = TrustlineEvents;
-export type TrustlineRemoved = TrustlineEvents;
-export type TrustlineUpdated = TrustlineEvents;
-
+export interface TrustlineCreated extends TrustlineEvents {
+  type_i: EffectType.trustline_created;
+}
+export interface TrustlineRemoved extends TrustlineEvents {
+  type_i: EffectType.trustline_removed;
+}
+export interface TrustlineUpdated extends TrustlineEvents {
+  type_i: EffectType.trustline_updated;
+}
 export interface TrustlineAuthorized extends BaseEffectRecord {
+  type_i: EffectType.trustline_authorized;
   asset_type: OfferAsset["asset_type"];
   asset_code: OfferAsset["asset_code"];
   trustor: string;
 }
-
-export type TrustlineDeautorized = TrustlineAuthorized;
-export type TrustlineAutorizedToMaintainLiabilities = TrustlineAuthorized;
-
+export interface TrustlineDeautorized
+  extends Omit<TrustlineAuthorized, "type_i"> {
+  type_i: EffectType.trustline_deauthorized;
+}
+export interface TrustlineAutorizedToMaintainLiabilities
+  extends Omit<TrustlineAuthorized, "type_i"> {
+  type_i: EffectType.trustline_authorized_to_maintain_liabilities;
+}
 export interface ClaimableBalanceCreated extends BaseEffectRecord {
+  type_i: EffectType.claimable_balance_created;
   amount: string;
-  balance_id: string;
+  balance_type_i: string;
   asset: string;
 }
-
-export type ClaimableBalanceClaimed = ClaimableBalanceCreated;
-export interface ClaimableBalanceClaimantCreated
-  extends ClaimableBalanceCreated {
-  predicate: Horizon.Predicate;
+export interface ClaimableBalanceClaimed
+  extends Omit<ClaimableBalanceCreated, "type_i"> {
+  type_i: EffectType.claimable_balance_claimed;
 }
 
+export interface ClaimableBalanceClaimantCreated
+  extends Omit<ClaimableBalanceCreated, "type_i"> {
+  type_i: EffectType.claimable_balance_claimant_created;
+}
 interface SponsershipFields {
   sponsor: string;
   new_sponsor: string;
   former_sponsor: string;
 }
-
 interface AccountSponsporshipEvents
   extends BaseEffectRecord,
     SponsershipFields {}
+
 export type AccountSponsporshipCreated = Omit<
   AccountSponsporshipEvents,
   "new_sponsor" | "former_sponsor"
->;
+> & { type_i: EffectType.account_sponsorship_created };
 export type AccountSponsporshipUpdated = Omit<
   AccountSponsporshipEvents,
   "sponsor"
->;
+> & { type_i: EffectType.account_sponsorship_updated };
 export type AccountSponsporshipRemoved = Omit<
   AccountSponsporshipEvents,
   "new_sponsor" | "sponsor"
->;
-
+> & { type_i: EffectType.account_sponsorship_removed };
 interface TrustlineSponsporshipEvents
   extends BaseEffectRecord,
     SponsershipFields {
   asset: string;
 }
-
 export type TrustlineSponsporshipCreated = Omit<
   TrustlineSponsporshipEvents,
   "new_sponsor" | "former_sponsor"
->;
+> & { type_i: EffectType.trustline_sponsorship_created };
 export type TrustlineSponsporshipUpdated = Omit<
   TrustlineSponsporshipEvents,
   "sponsor"
->;
+> & { type_i: EffectType.trustline_sponsorship_updated };
 export type TrustlineSponsporshipRemoved = Omit<
   TrustlineSponsporshipEvents,
   "new_sponsor" | "sponsor"
->;
-
+> & { type_i: EffectType.trustline_sponsorship_removed };
 interface DataSponsporshipEvents extends BaseEffectRecord, SponsershipFields {
   data_name: string;
 }
-
 export type DateSponsporshipCreated = Omit<
   DataSponsporshipEvents,
   "new_sponsor" | "former_sponsor"
->;
-export type DateSponsporshipUpdated = Omit<DataSponsporshipEvents, "sponsor">;
+> & { type_i: EffectType.data_sponsorship_created };
+export type DateSponsporshipUpdated = Omit<
+  DataSponsporshipEvents,
+  "sponsor"
+> & { type_i: EffectType.data_sponsorship_updated };
 export type DateSponsporshipRemoved = Omit<
   DataSponsporshipEvents,
   "new_sponsor" | "sponsor"
->;
-
+> & { type_i: EffectType.data_sponsorship_removed };
 interface ClaimableBalanceSponsorshipEvents
   extends BaseEffectRecord,
     SponsershipFields {
-  balance_id: string;
+  balance_type_i: string;
 }
 
 export type ClaimableBalanceSponsorshipCreated = Omit<
   ClaimableBalanceSponsorshipEvents,
   "new_sponsor" | "former_sponsor"
->;
+> & { type_i: EffectType.claimable_balance_sponsorship_created };
 export type ClaimableBalanceSponsorshipUpdated = Omit<
   ClaimableBalanceSponsorshipEvents,
   "sponsor"
->;
+> & { type_i: EffectType.claimable_balance_sponsorship_updated };
 export type ClaimableBalanceSponsorshipRemoved = Omit<
   ClaimableBalanceSponsorshipEvents,
   "new_sponsor" | "sponsor"
->;
-
+> & { type_i: EffectType.claimable_balance_sponsorship_removed };
 interface SignerSponsorshipEvents extends BaseEffectRecord, SponsershipFields {
   signer: string;
 }
@@ -217,9 +241,12 @@ interface SignerSponsorshipEvents extends BaseEffectRecord, SponsershipFields {
 export type SignerSponsorshipCreated = Omit<
   SignerSponsorshipEvents,
   "new_sponsor" | "former_sponsor"
->;
-export type SignerSponsorshipUpdated = Omit<SignerSponsorshipEvents, "sponsor">;
+> & { type_i: EffectType.signer_sponsorship_created };
+export type SignerSponsorshipUpdated = Omit<
+  SignerSponsorshipEvents,
+  "sponsor"
+> & { type_i: EffectType.signer_sponsorship_updated };
 export type SignerSponsorshipRemoved = Omit<
   SignerSponsorshipEvents,
   "new_sponsor" | "sponsor"
->;
+> & { type_i: EffectType.signer_sponsorship_removed };

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -1,0 +1,225 @@
+import { Horizon } from "./../horizon_api";
+import { OfferAsset } from "./assets";
+
+// Reference: GO SDK https://github.com/stellar/go/blob/ec5600bd6b2b6900d26988ff670b9ca7992313b8/services/horizon/internal/resourceadapter/effects.go
+export enum EffectType {
+  "account_created",
+  "account_removed",
+  "account_credited",
+  "account_debited",
+  "account_thresholds_updated",
+  "account_home_domain_updated",
+  "account_flags_updated",
+  "account_inflation_destination_updated",
+  "signer_created",
+  "signer_removed",
+  "signer_updated",
+  "trustline_created",
+  "trustline_removed",
+  "trustline_updated",
+  "trustline_authorized",
+  "trustline_authorized_to_maintain_liabilities",
+  "trustline_deauthorized",
+  "trustline_flags_updated",
+  "offer_created",
+  "offer_removed",
+  "offer_updated",
+  "trade",
+  "data_created",
+  "data_removed",
+  "data_updated",
+  "sequence_bumped",
+  "claimable_balance_created",
+  "claimable_balance_claimant_created",
+  "claimable_balance_claimed",
+  "account_sponsorship_created",
+  "account_sponsorship_updated",
+  "account_sponsorship_removed",
+  "trustline_sponsorship_created",
+  "trustline_sponsorship_updated",
+  "trustline_sponsorship_removed",
+  "data_sponsorship_created",
+  "data_sponsorship_updated",
+  "data_sponsorship_removed",
+  "claimable_balance_sponsorship_created",
+  "claimable_balance_sponsorship_updated",
+  "claimable_balance_sponsorship_removed",
+  "signer_sponsorship_created",
+  "signer_sponsorship_updated",
+  "signer_sponsorship_removed",
+  "claimable_balance_clawed_back",
+}
+
+export interface BaseEffectRecord extends Horizon.BaseResponse {
+  id: string;
+  account: string;
+  paging_token: string;
+  type_i: string;
+  type: EffectType;
+  created_at: string;
+}
+
+export interface AccountCreated extends BaseEffectRecord {
+  starting_balance: string;
+}
+
+export interface AccountCredited extends BaseEffectRecord, OfferAsset {
+  amount: string;
+}
+
+export type AccountDebited = AccountCredited;
+
+export interface AccountThresholdsUpdated extends BaseEffectRecord {
+  low_threshold: number;
+  med_threshold: number;
+  high_threshold: number;
+}
+
+export interface AccountHomeDomainUpdated extends BaseEffectRecord {
+  home_domain: string;
+}
+
+export interface AccountFlagsUpdated extends BaseEffectRecord {
+  auth_required_flag: boolean;
+  auth_revokable_flag: boolean;
+}
+
+interface DataEvents extends BaseEffectRecord {
+  name: boolean;
+  value: boolean;
+}
+
+export type DataCreated = DataEvents;
+export type DataUpdated = DataEvents;
+export type DataRemoved = DataEvents;
+
+export interface SequenceBumped extends BaseEffectRecord {
+  new_seq: number | string;
+}
+
+interface SignerEvents extends BaseEffectRecord {
+  weight: number;
+  key: string;
+  public_key: string;
+}
+
+export type SignerCreated = SignerEvents;
+export type SignerRemoved = SignerEvents;
+export type SignerUpdated = SignerEvents;
+
+interface TrustlineEvents extends BaseEffectRecord, OfferAsset {
+  limit: string;
+}
+
+export type TrustlineCreated = TrustlineEvents;
+export type TrustlineRemoved = TrustlineEvents;
+export type TrustlineUpdated = TrustlineEvents;
+
+export interface TrustlineAuthorized extends BaseEffectRecord {
+  asset_type: OfferAsset["asset_type"];
+  asset_code: OfferAsset["asset_code"];
+  trustor: string;
+}
+
+export type TrustlineDeautorized = TrustlineAuthorized;
+export type TrustlineAutorizedToMaintainLiabilities = TrustlineAuthorized;
+
+export interface ClaimableBalanceCreated extends BaseEffectRecord {
+  amount: string;
+  balance_id: string;
+  asset: string;
+}
+
+export type ClaimableBalanceClaimed = ClaimableBalanceCreated;
+export interface ClaimableBalanceClaimantCreated
+  extends ClaimableBalanceCreated {
+  predicate: Horizon.Predicate;
+}
+
+interface SponsershipFields {
+  sponsor: string;
+  new_sponsor: string;
+  former_sponsor: string;
+}
+
+interface AccountSponsporshipEvents
+  extends BaseEffectRecord,
+    SponsershipFields {}
+export type AccountSponsporshipCreated = Omit<
+  AccountSponsporshipEvents,
+  "new_sponsor" | "former_sponsor"
+>;
+export type AccountSponsporshipUpdated = Omit<
+  AccountSponsporshipEvents,
+  "sponsor"
+>;
+export type AccountSponsporshipRemoved = Omit<
+  AccountSponsporshipEvents,
+  "new_sponsor" | "sponsor"
+>;
+
+interface TrustlineSponsporshipEvents
+  extends BaseEffectRecord,
+    SponsershipFields {
+  asset: string;
+}
+
+export type TrustlineSponsporshipCreated = Omit<
+  TrustlineSponsporshipEvents,
+  "new_sponsor" | "former_sponsor"
+>;
+export type TrustlineSponsporshipUpdated = Omit<
+  TrustlineSponsporshipEvents,
+  "sponsor"
+>;
+export type TrustlineSponsporshipRemoved = Omit<
+  TrustlineSponsporshipEvents,
+  "new_sponsor" | "sponsor"
+>;
+
+interface DataSponsporshipEvents extends BaseEffectRecord, SponsershipFields {
+  data_name: string;
+}
+
+export type DateSponsporshipCreated = Omit<
+  DataSponsporshipEvents,
+  "new_sponsor" | "former_sponsor"
+>;
+export type DateSponsporshipUpdated = Omit<DataSponsporshipEvents, "sponsor">;
+export type DateSponsporshipRemoved = Omit<
+  DataSponsporshipEvents,
+  "new_sponsor" | "sponsor"
+>;
+
+interface ClaimableBalanceSponsorshipEvents
+  extends BaseEffectRecord,
+    SponsershipFields {
+  balance_id: string;
+}
+
+export type ClaimableBalanceSponsorshipCreated = Omit<
+  ClaimableBalanceSponsorshipEvents,
+  "new_sponsor" | "former_sponsor"
+>;
+export type ClaimableBalanceSponsorshipUpdated = Omit<
+  ClaimableBalanceSponsorshipEvents,
+  "sponsor"
+>;
+export type ClaimableBalanceSponsorshipRemoved = Omit<
+  ClaimableBalanceSponsorshipEvents,
+  "new_sponsor" | "sponsor"
+>;
+
+interface SignerSponsorshipEvents extends BaseEffectRecord, SponsershipFields {
+  signer: string;
+}
+
+export type SignerSponsorshipCreated = Omit<
+  SignerSponsorshipEvents,
+  "new_sponsor" | "former_sponsor"
+>;
+export type SignerSponsorshipUpdated = Omit<SignerSponsorshipEvents, "sponsor">;
+export type SignerSponsorshipRemoved = Omit<
+  SignerSponsorshipEvents,
+  "new_sponsor" | "sponsor"
+>;

--- a/src/types/offer.ts
+++ b/src/types/offer.ts
@@ -1,0 +1,22 @@
+import { AssetType } from "stellar-base";
+import { Horizon } from "./../horizon_api";
+
+export interface OfferAsset {
+  asset_type: AssetType;
+  asset_code?: string;
+  asset_issuer?: string;
+}
+
+export interface OfferRecord extends Horizon.BaseResponse {
+  id: number | string;
+  paging_token: string;
+  seller: string;
+  selling: OfferAsset;
+  buying: OfferAsset;
+  amount: string;
+  price_r: Horizon.PriceRShorthand;
+  price: string;
+  last_modified_ledger: number;
+  last_modified_time: string;
+  sponsor?: string;
+}

--- a/src/types/trade.ts
+++ b/src/types/trade.ts
@@ -1,0 +1,14 @@
+import { BaseEffectRecord } from "./effects";
+
+export interface Trade extends BaseEffectRecord {
+  seller: string;
+  offer_id: number | string;
+  bought_amount: string;
+  bought_asset_type: string;
+  bought_asset_code: string;
+  bought_asset_issuer: string;
+  sold_amount: string;
+  sold_asset_type: string;
+  sold_asset_code: string;
+  sold_asset_issuer: string;
+}


### PR DESCRIPTION
- Types provided for effects, with Go Package being the reference.
- Moving Asset, Trade and Offer Types to their own files.
- Kept service_api exporting back types imported to not break anything in other files.

Any feedback is really appreciated. 

Closes #299.