### PR TITLE
Remove defunct c query param, now that horizon sends cache-control headers

### DIFF
--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -332,8 +332,6 @@ export class CallBuilder<
       url = url.protocol(this.url.protocol());
     }
 
-    // Temp fix for: https://github.com/stellar/js-stellar-sdk/issues/15
-    url.setQuery("c", String(Math.random()));
     return HorizonAxiosClient.get(url.toString())
       .then((response) => response.data)
       .catch(this._handleNetworkError);


### PR DESCRIPTION
Now that horizon [sends `Cache-Control` headers](https://github.com/stellar/go/pull/476), I can't reproduce the caching issue from https://github.com/stellar/js-stellar-sdk/issues/15 (see comment there for updated code attempting to reproduce the issue). Seems safe to remove the temporary fix now.