### PR TITLE
Allow querying a single liquidity pool by its specific ID.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ A breaking change will get clearly marked in this log.
 
 ### Add
 
-- Introduced a `LiquidityPoolCallBuilder` to make calls to the new `/liquidity_pools` endpoint, including filtering by reserve asset ([#682](https://github.com/stellar/js-stellar-sdk/pull/682)).
+- Introduced a `LiquidityPoolCallBuilder` to make calls to the new `/liquidity_pools` endpoint, featuring:
+  * filtering by reserve asset via `?reserves=[...]` ([#682](https://github.com/stellar/js-stellar-sdk/pull/682)), and 
+  * retrieving a specific pool via `/<id>/` ([#687](https://github.com/stellar/js-stellar-sdk/pull/687)).
 
 ### Updates
 

--- a/src/account_call_builder.ts
+++ b/src/account_call_builder.ts
@@ -26,7 +26,7 @@ export class AccountCallBuilder extends CallBuilder<
    *
    * @see [Account Details](https://www.stellar.org/developers/horizon/reference/endpoints/accounts-single.html)
    * @param {string} id For example: `GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD`
-   * @returns {CallBuilder} current AccountCallBuilder instance
+   * @returns {CallBuilder} a new CallBuilder instance for the /accounts/:id endpoint
    */
   public accountId(id: string): CallBuilder<ServerApi.AccountRecord> {
     const builder = new CallBuilder<ServerApi.AccountRecord>(this.url.clone());

--- a/src/liquidity_pool_call_builder.ts
+++ b/src/liquidity_pool_call_builder.ts
@@ -27,7 +27,7 @@ export class LiquidityPoolCallBuilder extends CallBuilder<
    * @param {Asset[]} assets
    * @returns {LiquidityPoolCallBuilder} current LiquidityPoolCallBuilder instance
    */
-  public forAssets(...assets: Asset[]) {
+  public forAssets(...assets: Asset[]): this {
     const commaSeparatedAssets: string = assets
       .map((asset: Asset) => {
         return asset.toString();
@@ -35,5 +35,25 @@ export class LiquidityPoolCallBuilder extends CallBuilder<
       .join(",");
     this.url.setQuery("reserves", commaSeparatedAssets);
     return this;
+  }
+
+  /**
+   * Retrieves a specific liquidity pool by ID.
+   *
+   * @param  {string} id
+   * @returns {CallBuilder} a new CallBuilder instance for the /liquidity_pools/:id endpoint
+   */
+  public liquidityPoolId(
+    id: string,
+  ): CallBuilder<ServerApi.LiquidityPoolRecord> {
+    if (!id.match(/[a-fA-F0-9]{64}/)) {
+      throw new Error(`${id} does not look like a liquidity pool ID`);
+    }
+
+    const builder = new CallBuilder<ServerApi.LiquidityPoolRecord>(
+      this.url.clone(),
+    );
+    builder.filter.push([id.toLowerCase()]);
+    return builder;
   }
 }

--- a/test/unit/liquidity_pool_endpoints_test.js
+++ b/test/unit/liquidity_pool_endpoints_test.js
@@ -140,5 +140,46 @@ describe('/liquidity_pools tests', function() {
           .catch(done);
       });
     });
+
+    const poolResponse = {
+      "id": "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a",
+      "paging_token": "113725249324879873",
+      "fee_bp": 30,
+      "type": "constant_product",
+      "total_trustlines": "300",
+      "total_shares": "5000",
+      "reserves": [
+        {
+          "amount": "1000.0000005",
+          "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+        },
+        {
+          "amount": "2000.0000000",
+          "asset": "PHP:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+        },
+      ]
+    };
+    const lpId = "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a";
+
+    it('filters by specific ID', function(done) {
+      this.axiosMock
+        .expects('get')
+        .withArgs(sinon.match(`${LP_URL}/${lpId}`))
+        .returns(Promise.resolve({ data: poolResponse }))
+
+      this.server
+        .liquidityPools()
+        .liquidityPoolId(lpId)
+        .call()
+        .then((pool) => {
+          expect(pool).to.deep.equal(poolResponse);
+          done();
+        })
+        .catch(done);
+    });
+
+    it('checks for valid IDs', function() {
+      expect(() => this.server.liquidityPools().liquidityPoolId("nonsense")).to.throw();
+    });
   });
 });

--- a/test/unit/liquidity_pool_endpoints_test.js
+++ b/test/unit/liquidity_pool_endpoints_test.js
@@ -141,27 +141,33 @@ describe('/liquidity_pools tests', function() {
       });
     });
 
-    const poolResponse = {
-      "id": "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a",
-      "paging_token": "113725249324879873",
-      "fee_bp": 30,
-      "type": "constant_product",
-      "total_trustlines": "300",
-      "total_shares": "5000",
-      "reserves": [
-        {
-          "amount": "1000.0000005",
-          "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
-        },
-        {
-          "amount": "2000.0000000",
-          "asset": "PHP:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
-        },
-      ]
-    };
     const lpId = "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a";
 
+    it('checks for valid IDs', function() {
+      expect(() => this.server.liquidityPools().liquidityPoolId("nonsense")).to.throw();
+      expect(() => this.server.liquidityPools().liquidityPoolId(lpId)).not.to.throw();
+    });
+
     it('filters by specific ID', function(done) {
+      const poolResponse = {
+        "id": "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a",
+        "paging_token": "113725249324879873",
+        "fee_bp": 30,
+        "type": "constant_product",
+        "total_trustlines": "300",
+        "total_shares": "5000",
+        "reserves": [
+          {
+            "amount": "1000.0000005",
+            "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+          },
+          {
+            "amount": "2000.0000000",
+            "asset": "PHP:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+          },
+        ]
+      };
+
       this.axiosMock
         .expects('get')
         .withArgs(sinon.match(`${LP_URL}/${lpId}`))
@@ -176,10 +182,6 @@ describe('/liquidity_pools tests', function() {
           done();
         })
         .catch(done);
-    });
-
-    it('checks for valid IDs', function() {
-      expect(() => this.server.liquidityPools().liquidityPoolId("nonsense")).to.throw();
     });
   });
 });


### PR DESCRIPTION
This should enable querying the `/liquidity_pools/:id` endpoint.