### PR TITLE
Make AccountResponse conform to the StellarBase.Account interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Fix
+- Fixes a breaking bug introduced in v8.2.0 in which `AccountResponse` no longer conformed to the `StellarBase.Account` interface, which was updated in [stellar-base@v5.2.0](https://github.com/stellar/js-stellar-base/releases/tag/v5.2.0) [(#655)](https://github.com/stellar/js-stellar-sdk/pull/655).
+
 
 ## [v8.2.1](https://github.com/stellar/js-stellar-sdk/compare/v8.2.0...v8.2.1)
 

--- a/src/account_response.ts
+++ b/src/account_response.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:variable-name */
 
 import forIn from "lodash/forIn";
-import { Account as BaseAccount } from "stellar-base";
+import { Account as BaseAccount, MuxedAccount } from "stellar-base";
 import { Horizon } from "./horizon_api";
 import { ServerApi } from "./server_api";
 
@@ -82,5 +82,9 @@ export class AccountResponse {
   public incrementSequenceNumber(): void {
     this._baseAccount.incrementSequenceNumber();
     this.sequence = this._baseAccount.sequenceNumber();
+  }
+
+  public createSubaccount(id: string): MuxedAccount {
+    return this._baseAccount.createSubaccount(id);
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -655,9 +655,13 @@ export class Server {
   }
 
   /**
-   * Fetches an account's most current state in the ledger and then creates and returns an {@link Account} object.
+   * Fetches an account's most current state in the ledger, then creates and
+   * returns an {@link AccountResponse} object.
+   *
    * @param {string} accountId - The account to load.
-   * @returns {Promise} Returns a promise to the {@link AccountResponse} object with populated sequence number.
+   *
+   * @returns {Promise} Returns a promise to the {@link AccountResponse} object
+   * with populated sequence number.
    */
   public async loadAccount(accountId: string): Promise<AccountResponse> {
     const res = await this.accounts()


### PR DESCRIPTION
This resolves an unintentional breaking change introduced in 8.2.0 in which `StellarSdk.AccountResponse` was no longer interchangeable with `StellarBase.Account` in things like `TransactionBuilder`. This also closes #653.

**Limitations:** Since the test suite is written in JavaScript rather than TypeScript, this is impossible to catch there. More work needs to be done to avoid this happening in the future.