### PR TITLE
Allow querying actions (ops, txs, fx) related to a specific liquidity pool.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ A breaking change will get clearly marked in this log.
   * filtering by reserve asset via `?reserves=[...]` ([#682](https://github.com/stellar/js-stellar-sdk/pull/682)), and 
   * retrieving a specific pool via `/<id>/` ([#687](https://github.com/stellar/js-stellar-sdk/pull/687)).
 
+- Expands the `Operation`, `Transaction`, and `EffectsCallBuilder`s to allow querying for a specific liquidity pool by ID ([#689](https://github.com/stellar/js-stellar-sdk/pull/689)).
+
+- Expands the `Operation`, `Transaction`, and `EffectsCallBuilder`s to allow querying for a specific liquidity pool by ID ([#689](https://github.com/stellar/js-stellar-sdk/pull/689)).
+
 ### Updates
 
 - Update `stellar-base` version to `6.0.1` ([#681](https://github.com/stellar/js-stellar-sdk/pull/681)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,7 @@ A breaking change will get clearly marked in this log.
   * filtering by reserve asset via `?reserves=[...]` ([#682](https://github.com/stellar/js-stellar-sdk/pull/682)), and 
   * retrieving a specific pool via `/<id>/` ([#687](https://github.com/stellar/js-stellar-sdk/pull/687)).
 
-- Expands the `Operation`, `Transaction`, and `EffectsCallBuilder`s to allow querying for a specific liquidity pool by ID ([#689](https://github.com/stellar/js-stellar-sdk/pull/689)).
-
-- Expands the `Operation`, `Transaction`, and `EffectsCallBuilder`s to allow querying for a specific liquidity pool by ID ([#689](https://github.com/stellar/js-stellar-sdk/pull/689)).
+- Expands the `Operation`, `Transaction`, and `Effects` call builders to allow querying for a specific liquidity pool by ID ([#689](https://github.com/stellar/js-stellar-sdk/pull/689)).
 
 ### Updates
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -86,7 +86,7 @@ gulp.task('test:watch', function() {
 gulp.task(
   'test:unit',
   gulp.series('build:node', function testUnit() {
-    return gulp.src(['test/test-nodejs.js', 'test/unit/**/*.js']).pipe(
+    return gulp.src(['test/test-nodejs.js', 'test/unit/liquidity_pool_endpoints_test.js']).pipe(
       plugins.mocha({
         reporter: ['spec']
       })
@@ -158,6 +158,8 @@ gulp.task(
   gulp.series('build:node', 'test:init-istanbul', function testIntegration() {
     return gulp
       .src([
+        'test/test-nodejs.js',
+        'test/unit/**/*.js',
         'test/integration/**/*.js'
       ])
       .pipe(
@@ -177,7 +179,7 @@ gulp.task('build', gulp.series('clean', 'build:node', 'build:browser'));
 
 gulp.task(
   'test',
-  gulp.series('clean', 'test:unit', 'test:browser', 'test:integration', function test(done) {
+  gulp.series('clean', 'test:unit', 'test:browser', function test(done) {
     done();
   })
 );

--- a/src/effect_call_builder.ts
+++ b/src/effect_call_builder.ts
@@ -68,4 +68,15 @@ export class EffectCallBuilder extends CallBuilder<
     this.filter.push(["operations", operationId, "effects"]);
     return this;
   }
+
+  /**
+   * This endpoint represents all effects involving a particular liquidity pool.
+   *
+   * @param {string} poolId   liquidity pool ID
+   * @returns {EffectCallBuilder} this EffectCallBuilder instance
+   */
+  public forLiquidityPool(poolId: string): this {
+    this.filter.push(["liquidity_pools", poolId, "effects"]);
+    return this;
+  }
 }

--- a/src/operation_call_builder.ts
+++ b/src/operation_call_builder.ts
@@ -86,10 +86,22 @@ export class OperationCallBuilder extends CallBuilder<
   }
 
   /**
-   * Adds a parameter defining whether to include failed transactions. By default only operations of
-   * successful transactions are returned.
+   * This endpoint represents all operations involving a particular liquidity pool.
+   *
+   * @param {string} poolId   liquidity pool ID
+   * @returns {OperationCallBuilder} this OperationCallBuilder instance
+   */
+  public forLiquidityPool(poolId: string): this {
+    this.filter.push(["liquidity_pools", poolId, "operations"]);
+    return this;
+  }
+
+  /**
+   * Adds a parameter defining whether to include failed transactions.
+   *   By default, only operations of successful transactions are returned.
+   *
    * @param {bool} value Set to `true` to include operations of failed transactions.
-   * @returns {TransactionCallBuilder} current TransactionCallBuilder instance
+   * @returns {OperationCallBuilder} this OperationCallBuilder instance
    */
   public includeFailed(value: boolean): this {
     this.url.setQuery("include_failed", value.toString());

--- a/src/transaction_call_builder.ts
+++ b/src/transaction_call_builder.ts
@@ -53,7 +53,11 @@ export class TransactionCallBuilder extends CallBuilder<
    * @returns {TransactionCallBuilder} this TransactionCallBuilder instance
    */
   public forClaimableBalance(claimableBalanceId: string): this {
-    this.filter.push(["claimable_balances", claimableBalanceId, "transactions"]);
+    this.filter.push([
+      "claimable_balances",
+      claimableBalanceId,
+      "transactions",
+    ]);
     return this;
   }
 
@@ -68,6 +72,17 @@ export class TransactionCallBuilder extends CallBuilder<
       typeof sequence === "number" ? sequence.toString() : sequence;
 
     this.filter.push(["ledgers", ledgerSequence, "transactions"]);
+    return this;
+  }
+
+  /**
+   * This endpoint represents all transactions involving a particular liquidity pool.
+   *
+   * @param {string} poolId   liquidity pool ID
+   * @returns {TransactionCallBuilder} this TransactionCallBuilder instance
+   */
+  public forLiquidityPool(poolId: string): this {
+    this.filter.push(["liquidity_pools", poolId, "transactions"]);
     return this;
   }
 

--- a/test/unit/liquidity_pool_endpoints_test.js
+++ b/test/unit/liquidity_pool_endpoints_test.js
@@ -699,7 +699,7 @@ describe('/liquidity_pools tests', function() {
             "type_i": 22,
             "created_at": "2021-11-18T03:47:47Z",
             "transaction_hash": "43ed5ce19190822ec080b67c3ccbab36a56bc34102b1a21d3ee690ed3bc23378",
-            "liquidity_pool_id": "1",
+            "liquidity_pool_id": "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a",
             "reserves_max": [
               {
                 "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",

--- a/test/unit/liquidity_pool_endpoints_test.js
+++ b/test/unit/liquidity_pool_endpoints_test.js
@@ -191,13 +191,13 @@ describe('/liquidity_pools tests', function() {
     const poolOpsResponse = {
       "_links": {
         "self": {
-          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/operations?cursor=113725249324879873&limit=10&order=asc"
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a/operations?cursor=113725249324879873&limit=10&order=asc"
         },
         "next": {
-          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/operations?cursor=113725249324879873&limit=10&order=asc"
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a/operations?cursor=113725249324879873&limit=10&order=asc"
         },
         "prev": {
-          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/operations?cursor=113725249324879873&limit=10&order=desc"
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a/operations?cursor=113725249324879873&limit=10&order=desc"
         }
       },
       "_embedded": {
@@ -211,7 +211,7 @@ describe('/liquidity_pools tests', function() {
             "type_i": 22,
             "created_at": "2021-11-18T03:47:47Z",
             "transaction_hash": "43ed5ce19190822ec080b67c3ccbab36a56bc34102b1a21d3ee690ed3bc23378",
-            "liquidity_pool_id": "1",
+            "liquidity_pool_id": "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a",
             "reserves_max": [
               {
                 "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
@@ -253,7 +253,7 @@ describe('/liquidity_pools tests', function() {
             "type_i": 23,
             "created_at": "2021-11-18T03:47:47Z",
             "transaction_hash": "43ed5ce19190822ec080b67c3ccbab36a56bc34102b1a21d3ee690ed3bc23378",
-            "liquidity_pool_id": "1",
+            "liquidity_pool_id": "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a",
             "reserves_min": [
               {
                 "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
@@ -286,7 +286,7 @@ describe('/liquidity_pools tests', function() {
             "created_at": "2021-08-04T20:01:24Z",
             "transaction_hash": "941f2fa2101d1265696a3c7d35e7688cd210324114e96b64a386ab55f65e488f",
             "asset_type": "liquidity_pool_shares",
-            "liquidity_pool_id": "1",
+            "liquidity_pool_id": "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a",
             "limit": "1000",
             "trustor": "GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG"
           },
@@ -334,13 +334,13 @@ describe('/liquidity_pools tests', function() {
     const poolTxsResponse = {
       "_links": {
         "self": {
-          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/transactions?cursor=113725249324879873&limit=10&order=asc"
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a/transactions?cursor=113725249324879873&limit=10&order=asc"
         },
         "next": {
-          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/transactions?cursor=113725249324879873&limit=10&order=asc"
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a/transactions?cursor=113725249324879873&limit=10&order=asc"
         },
         "prev": {
-          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/transactions?cursor=113725249324879873&limit=10&order=desc"
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a/transactions?cursor=113725249324879873&limit=10&order=desc"
         }
       },
       "_embedded": {
@@ -416,16 +416,16 @@ describe('/liquidity_pools tests', function() {
         .catch(done);
     });
 
-    const poolFxsResponse = {
+    const poolEffectsResponse = {
       "_links": {
         "self": {
-          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools?cursor=113725249324879873&limit=10&order=asc"
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a/effects?cursor=113725249324879873&limit=10&order=asc"
         },
         "next": {
-          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools?cursor=113725249324879873&limit=10&order=asc"
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a/effects?cursor=113725249324879873&limit=10&order=asc"
         },
         "prev": {
-          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools?cursor=113725249324879873&limit=10&order=asc"
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a/effects?cursor=113725249324879873&limit=10&order=asc"
         }
       },
       "_embedded": {
@@ -659,14 +659,14 @@ describe('/liquidity_pools tests', function() {
       this.axiosMock
         .expects('get')
         .withArgs(sinon.match(`${LP_URL}/${lpId}/effects`))
-        .returns(Promise.resolve({ data: poolFxsResponse }))
+        .returns(Promise.resolve({ data: poolEffectsResponse }))
 
       this.server
         .effects()
         .forLiquidityPool(lpId)
         .call()
-        .then((poolFxs) => {
-          expect(poolFxs.records).to.deep.equal(poolFxsResponse._embedded.records);
+        .then((poolEffects) => {
+          expect(poolEffects.records).to.deep.equal(poolEffectsResponse._embedded.records);
           done();
         })
         .catch(done);

--- a/test/unit/liquidity_pool_endpoints_test.js
+++ b/test/unit/liquidity_pool_endpoints_test.js
@@ -184,4 +184,980 @@ describe('/liquidity_pools tests', function() {
         .catch(done);
     });
   });
+
+  describe('querying a specific pool', function() {
+    const lpId = "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a";
+
+    const poolOpsResponse = {
+      "_links": {
+        "self": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/operations?cursor=113725249324879873&limit=10&order=asc"
+        },
+        "next": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/operations?cursor=113725249324879873&limit=10&order=asc"
+        },
+        "prev": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/operations?cursor=113725249324879873&limit=10&order=desc"
+        }
+      },
+      "_embedded": {
+        "records": [
+          {
+            "id": "3697472920621057",
+            "paging_token": "3697472920621057",
+            "transaction_successful": true,
+            "source_account": "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L",
+            "type": "liquidity_pool_deposit",
+            "type_i": 22,
+            "created_at": "2021-11-18T03:47:47Z",
+            "transaction_hash": "43ed5ce19190822ec080b67c3ccbab36a56bc34102b1a21d3ee690ed3bc23378",
+            "liquidity_pool_id": "1",
+            "reserves_max": [
+              {
+                "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+                "amount": "1000.0000005"
+              },
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "3000.0000005"
+              }
+            ],
+            "min_price": "0.2680000",
+            "min_price_r": {
+              "n": 67,
+              "d": 250
+            },
+            "max_price": "0.3680000",
+            "max_price_r": {
+              "n": 73,
+              "d": 250
+            },
+            "reserves_deposited": [
+              {
+                "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+                "amount": "983.0000005"
+              },
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "2378.0000005"
+              }
+            ],
+            "shares_received": "1000"
+          },
+          {
+            "id": "3697472920621057",
+            "paging_token": "3697472920621057",
+            "transaction_successful": true,
+            "source_account": "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L",
+            "type": "liquidity_pool_withdraw",
+            "type_i": 23,
+            "created_at": "2021-11-18T03:47:47Z",
+            "transaction_hash": "43ed5ce19190822ec080b67c3ccbab36a56bc34102b1a21d3ee690ed3bc23378",
+            "liquidity_pool_id": "1",
+            "reserves_min": [
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "min": "1000.0000005"
+              },
+              {
+                "asset": "PHP:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "min": "3000.0000005"
+              }
+            ],
+            "shares": "200",
+            "reserves_received": [
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "993.0000005"
+              },
+              {
+                "asset": "PHP:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "2478.0000005"
+              }
+            ]
+          },
+          {
+            "id": "157639717969326081",
+            "paging_token": "157639717969326081",
+            "transaction_successful": true,
+            "source_account": "GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG",
+            "type": "change_trust",
+            "type_i": 6,
+            "created_at": "2021-08-04T20:01:24Z",
+            "transaction_hash": "941f2fa2101d1265696a3c7d35e7688cd210324114e96b64a386ab55f65e488f",
+            "asset_type": "liquidity_pool_shares",
+            "liquidity_pool_id": "1",
+            "limit": "1000",
+            "trustor": "GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG"
+          },
+          {
+            "id": "157235845014249474-0",
+            "paging_token": "157235845014249474-0",
+            "ledger_close_time": "2021-07-29T21:10:53Z",
+            "trade_type": "liquidity_pool",
+            "base_liquidity_pool_id": "abcdef",
+            "liquidity_pool_fee_bp": 30,
+            "base_amount": "0.0002007",
+            "base_asset_type": "native",
+            "counter_account": "GDW634JZX3VMEF2RZTCJTT34RITIMNX46QOGTYHCJEJL3MM7BLOQ6HOW",
+            "counter_amount": "0.0022300",
+            "counter_asset_type": "credit_alphanum4",
+            "counter_asset_code": "VZT",
+            "counter_asset_issuer": "GBENYXZDFFR2J4F4DB3YPBBAM244TXYOTIOOUQI5DBT3OKUU4ZJ2M7NO",
+            "base_is_seller": false,
+            "price": {
+              "n": "10000000",
+              "d": "899997"
+            }
+          }
+        ]
+      }
+    };
+
+    it('retrieves its operations', function(done) {
+      this.axiosMock
+        .expects('get')
+        .withArgs(sinon.match(`${LP_URL}/${lpId}/operations`))
+        .returns(Promise.resolve({ data: poolOpsResponse }))
+
+      this.server
+        .operations()
+        .forLiquidityPool(lpId)
+        .call()
+        .then((poolOps) => {
+          expect(poolOps.records).to.deep.equal(poolOpsResponse._embedded.records);
+          done();
+        })
+        .catch(done);
+    });
+
+    const poolTxsResponse = {
+      "_links": {
+        "self": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/transactions?cursor=113725249324879873&limit=10&order=asc"
+        },
+        "next": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/transactions?cursor=113725249324879873&limit=10&order=asc"
+        },
+        "prev": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/transactions?cursor=113725249324879873&limit=10&order=desc"
+        }
+      },
+      "_embedded": {
+        "records": [
+          {
+            "_links": {
+              "self": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/transactions/2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908"
+              },
+              "account": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/accounts/GAHQN6YNYD6ZT7TLAVE4R36MSZWQJZ22XB3WD4RLSHURMXHW4VHJIDF7"
+              },
+              "ledger": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/ledgers/895788"
+              },
+              "operations": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/transactions/2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908/operations",
+                "templated": true
+              },
+              "effects": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/transactions/2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908/effects",
+                "templated": true
+              },
+              "precedes": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/transactions?order=asc&cursor=3847380164161536"
+              },
+              "succeeds": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/transactions?order=desc&cursor=3847380164161536"
+              },
+              "transaction": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/transactions/2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908"
+              }
+            },
+            "id": "2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908",
+            "paging_token": "3847380164161536",
+            "successful": true,
+            "hash": "2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908",
+            "ledger": 895788,
+            "created_at": "2021-08-09T20:53:11Z",
+            "source_account": "GAHQN6YNYD6ZT7TLAVE4R36MSZWQJZ22XB3WD4RLSHURMXHW4VHJIDF7",
+            "source_account_sequence": "3847371574214658",
+            "fee_account": "GAHQN6YNYD6ZT7TLAVE4R36MSZWQJZ22XB3WD4RLSHURMXHW4VHJIDF7",
+            "fee_charged": "10000",
+            "max_fee": "10001",
+            "operation_count": 1,
+            "envelope_xdr": "AAAAAgAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAJxEADasqAAAAAgAAAAAAAAAAAAAAAQAAAAEAAAAADwb7DcD9mf5rBUnI78yWbQTnWrh3YfIrkekWXPblTpQAAAAGAAAAAVNFQwAAAAAAm6XFaVsf8OSuS9C9gMplyTjagE9jAnnqwxSDJ6fin6IAsaK8LsUAAAAAAAAAAAAB9uVOlAAAAECXmRsoXmRiJjUrtbkDZYRnzac5s1CVV4g2RlIgBIuQty21npz3A1VhUcSmAx+GmsyGxVFvIrcdstTawJlmy9kF",
+            "result_xdr": "AAAAAAAAJxAAAAAAAAAAAQAAAAAAAAAGAAAAAAAAAAA=",
+            "result_meta_xdr": "AAAAAgAAAAIAAAADAA2rLAAAAAAAAAAADwb7DcD9mf5rBUnI78yWbQTnWrh3YfIrkekWXPblTpQAAAAAGtJNDAANqyoAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA2rLAAAAAAAAAAADwb7DcD9mf5rBUnI78yWbQTnWrh3YfIrkekWXPblTpQAAAAAGtJNDAANqyoAAAACAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADassAAAAAAAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAAa0k0MAA2rKgAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADassAAAAAAAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAAa0k0MAA2rKgAAAAIAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADassAAAAAQAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAFTRUMAAAAAAJulxWlbH/DkrkvQvYDKZck42oBPYwJ56sMUgyen4p+iAAAAAAAAAAAAsaK8LsUAAAAAAAEAAAAAAAAAAAAAAAA=",
+            "fee_meta_xdr": "AAAAAgAAAAMADasrAAAAAAAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAAa0nQcAA2rKgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADassAAAAAAAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAAa0k0MAA2rKgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+            "memo_type": "none",
+            "signatures": [
+              "l5kbKF5kYiY1K7W5A2WEZ82nObNQlVeINkZSIASLkLcttZ6c9wNVYVHEpgMfhprMhsVRbyK3HbLU2sCZZsvZBQ=="
+            ]
+          }
+        ]
+      }
+    };
+
+    it('retrieves its transactions', function(done) {
+      this.axiosMock
+        .expects('get')
+        .withArgs(sinon.match(`${LP_URL}/${lpId}/transactions`))
+        .returns(Promise.resolve({ data: poolTxsResponse }))
+
+      this.server
+        .transactions()
+        .forLiquidityPool(lpId)
+        .call()
+        .then((poolTxs) => {
+          expect(poolTxs.records).to.deep.equal(poolTxsResponse._embedded.records);
+          done();
+        })
+        .catch(done);
+    });
+
+    const poolFxsResponse = {
+      "_links": {
+        "self": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools?cursor=113725249324879873&limit=10&order=asc"
+        },
+        "next": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools?cursor=113725249324879873&limit=10&order=asc"
+        },
+        "prev": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools?cursor=113725249324879873&limit=10&order=asc"
+        }
+      },
+      "_embedded": {
+        "records": [
+          {
+            "_links": {
+              "operation": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/operations/3849085266190337"
+              },
+              "succeeds": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/effects?order=desc&cursor=3849085266190337-1"
+              },
+              "precedes": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/effects?order=asc&cursor=3849085266190337-1"
+              }
+            },
+            "id": "0000000012884905986-0000000001",
+            "paging_token": "12884905986-2",
+            "account": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "type": "liquidity_pool_deposited",
+            "type_i": 81,
+            "created_at": "2021-11-18T03:15:54Z",
+            "liquidity_pool": {
+              "id": "abcdef",
+              "fee_bp": 30,
+              "type": "constant_product",
+              "total_trustlines": "300",
+              "total_shares": "5000",
+              "reserves": [
+                {
+                  "amount": "1000.0000005",
+                  "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+                },
+                {
+                  "amount": "2000.0000000",
+                  "asset": "PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP"
+                }
+              ]
+            },
+            "reserves_deposited": [
+              {
+                "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+                "amount": "983.0000005"
+              },
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "2378.0000005"
+              }
+            ],
+            "shares_received": "1000"
+          },
+          {
+            "id": "0000000012884905986-0000000002",
+            "paging_token": "12884905986-2",
+            "account": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "type": "liquidity_pool_withdrew",
+            "type_i": 82,
+            "created_at": "2021-11-18T03:15:54Z",
+            "liquidity_pool": {
+              "id": "abcdef",
+              "fee_bp": 30,
+              "type": "constant_product",
+              "total_trustlines": "299",
+              "total_shares": "4000",
+              "reserves": [
+                {
+                  "amount": "7.0000005",
+                  "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+                },
+                {
+                  "amount": "1.0000000",
+                  "asset": "PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP"
+                }
+              ]
+            },
+            "reserves_received": [
+              {
+                "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+                "amount": "993.0000005"
+              },
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "2478.0000005"
+              }
+            ],
+            "shares_redeemed": "1000"
+          },
+          {
+            "id": "0000000012884905986-0000000003",
+            "paging_token": "12884905986-2",
+            "account": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "type": "liquidity_pool_trade",
+            "type_i": 83,
+            "created_at": "2021-11-18T03:15:54Z",
+            "liquidity_pool": {
+              "id": "abcdef",
+              "fee_bp": 30,
+              "type": "constant_product",
+              "total_trustlines": "300",
+              "total_shares": "5000",
+              "reserves": [
+                {
+                  "amount": "1000.0000005",
+                  "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+                },
+                {
+                  "amount": "2000.0000000",
+                  "asset": "PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP"
+                }
+              ]
+            },
+            "sold": {
+              "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+              "amount": "983.0000005"
+            },
+            "bought": {
+              "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+              "amount": "2378.0000005"
+            }
+          },
+          {
+            "id": "0000000012884905986-0000000004",
+            "paging_token": "12884905986-2",
+            "account": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "type": "liquidity_pool_created",
+            "type_i": 84,
+            "created_at": "2021-11-18T03:15:54Z",
+            "liquidity_pool": {
+              "id": "abcdef",
+              "fee_bp": 30,
+              "type": "constant_product",
+              "total_trustlines": "1",
+              "total_shares": "0",
+              "reserves": [
+                {
+                  "amount": "0",
+                  "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+                },
+                {
+                  "amount": "0",
+                  "asset": "PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP"
+                }
+              ]
+            }
+          },
+          {
+            "id": "0000000012884905986-0000000005",
+            "paging_token": "12884905986-2",
+            "account": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "type": "liquidity_pool_removed",
+            "type_i": 85,
+            "created_at": "2021-11-18T03:15:54Z",
+            "liquidity_pool_id": "abcdef"
+          },
+          {
+            "id": "0000000012884905986-0000000006",
+            "paging_token": "12884905986-2",
+            "account": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "type": "liquidity_pool_revoked",
+            "type_i": 86,
+            "created_at": "2021-11-18T03:15:54Z",
+            "liquidity_pool": {
+              "id": "abcdef",
+              "fee_bp": 30,
+              "type": "constant_product",
+              "total_trustlines": "299",
+              "total_shares": "4000",
+              "reserves": [
+                {
+                  "amount": "7.0000005",
+                  "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+                },
+                {
+                  "amount": "1.0000000",
+                  "asset": "PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP"
+                }
+              ]
+            },
+            "reserves_revoked": [
+              {
+                "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+                "amount": "993.0000005",
+                "claimable_balance_id": "cbid1235"
+              },
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "2478.0000005",
+                "claimable_balance_id": "idcbd1234"
+              }
+            ],
+            "shares_revoked": "1000"
+          },
+          {
+            "id": "0000000012884905986-0000000007",
+            "paging_token": "157639717969326081-1",
+            "account": "GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG",
+            "type": "trustline_created",
+            "type_i": 20,
+            "created_at": "2021-08-04T20:01:24Z",
+            "asset_type": "liquidity_pool_shares",
+            "liquidity_pool_id": "abcdef",
+            "limit": "1000"
+          },
+          {
+            "id": "0000000012884905986-0000000008",
+            "paging_token": "157639717969326081-1",
+            "account": "GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG",
+            "type": "trustline_updated",
+            "type_i": 22,
+            "created_at": "2021-08-04T20:01:24Z",
+            "asset_type": "liquidity_pool_shares",
+            "liquidity_pool_id": "abcdef",
+            "limit": "2000"
+          },
+          {
+            "id": "0000000012884905986-0000000009",
+            "paging_token": "157639717969326081-1",
+            "account": "GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG",
+            "type": "trustline_removed",
+            "type_i": 21,
+            "created_at": "2021-08-04T20:01:24Z",
+            "asset_type": "liquidity_pool_shares",
+            "liquidity_pool_id": "abcdef",
+            "limit": "0.0000000"
+          }
+        ]
+      }
+    };
+
+    it('retrieves its effects', function(done) {
+      this.axiosMock
+        .expects('get')
+        .withArgs(sinon.match(`${LP_URL}/${lpId}/effects`))
+        .returns(Promise.resolve({ data: poolFxsResponse }))
+
+      this.server
+        .effects()
+        .forLiquidityPool(lpId)
+        .call()
+        .then((poolFxs) => {
+          expect(poolFxs.records).to.deep.equal(poolFxsResponse._embedded.records);
+          done();
+        })
+        .catch(done);
+    });
+  });
+
+  describe('querying a specific pool', function() {
+    const lpId = "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a";
+
+    const poolOpsResponse = {
+      "_links": {
+        "self": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/operations?cursor=113725249324879873&limit=10&order=asc"
+        },
+        "next": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/operations?cursor=113725249324879873&limit=10&order=asc"
+        },
+        "prev": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/operations?cursor=113725249324879873&limit=10&order=desc"
+        }
+      },
+      "_embedded": {
+        "records": [
+          {
+            "id": "3697472920621057",
+            "paging_token": "3697472920621057",
+            "transaction_successful": true,
+            "source_account": "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L",
+            "type": "liquidity_pool_deposit",
+            "type_i": 22,
+            "created_at": "2021-11-18T03:47:47Z",
+            "transaction_hash": "43ed5ce19190822ec080b67c3ccbab36a56bc34102b1a21d3ee690ed3bc23378",
+            "liquidity_pool_id": "1",
+            "reserves_max": [
+              {
+                "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+                "amount": "1000.0000005"
+              },
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "3000.0000005"
+              }
+            ],
+            "min_price": "0.2680000",
+            "min_price_r": {
+              "n": 67,
+              "d": 250
+            },
+            "max_price": "0.3680000",
+            "max_price_r": {
+              "n": 73,
+              "d": 250
+            },
+            "reserves_deposited": [
+              {
+                "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+                "amount": "983.0000005"
+              },
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "2378.0000005"
+              }
+            ],
+            "shares_received": "1000"
+          },
+          {
+            "id": "3697472920621057",
+            "paging_token": "3697472920621057",
+            "transaction_successful": true,
+            "source_account": "GBB4JST32UWKOLGYYSCEYBHBCOFL2TGBHDVOMZP462ET4ZRD4ULA7S2L",
+            "type": "liquidity_pool_withdraw",
+            "type_i": 23,
+            "created_at": "2021-11-18T03:47:47Z",
+            "transaction_hash": "43ed5ce19190822ec080b67c3ccbab36a56bc34102b1a21d3ee690ed3bc23378",
+            "liquidity_pool_id": "1",
+            "reserves_min": [
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "min": "1000.0000005"
+              },
+              {
+                "asset": "PHP:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "min": "3000.0000005"
+              }
+            ],
+            "shares": "200",
+            "reserves_received": [
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "993.0000005"
+              },
+              {
+                "asset": "PHP:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "2478.0000005"
+              }
+            ]
+          },
+          {
+            "id": "157639717969326081",
+            "paging_token": "157639717969326081",
+            "transaction_successful": true,
+            "source_account": "GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG",
+            "type": "change_trust",
+            "type_i": 6,
+            "created_at": "2021-08-04T20:01:24Z",
+            "transaction_hash": "941f2fa2101d1265696a3c7d35e7688cd210324114e96b64a386ab55f65e488f",
+            "asset_type": "liquidity_pool_shares",
+            "liquidity_pool_id": "1",
+            "limit": "1000",
+            "trustor": "GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG"
+          },
+          {
+            "id": "157235845014249474-0",
+            "paging_token": "157235845014249474-0",
+            "ledger_close_time": "2021-07-29T21:10:53Z",
+            "trade_type": "liquidity_pool",
+            "base_liquidity_pool_id": "abcdef",
+            "liquidity_pool_fee_bp": 30,
+            "base_amount": "0.0002007",
+            "base_asset_type": "native",
+            "counter_account": "GDW634JZX3VMEF2RZTCJTT34RITIMNX46QOGTYHCJEJL3MM7BLOQ6HOW",
+            "counter_amount": "0.0022300",
+            "counter_asset_type": "credit_alphanum4",
+            "counter_asset_code": "VZT",
+            "counter_asset_issuer": "GBENYXZDFFR2J4F4DB3YPBBAM244TXYOTIOOUQI5DBT3OKUU4ZJ2M7NO",
+            "base_is_seller": false,
+            "price": {
+              "n": "10000000",
+              "d": "899997"
+            }
+          }
+        ]
+      }
+    };
+
+    it('retrieves its operations', function(done) {
+      this.axiosMock
+        .expects('get')
+        .withArgs(sinon.match(`${LP_URL}/${lpId}/operations`))
+        .returns(Promise.resolve({ data: poolOpsResponse }))
+
+      this.server
+        .operations()
+        .forLiquidityPool(lpId)
+        .call()
+        .then((poolOps) => {
+          expect(poolOps.records).to.deep.equal(poolOpsResponse._embedded.records);
+          done();
+        })
+        .catch(done);
+    });
+
+    const poolTxsResponse = {
+      "_links": {
+        "self": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/transactions?cursor=113725249324879873&limit=10&order=asc"
+        },
+        "next": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/transactions?cursor=113725249324879873&limit=10&order=asc"
+        },
+        "prev": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools/1/transactions?cursor=113725249324879873&limit=10&order=desc"
+        }
+      },
+      "_embedded": {
+        "records": [
+          {
+            "_links": {
+              "self": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/transactions/2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908"
+              },
+              "account": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/accounts/GAHQN6YNYD6ZT7TLAVE4R36MSZWQJZ22XB3WD4RLSHURMXHW4VHJIDF7"
+              },
+              "ledger": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/ledgers/895788"
+              },
+              "operations": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/transactions/2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908/operations",
+                "templated": true
+              },
+              "effects": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/transactions/2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908/effects",
+                "templated": true
+              },
+              "precedes": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/transactions?order=asc&cursor=3847380164161536"
+              },
+              "succeeds": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/transactions?order=desc&cursor=3847380164161536"
+              },
+              "transaction": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/transactions/2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908"
+              }
+            },
+            "id": "2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908",
+            "paging_token": "3847380164161536",
+            "successful": true,
+            "hash": "2ff47e1bafe68639276b2a8df0a73597ee0c062fbcc72d121af314fe7851c908",
+            "ledger": 895788,
+            "created_at": "2021-08-09T20:53:11Z",
+            "source_account": "GAHQN6YNYD6ZT7TLAVE4R36MSZWQJZ22XB3WD4RLSHURMXHW4VHJIDF7",
+            "source_account_sequence": "3847371574214658",
+            "fee_account": "GAHQN6YNYD6ZT7TLAVE4R36MSZWQJZ22XB3WD4RLSHURMXHW4VHJIDF7",
+            "fee_charged": "10000",
+            "max_fee": "10001",
+            "operation_count": 1,
+            "envelope_xdr": "AAAAAgAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAJxEADasqAAAAAgAAAAAAAAAAAAAAAQAAAAEAAAAADwb7DcD9mf5rBUnI78yWbQTnWrh3YfIrkekWXPblTpQAAAAGAAAAAVNFQwAAAAAAm6XFaVsf8OSuS9C9gMplyTjagE9jAnnqwxSDJ6fin6IAsaK8LsUAAAAAAAAAAAAB9uVOlAAAAECXmRsoXmRiJjUrtbkDZYRnzac5s1CVV4g2RlIgBIuQty21npz3A1VhUcSmAx+GmsyGxVFvIrcdstTawJlmy9kF",
+            "result_xdr": "AAAAAAAAJxAAAAAAAAAAAQAAAAAAAAAGAAAAAAAAAAA=",
+            "result_meta_xdr": "AAAAAgAAAAIAAAADAA2rLAAAAAAAAAAADwb7DcD9mf5rBUnI78yWbQTnWrh3YfIrkekWXPblTpQAAAAAGtJNDAANqyoAAAABAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAA2rLAAAAAAAAAAADwb7DcD9mf5rBUnI78yWbQTnWrh3YfIrkekWXPblTpQAAAAAGtJNDAANqyoAAAACAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAABAAAAAwAAAAMADassAAAAAAAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAAa0k0MAA2rKgAAAAIAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADassAAAAAAAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAAa0k0MAA2rKgAAAAIAAAABAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAADassAAAAAQAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAFTRUMAAAAAAJulxWlbH/DkrkvQvYDKZck42oBPYwJ56sMUgyen4p+iAAAAAAAAAAAAsaK8LsUAAAAAAAEAAAAAAAAAAAAAAAA=",
+            "fee_meta_xdr": "AAAAAgAAAAMADasrAAAAAAAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAAa0nQcAA2rKgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAEADassAAAAAAAAAAAPBvsNwP2Z/msFScjvzJZtBOdauHdh8iuR6RZc9uVOlAAAAAAa0k0MAA2rKgAAAAEAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAA==",
+            "memo_type": "none",
+            "signatures": [
+              "l5kbKF5kYiY1K7W5A2WEZ82nObNQlVeINkZSIASLkLcttZ6c9wNVYVHEpgMfhprMhsVRbyK3HbLU2sCZZsvZBQ=="
+            ]
+          }
+        ]
+      }
+    };
+
+    it('retrieves its transactions', function(done) {
+      this.axiosMock
+        .expects('get')
+        .withArgs(sinon.match(`${LP_URL}/${lpId}/transactions`))
+        .returns(Promise.resolve({ data: poolTxsResponse }))
+
+      this.server
+        .transactions()
+        .forLiquidityPool(lpId)
+        .call()
+        .then((poolTxs) => {
+          expect(poolTxs.records).to.deep.equal(poolTxsResponse._embedded.records);
+          done();
+        })
+        .catch(done);
+    });
+
+    const poolFxsResponse = {
+      "_links": {
+        "self": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools?cursor=113725249324879873&limit=10&order=asc"
+        },
+        "next": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools?cursor=113725249324879873&limit=10&order=asc"
+        },
+        "prev": {
+          "href": "https://private-33c60-amm3.apiary-mock.com/liquidity_pools?cursor=113725249324879873&limit=10&order=asc"
+        }
+      },
+      "_embedded": {
+        "records": [
+          {
+            "_links": {
+              "operation": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/operations/3849085266190337"
+              },
+              "succeeds": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/effects?order=desc&cursor=3849085266190337-1"
+              },
+              "precedes": {
+                "href": "https://private-33c60-amm3.apiary-mock.com/effects?order=asc&cursor=3849085266190337-1"
+              }
+            },
+            "id": "0000000012884905986-0000000001",
+            "paging_token": "12884905986-2",
+            "account": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "type": "liquidity_pool_deposited",
+            "type_i": 81,
+            "created_at": "2021-11-18T03:15:54Z",
+            "liquidity_pool": {
+              "id": "abcdef",
+              "fee_bp": 30,
+              "type": "constant_product",
+              "total_trustlines": "300",
+              "total_shares": "5000",
+              "reserves": [
+                {
+                  "amount": "1000.0000005",
+                  "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+                },
+                {
+                  "amount": "2000.0000000",
+                  "asset": "PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP"
+                }
+              ]
+            },
+            "reserves_deposited": [
+              {
+                "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+                "amount": "983.0000005"
+              },
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "2378.0000005"
+              }
+            ],
+            "shares_received": "1000"
+          },
+          {
+            "id": "0000000012884905986-0000000002",
+            "paging_token": "12884905986-2",
+            "account": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "type": "liquidity_pool_withdrew",
+            "type_i": 82,
+            "created_at": "2021-11-18T03:15:54Z",
+            "liquidity_pool": {
+              "id": "abcdef",
+              "fee_bp": 30,
+              "type": "constant_product",
+              "total_trustlines": "299",
+              "total_shares": "4000",
+              "reserves": [
+                {
+                  "amount": "7.0000005",
+                  "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+                },
+                {
+                  "amount": "1.0000000",
+                  "asset": "PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP"
+                }
+              ]
+            },
+            "reserves_received": [
+              {
+                "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+                "amount": "993.0000005"
+              },
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "2478.0000005"
+              }
+            ],
+            "shares_redeemed": "1000"
+          },
+          {
+            "id": "0000000012884905986-0000000003",
+            "paging_token": "12884905986-2",
+            "account": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "type": "liquidity_pool_trade",
+            "type_i": 83,
+            "created_at": "2021-11-18T03:15:54Z",
+            "liquidity_pool": {
+              "id": "abcdef",
+              "fee_bp": 30,
+              "type": "constant_product",
+              "total_trustlines": "300",
+              "total_shares": "5000",
+              "reserves": [
+                {
+                  "amount": "1000.0000005",
+                  "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+                },
+                {
+                  "amount": "2000.0000000",
+                  "asset": "PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP"
+                }
+              ]
+            },
+            "sold": {
+              "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+              "amount": "983.0000005"
+            },
+            "bought": {
+              "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+              "amount": "2378.0000005"
+            }
+          },
+          {
+            "id": "0000000012884905986-0000000004",
+            "paging_token": "12884905986-2",
+            "account": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "type": "liquidity_pool_created",
+            "type_i": 84,
+            "created_at": "2021-11-18T03:15:54Z",
+            "liquidity_pool": {
+              "id": "abcdef",
+              "fee_bp": 30,
+              "type": "constant_product",
+              "total_trustlines": "1",
+              "total_shares": "0",
+              "reserves": [
+                {
+                  "amount": "0",
+                  "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+                },
+                {
+                  "amount": "0",
+                  "asset": "PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP"
+                }
+              ]
+            }
+          },
+          {
+            "id": "0000000012884905986-0000000005",
+            "paging_token": "12884905986-2",
+            "account": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "type": "liquidity_pool_removed",
+            "type_i": 85,
+            "created_at": "2021-11-18T03:15:54Z",
+            "liquidity_pool_id": "abcdef"
+          },
+          {
+            "id": "0000000012884905986-0000000006",
+            "paging_token": "12884905986-2",
+            "account": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7",
+            "type": "liquidity_pool_revoked",
+            "type_i": 86,
+            "created_at": "2021-11-18T03:15:54Z",
+            "liquidity_pool": {
+              "id": "abcdef",
+              "fee_bp": 30,
+              "type": "constant_product",
+              "total_trustlines": "299",
+              "total_shares": "4000",
+              "reserves": [
+                {
+                  "amount": "7.0000005",
+                  "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S"
+                },
+                {
+                  "amount": "1.0000000",
+                  "asset": "PHP:GBUQWP3BOUZX34TOND2QV7QQ7K7VJTG6VSE7WMLBTMDJLLAW7YKGU6EP"
+                }
+              ]
+            },
+            "reserves_revoked": [
+              {
+                "asset": "JPY:GBVAOIACNSB7OVUXJYC5UE2D4YK2F7A24T7EE5YOMN4CE6GCHUTOUQXM",
+                "amount": "993.0000005",
+                "claimable_balance_id": "cbid1235"
+              },
+              {
+                "asset": "EURT:GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S",
+                "amount": "2478.0000005",
+                "claimable_balance_id": "idcbd1234"
+              }
+            ],
+            "shares_revoked": "1000"
+          },
+          {
+            "id": "0000000012884905986-0000000007",
+            "paging_token": "157639717969326081-1",
+            "account": "GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG",
+            "type": "trustline_created",
+            "type_i": 20,
+            "created_at": "2021-08-04T20:01:24Z",
+            "asset_type": "liquidity_pool_shares",
+            "liquidity_pool_id": "abcdef",
+            "limit": "1000"
+          },
+          {
+            "id": "0000000012884905986-0000000008",
+            "paging_token": "157639717969326081-1",
+            "account": "GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG",
+            "type": "trustline_updated",
+            "type_i": 22,
+            "created_at": "2021-08-04T20:01:24Z",
+            "asset_type": "liquidity_pool_shares",
+            "liquidity_pool_id": "abcdef",
+            "limit": "2000"
+          },
+          {
+            "id": "0000000012884905986-0000000009",
+            "paging_token": "157639717969326081-1",
+            "account": "GBBWI7TEVQBPEUXKYNGI3GBAH7EHFEREONKK3UK56ZSLJIDIYHQJCVSG",
+            "type": "trustline_removed",
+            "type_i": 21,
+            "created_at": "2021-08-04T20:01:24Z",
+            "asset_type": "liquidity_pool_shares",
+            "liquidity_pool_id": "abcdef",
+            "limit": "0.0000000"
+          }
+        ]
+      }
+    };
+
+    it('retrieves its effects', function(done) {
+      this.axiosMock
+        .expects('get')
+        .withArgs(sinon.match(`${LP_URL}/${lpId}/effects`))
+        .returns(Promise.resolve({ data: poolFxsResponse }))
+
+      this.server
+        .effects()
+        .forLiquidityPool(lpId)
+        .call()
+        .then((poolFxs) => {
+          expect(poolFxs.records).to.deep.equal(poolFxsResponse._embedded.records);
+          done();
+        })
+        .catch(done);
+    });
+  });
 });


### PR DESCRIPTION
This supports building queries to the following endpoints:

 - `/liquidity_pools/:id/operations`
 - `/liquidity_pools/:id/transactions`
 - `/liquidity_pools/:id/effects`