### PR TITLE
Support filtering accounts participating in a given LP and update accounts balance response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ A breaking change will get clearly marked in this log.
   - There's a new field `trade_type` that can be either `orderbook` or `liquidity_pool`. You can filter by that field.
   - Liquidity pool trades will contain the field `liquidity_pool_fee_bp` and either `base_liquidity_pool_id` or `counter_liquidity_pool_id`.
   - There are a few breaking changes to this endpoint listed in the section below.
-- A new kind of trustline called `liquidity_pool_shares` was added and clients can now filter the results from the `/accounts` endpoint by `liquidity_pool`. This will include a new kind of trustline in the account `balances` array, causing a breaking change as described in the section below ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).
+- A new type of trustline called `liquidity_pool_shares` was added, which is included in the account `balances` array and causes a breaking change (see below) ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).
+- Clients can now filter the results from the `/accounts` endpoint based on participation in a certain liquidity pool ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).
 
 ### Breaking changes
 
@@ -29,7 +30,7 @@ A breaking change will get clearly marked in this log.
   - The links to "base" and "counter" returned from horizon can now point to either an account or a liquidity pool.
 - The `balances` array from an account response now supports liquidity pool balances ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).
   - the `asset_type` field can now be `liquidity_pool_shares`.
-  - `buying_liabilities`, `selling_liabilities`, `asset_code`, and `asset_issuer` are omited from the response for pool shares because they are not relevant to liquidity pools.
+  - `buying_liabilities`, `selling_liabilities`, `asset_code`, and `asset_issuer` are omitted from the response for pool shares because they are not relevant to liquidity pools.
 - Update the `ChangeTrustOperationResponse` interface so it can conform to a change in a liquidity pool trustline ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).
   - `asset_type` can now be `liquidity_pool_shares`.
   - `asset_code` and `asset_issuer` are now optional.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ A breaking change will get clearly marked in this log.
   - There's a new field `trade_type` that can be either `orderbook` or `liquidity_pool`. You can filter by that field.
   - Liquidity pool trades will contain the field `liquidity_pool_fee_bp` and either `base_liquidity_pool_id` or `counter_liquidity_pool_id`.
   - There are a few breaking changes to this endpoint listed in the section below.
-- A new kind of trustline called `liquidity_pool_shares` was added and clients can now filter the results from the `/accounts` endpoint by `liquidity_pool`. This will include a new kind of trustline in the account `balances` array, causing a breaking change as described in the section below ([#687](https://github.com/stellar/js-stellar-sdk/pull/687)).
+- A new kind of trustline called `liquidity_pool_shares` was added and clients can now filter the results from the `/accounts` endpoint by `liquidity_pool`. This will include a new kind of trustline in the account `balances` array, causing a breaking change as described in the section below ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).
 
 ### Breaking changes
 
@@ -27,7 +27,7 @@ A breaking change will get clearly marked in this log.
   - Some previously mandatory fields were made optional: `counter_offer_id`, `base_offer_id` will only show up in orderbook trades while only one of `base_account` and `counter_account` will appear in liquidity pool trades.
   - The `price` field changed from `{n: number; d: number;}` to `{n: string; d: string;}`.
   - The links to "base" and "counter" returned from horizon can now point to either an account or a liquidity pool.
-- Update the `ChangeTrustOperationResponse` interface so it can conform to a change in a liquidity pool trustline ([#687](https://github.com/stellar/js-stellar-sdk/pull/687)).
+- Update the `ChangeTrustOperationResponse` interface so it can conform to a change in a liquidity pool trustline ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).
   - `asset_type` can now be `liquidity_pool_shares`
   - `asset_code` and `asset_issuer` are now optional.
   - Added `liquidity_pool_id` as an optional field.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,11 @@ A breaking change will get clearly marked in this log.
   - Some previously mandatory fields were made optional: `counter_offer_id`, `base_offer_id` will only show up in orderbook trades while only one of `base_account` and `counter_account` will appear in liquidity pool trades.
   - The `price` field changed from `{n: number; d: number;}` to `{n: string; d: string;}`.
   - The links to "base" and "counter" returned from horizon can now point to either an account or a liquidity pool.
+- The `balances` array from an account response now supports liquidity pool balances ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).
+  - the `asset_type` field can now be `liquidity_pool_shares`.
+  - `buying_liabilities`, `selling_liabilities`, `asset_code`, and `asset_issuer` are omited from the response for pool shares because they are not relevant to liquidity pools.
 - Update the `ChangeTrustOperationResponse` interface so it can conform to a change in a liquidity pool trustline ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).
-  - `asset_type` can now be `liquidity_pool_shares`
+  - `asset_type` can now be `liquidity_pool_shares`.
   - `asset_code` and `asset_issuer` are now optional.
   - Added `liquidity_pool_id` as an optional field.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ A breaking change will get clearly marked in this log.
   - There's a new field `trade_type` that can be either `orderbook` or `liquidity_pool`. You can filter by that field.
   - Liquidity pool trades will contain the field `liquidity_pool_fee_bp` and either `base_liquidity_pool_id` or `counter_liquidity_pool_id`.
   - There are a few breaking changes to this endpoint listed in the section below.
+- A new kind of trustline called `liquidity_pool_shares` was added and clients can now filter the results from the `/accounts` endpoint by `liquidity_pool`. This will include a new kind of trustline in the account `balances` array, causing a breaking change as described in the section below ([#687](https://github.com/stellar/js-stellar-sdk/pull/687)).
 
 ### Breaking changes
 
@@ -26,6 +27,10 @@ A breaking change will get clearly marked in this log.
   - Some previously mandatory fields were made optional: `counter_offer_id`, `base_offer_id` will only show up in orderbook trades while only one of `base_account` and `counter_account` will appear in liquidity pool trades.
   - The `price` field changed from `{n: number; d: number;}` to `{n: string; d: string;}`.
   - The links to "base" and "counter" returned from horizon can now point to either an account or a liquidity pool.
+- Update the `ChangeTrustOperationResponse` interface so it can conform to a change in a liquidity pool trustline ([#687](https://github.com/stellar/js-stellar-sdk/pull/687)).
+  - `asset_type` can now be `liquidity_pool_shares`
+  - `asset_code` and `asset_issuer` are now optional.
+  - Added `liquidity_pool_id` as an optional field.
 
 ### Fix
 - Updated various developer dependencies to secure versions ([#671](https://github.com/stellar/js-stellar-sdk/pull/671)).

--- a/src/account_call_builder.ts
+++ b/src/account_call_builder.ts
@@ -67,4 +67,15 @@ export class AccountCallBuilder extends CallBuilder<
     this.url.setQuery("sponsor", id);
     return this;
   }
+
+  /**
+   * This endpoint filters accounts holding a trustline to the given liquidity pool.
+   *
+   * @param {string} id The ID of the liquidity pool. For example: `dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7`.
+   * @returns {AccountCallBuilder} current AccountCallBuilder instance
+   */
+  public forLiquidityPool(id: string): this {
+    this.url.setQuery("liquidity_pool", id);
+    return this;
+  }
 }

--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -355,9 +355,13 @@ export namespace Horizon {
       OperationResponseType.changeTrust,
       OperationResponseTypeI.changeTrust
     > {
-    asset_type: AssetType.credit4 | AssetType.credit12;
-    asset_code: string;
-    asset_issuer: string;
+    asset_type:
+      | AssetType.credit4
+      | AssetType.credit12
+      | AssetType.liquidityPoolShares;
+    asset_code?: string;
+    asset_issuer?: string;
+    liquidity_pool_id?: string;
     trustee: string;
     trustor: string;
     limit: string;

--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -63,6 +63,15 @@ export namespace Horizon {
     buying_liabilities: string;
     selling_liabilities: string;
   }
+  export interface BalanceLineLiquidityPool {
+    liquidity_pool_id: string;
+    asset_type: AssetType.liquidityPoolShares;
+    balance: string;
+    limit: string;
+    last_modified_ledger: number;
+    is_authorized: boolean;
+    is_authorized_to_maintain_liabilities: boolean;
+  }
   export interface BalanceLineAsset<
     T extends AssetType.credit4 | AssetType.credit12 =
       | AssetType.credit4
@@ -86,7 +95,9 @@ export namespace Horizon {
     ? BalanceLineNative
     : T extends AssetType.credit4 | AssetType.credit12
     ? BalanceLineAsset<T>
-    : BalanceLineNative | BalanceLineAsset;
+    : T extends AssetType.liquidityPoolShares
+    ? BalanceLineLiquidityPool
+    : BalanceLineNative | BalanceLineAsset | BalanceLineLiquidityPool;
 
   export interface AssetAccounts {
     authorized: number;

--- a/test/unit/server_check_memo_required_test.js
+++ b/test/unit/server_check_memo_required_test.js
@@ -239,6 +239,7 @@ describe("server.js check-memo-required", function() {
 
       const usd = new StellarSdk.Asset("USD", "GBBM6BKZPEHWYO3E3YKREDPQXMS4VK35YLNU7NFBRI26RAN7GI5POFBB");
       const eur = new StellarSdk.Asset("EUR", "GDTNXRLOJD2YEBPKK7KCMR7J33AAG5VZXHAJTHIG736D6LVEFLLLKPDL");
+      const liquidityPoolAsset = new StellarSdk.LiquidityPoolAsset(eur, usd, 30);
 
       let operations = [
         StellarSdk.Operation.accountMerge({
@@ -262,6 +263,9 @@ describe("server.js check-memo-required", function() {
         }),
         StellarSdk.Operation.changeTrust({
           asset: usd
+        }),
+        StellarSdk.Operation.changeTrust({
+          asset: liquidityPoolAsset
         })
       ];
 

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -1581,8 +1581,9 @@ describe('server.js non-transaction tests', function() {
                     balance: "10",
                     limit: "10000",
                     last_modified_ledger: 7877447,
-                    is_authorized: false,
-                    is_authorized_to_maintain_liabilities: false
+                    is_authorized: true,
+                    is_authorized_to_maintain_liabilities: false,
+                    is_clawback_enabled: false
                   },
                   {
                     balance: '0.0000000',
@@ -1591,6 +1592,8 @@ describe('server.js non-transaction tests', function() {
                     selling_liabilities: '0.0000000',
                     last_modified_ledger: 983682,
                     is_authorized: true,
+                    is_authorized_to_maintain_liabilities: false,
+                    is_clawback_enabled: false,
                     asset_type: 'credit_alphanum4',
                     asset_code: 'ARST',
                     asset_issuer: 'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
@@ -1602,6 +1605,8 @@ describe('server.js non-transaction tests', function() {
                     selling_liabilities: '0.0000000',
                     last_modified_ledger: 983682,
                     is_authorized: true,
+                    is_authorized_to_maintain_liabilities: false,
+                    is_clawback_enabled: false,
                     asset_type: 'credit_alphanum4',
                     asset_code: 'USD',
                     asset_issuer: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -1509,7 +1509,7 @@ describe('server.js non-transaction tests', function() {
           });
       });
 
-      it('adds an "liquidity_pool" query to the endpoint', function(done) {
+      it('adds a "liquidity_pool" filter to the endpoint', function(done) {
         const accountsForAssetResponse = {
           _links: {
             self: {

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -278,11 +278,13 @@ describe('server.js non-transaction tests', function() {
       },
       "balances": [
         {
-          "balance": "0.0000000",
-          "limit": "922337203685.4775807",
-          "asset_type": "credit_alphanum4",
-          "asset_code": "AAA",
-          "asset_issuer": "GAX4CUJEOUA27MDHTLSQCFRGQPEXCC6GMO2P2TZCG7IEBZIEGPOD6HKF"
+          "liquidity_pool_id": "dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7",
+          "asset_type": "liquidity_pool_shares",
+          "balance": "10",
+          "limit": "10000",
+          "last_modified_ledger": 7877447,
+          "is_authorized": false,
+          "is_authorized_to_maintain_liabilities": false
         },
         {
           "balance": "5000.0000000",
@@ -1574,7 +1576,7 @@ describe('server.js non-transaction tests', function() {
                 },
                 balances: [
                   {
-                    liquidity_pool_id: "abcdef",
+                    liquidity_pool_id: "dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7",
                     asset_type: "liquidity_pool_shares",
                     balance: "10",
                     limit: "10000",

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -1507,6 +1507,149 @@ describe('server.js non-transaction tests', function() {
           });
       });
 
+      it('adds an "liquidity_pool" query to the endpoint', function(done) {
+        const accountsForAssetResponse = {
+          _links: {
+            self: {
+              href: '/accounts?liquidity_pool=dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7&cursor=&limit=10&order=asc'
+            },
+            next: {
+              href: '/accounts?liquidity_pool=dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7&cursor=GC4J73PTB5WN7MOJWOAECPHRCV2UU3WCY37L3BNY6RZVKE23JGQYJMJ6&limit=10&order=asc'
+            },
+            prev: {
+              href: '/accounts?liquidity_pool=dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7&cursor=GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667&limit=10&order=desc'
+            }
+          },
+          _embedded: {
+            records: [
+              {
+                _links: {
+                  self: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667'
+                  },
+                  transactions: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/transactions{?cursor,limit,order}',
+                    templated: true
+                  },
+                  operations: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/operations{?cursor,limit,order}',
+                    templated: true
+                  },
+                  payments: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/payments{?cursor,limit,order}',
+                    templated: true
+                  },
+                  effects: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/effects{?cursor,limit,order}',
+                    templated: true
+                  },
+                  offers: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/offers{?cursor,limit,order}',
+                    templated: true
+                  },
+                  trades: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/trades{?cursor,limit,order}',
+                    templated: true
+                  },
+                  data: {
+                    href: '/accounts/GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667/data/{key}',
+                    templated: true
+                  }
+                },
+                id: 'GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667',
+                account_id: 'GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667',
+                sequence: '3902600558673934',
+                subentry_count: 3,
+                last_modified_ledger: 983682,
+                thresholds: {
+                  low_threshold: 0,
+                  med_threshold: 0,
+                  high_threshold: 0
+                },
+                flags: {
+                  auth_required: false,
+                  auth_revocable: false,
+                  auth_immutable: false,
+                  auth_clawback_enabled: false
+                },
+                balances: [
+                  {
+                    liquidity_pool_id: "abcdef",
+                    asset_type: "liquidity_pool_shares",
+                    balance: "10",
+                    limit: "10000",
+                    last_modified_ledger: 7877447,
+                    is_authorized: false,
+                    is_authorized_to_maintain_liabilities: false
+                  },
+                  {
+                    balance: '0.0000000',
+                    limit: '922337203685.4775807',
+                    buying_liabilities: '0.0000000',
+                    selling_liabilities: '0.0000000',
+                    last_modified_ledger: 983682,
+                    is_authorized: true,
+                    asset_type: 'credit_alphanum4',
+                    asset_code: 'ARST',
+                    asset_issuer: 'GB7TAYRUZGE6TVT7NHP5SMIZRNQA6PLM423EYISAOAP3MKYIQMVYP2JO'
+                  },
+                  {
+                    balance: '0.0000000',
+                    limit: '922337203685.4775807',
+                    buying_liabilities: '0.0000000',
+                    selling_liabilities: '0.0000000',
+                    last_modified_ledger: 983682,
+                    is_authorized: true,
+                    asset_type: 'credit_alphanum4',
+                    asset_code: 'USD',
+                    asset_issuer: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
+                  },
+                  {
+                    balance: '9999.9998600',
+                    buying_liabilities: '0.0000000',
+                    selling_liabilities: '0.0000000',
+                    asset_type: 'native'
+                  }
+                ],
+                signers: [
+                  {
+                    weight: 1,
+                    key: 'GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667',
+                    type: 'ed25519_public_key'
+                  }
+                ],
+                data: {},
+                paging_token: 'GBPFGVESMB7HSTQREV354WA4UDGAPS2NCB5DZQ7K2VZM3PSX4TDCV667'
+              }
+            ]
+          }
+        };
+
+        this.axiosMock
+          .expects('get')
+          .withArgs(
+            sinon.match(
+              'https://horizon-live.stellar.org:1337/accounts?liquidity_pool=dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7'
+            )
+          )
+          .returns(Promise.resolve({ data: accountsForAssetResponse }));
+
+        this.server
+          .accounts()
+          .forLiquidityPool('dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7')
+          .call()
+          .then(function(response) {
+            expect(response.records).to.be.deep.equal(
+              accountsForAssetResponse._embedded.records
+            );
+            expect(response.next).to.be.function;
+            expect(response.prev).to.be.function;
+            done();
+          })
+          .catch(function(err) {
+            done(err);
+          });
+      });
     });
 
     describe('OfferCallBuilder', function() {


### PR DESCRIPTION
Support `/accounts?liquidity_pool={:pool_id}` and update the response from `/accounts/{:acc_id}`

### Update

- A new type of trustline called `liquidity_pool_shares` was added, which is included in the account `balances` array and causes a breaking change (see below) ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).
- Clients can now filter the results from the `/accounts` endpoint based on participation in a certain liquidity pool ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).

### Breaking Changes

- The `balances` array from an account response now supports liquidity pool balances ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).
  - the `asset_type` field can now be `liquidity_pool_shares`.
  - `buying_liabilities`, `selling_liabilities`, `asset_code`, and `asset_issuer` are omitted from the response for pool shares because they are not relevant to liquidity pools.
- Update the `ChangeTrustOperationResponse` interface so it can conform to a change in a liquidity pool trustline ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).
  - `asset_type` can now be `liquidity_pool_shares`.
  - `asset_code` and `asset_issuer` are now optional.
  - Added `liquidity_pool_id` as an optional field.
