### PR TITLE
Update transaction result processing to parse offers correctly.

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -352,7 +352,34 @@ export class Server {
               const offersClaimed = offerSuccess
                 .offersClaimed()
                 // TODO: fix stellar-base types.
-                .map((offerClaimed: any) => {
+                .map((offerClaimedAtom: any) => {
+                  const offerClaimed = offerClaimedAtom.value();
+
+                  let sellerId: string = "";
+                  switch (offerClaimedAtom.switch()) {
+                    case xdr.ClaimAtomType.claimAtomTypeV0():
+                      sellerId = StrKey.encodeEd25519PublicKey(
+                        offerClaimed.sellerEd25519(),
+                      );
+                      break;
+                    case xdr.ClaimAtomType.claimAtomTypeOrderBook():
+                      sellerId = StrKey.encodeEd25519PublicKey(
+                        offerClaimed.sellerId().ed25519(),
+                      );
+                      break;
+                    // It shouldn't be possible for a claimed offer to have type
+                    // claimAtomTypeLiquidityPool:
+                    //
+                    // https://github.com/stellar/stellar-core/blob/c5f6349b240818f716617ca6e0f08d295a6fad9a/src/transactions/TransactionUtils.cpp#L1284
+                    //
+                    // However, you can never be too careful.
+                    default:
+                      throw new Error(
+                        "Invalid offer result type: " +
+                          offerClaimedAtom.switch(),
+                      );
+                  }
+
                   const claimedOfferAmountBought = new BigNumber(
                     // amountBought is a js-xdr hyper
                     offerClaimed.amountBought().toString(),
@@ -388,9 +415,7 @@ export class Server {
                   };
 
                   return {
-                    sellerId: StrKey.encodeEd25519PublicKey(
-                      offerClaimed.sellerId().ed25519(),
-                    ),
+                    sellerId,
                     offerId: offerClaimed.offerId().toString(),
                     assetSold,
                     amountSold: _getAmountInLumens(claimedOfferAmountSold),


### PR DESCRIPTION
This updates stellar-base to be compatible with CAP-38 (v6.0.1), and also updates the offer response processor to be work with the new `ClaimAtom` changes. Specifically, the seller ID needs to be parsed out differently depending on the type of `ClaimAtom` encountered.