### PR TITLE
Add new effect types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ A breaking change will get clearly marked in this log.
 ### Add
 
 - Introduced a `LiquidityPoolCallBuilder` to make calls to the new `/liquidity_pools` endpoint, including filtering by reserve asset ([#682](https://github.com/stellar/js-stellar-sdk/pull/682)).
+- New effect types: `DepositLiquidityEffect`, `WithdrawLiquidityEffect`, `LiquidityPoolTradeEffect`, `LiquidityPoolCreatedEffect`, `LiquidityPoolRemovedEffect` and `LiquidityPoolRevokedEffect`.
 
 ### Updates
 
@@ -35,6 +36,8 @@ A breaking change will get clearly marked in this log.
   - `asset_type` can now be `liquidity_pool_shares`.
   - `asset_code` and `asset_issuer` are now optional.
   - Added `liquidity_pool_id` as an optional field.
+- Trustline created/updated/revoked effects' asset type can now be `liquidity_pool_shares`.
+- Trustline sponsorship effects have been updated so the `asset` becomes optional and is replaced with `liquidity_pool_id` for liquidity pools.
 
 ### Fix
 - Updated various developer dependencies to secure versions ([#671](https://github.com/stellar/js-stellar-sdk/pull/671)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ A breaking change will get clearly marked in this log.
 
 - Introduced a `LiquidityPoolCallBuilder` to make calls to the new `/liquidity_pools` endpoint, including filtering by reserve asset ([#682](https://github.com/stellar/js-stellar-sdk/pull/682)).
 - New effect types: `DepositLiquidityEffect`, `WithdrawLiquidityEffect`, `LiquidityPoolTradeEffect`, `LiquidityPoolCreatedEffect`, `LiquidityPoolRemovedEffect` and `LiquidityPoolRevokedEffect`.
+- The `RevokeSponsorshipOperationResponse` interface can now contain an optional attribute `trustline_liquidity_pool_id` for when a liquidity pool trustline is revoked.
 
 ### Updates
 

--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -467,6 +467,7 @@ export namespace Horizon {
     offer_id?: string;
     trustline_account_id?: string;
     trustline_asset?: string;
+    trustline_liquidity_pool_id?: string;
     signer_account_id?: string;
     signer_key?: string;
   }

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -130,6 +130,7 @@ export interface SignerUpdated extends SignerEvents {
 }
 interface TrustlineEvents extends BaseEffectRecord, OfferAsset {
   limit: string;
+  liquidity_pool_id?: string;
 }
 export interface TrustlineCreated extends TrustlineEvents {
   type_i: EffectType.trustline_created;
@@ -193,7 +194,8 @@ export type AccountSponsorshipRemoved = Omit<
 interface TrustlineSponsorshipEvents
   extends BaseEffectRecord,
     SponsershipFields {
-  asset: string;
+  asset?: string;
+  liquidity_pool_id?: string;
 }
 export type TrustlineSponsorshipCreated = Omit<
   TrustlineSponsorshipEvents,

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -257,52 +257,35 @@ export type SignerSponsorshipRemoved = Omit<
   SignerSponsorshipEvents,
   "new_sponsor" | "sponsor"
 > & { type_i: EffectType.signer_sponsorship_removed };
+export interface Reserve {
+  asset: string;
+  amount: string;
+}
 export interface LiquidityPoolEffectRecord extends Horizon.BaseResponse {
   id: string;
   fee_bp: number;
   type: Horizon.LiquidityPoolType;
   total_trustlines: string;
   total_shares: string;
-  reserves: [
-    {
-      amount: string;
-      asset: string;
-    },
-  ];
+  reserves: Reserve[];
 }
 export interface DepositLiquidityEffect extends BaseEffectRecord {
   type_i: EffectType.liquidity_pool_deposited;
   liquidity_pool: LiquidityPoolEffectRecord;
-  reserves_deposited: [
-    {
-      asset: string;
-      amount: string;
-    },
-  ];
+  reserves_deposited: Reserve[];
   shares_received: string;
 }
 export interface WithdrawLiquidityEffect extends BaseEffectRecord {
   type_i: EffectType.liquidity_pool_withdrew;
   liquidity_pool: LiquidityPoolEffectRecord;
-  reserves_received: [
-    {
-      asset: string;
-      amount: string;
-    },
-  ];
+  reserves_received: Reserve[];
   shares_redeemed: string;
 }
 export interface LiquidityPoolTradeEffect extends BaseEffectRecord {
   type_i: EffectType.liquidity_pool_trade;
   liquidity_pool: LiquidityPoolEffectRecord;
-  sold: {
-    asset: string;
-    amount: string;
-  };
-  bought: {
-    asset: string;
-    amount: string;
-  };
+  sold: Reserve;
+  bought: Reserve;
 }
 export interface LiquidityPoolCreatedEffect extends BaseEffectRecord {
   type_i: EffectType.liquidity_pool_created;

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -57,6 +57,8 @@ export enum EffectType {
   claimable_balance_clawed_back = 80,
   liquidity_pool_deposited = 81,
   liquidity_pool_withdrew = 82,
+  liquidity_pool_trade = 83,
+  liquidity_pool_created = 84,
 }
 export interface BaseEffectRecord extends Horizon.BaseResponse {
   id: string;
@@ -285,4 +287,20 @@ export interface WithdrawLiquidityEffect extends BaseEffectRecord {
     },
   ];
   shares_redeemed: string;
+}
+export interface LiquidityPoolTradeEffect extends BaseEffectRecord {
+  type_i: EffectType.liquidity_pool_trade;
+  liquidity_pool: LiquidityPoolEffectRecord;
+  sold: {
+    asset: string;
+    amount: string;
+  };
+  bought: {
+    asset: string;
+    amount: string;
+  };
+}
+export interface LiquidityPoolCreatedEffect extends BaseEffectRecord {
+  type_i: EffectType.liquidity_pool_created;
+  liquidity_pool: LiquidityPoolEffectRecord;
 }

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -55,6 +55,8 @@ export enum EffectType {
   signer_sponsorship_updated = 73,
   signer_sponsorship_removed = 74,
   claimable_balance_clawed_back = 80,
+  liquidity_pool_deposited = 81,
+  liquidity_pool_withdrew = 82,
 }
 export interface BaseEffectRecord extends Horizon.BaseResponse {
   id: string;
@@ -249,3 +251,38 @@ export type SignerSponsorshipRemoved = Omit<
   SignerSponsorshipEvents,
   "new_sponsor" | "sponsor"
 > & { type_i: EffectType.signer_sponsorship_removed };
+export interface LiquidityPoolEffectRecord extends Horizon.BaseResponse {
+  id: string;
+  fee_bp: number;
+  type: Horizon.LiquidityPoolType;
+  total_trustlines: string;
+  total_shares: string;
+  reserves: [
+    {
+      amount: string;
+      asset: string;
+    },
+  ];
+}
+export interface DepositLiquidityEffect extends BaseEffectRecord {
+  type_i: EffectType.liquidity_pool_deposited;
+  liquidity_pool: LiquidityPoolEffectRecord;
+  reserves_deposited: [
+    {
+      asset: string;
+      amount: string;
+    },
+  ];
+  shares_received: string;
+}
+export interface WithdrawLiquidityEffect extends BaseEffectRecord {
+  type_i: EffectType.liquidity_pool_withdrew;
+  liquidity_pool: LiquidityPoolEffectRecord;
+  reserves_received: [
+    {
+      asset: string;
+      amount: string;
+    },
+  ];
+  shares_redeemed: string;
+}

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -59,6 +59,8 @@ export enum EffectType {
   liquidity_pool_withdrew = 82,
   liquidity_pool_trade = 83,
   liquidity_pool_created = 84,
+  liquidity_pool_removed = 85,
+  liquidity_pool_revoked = 86,
 }
 export interface BaseEffectRecord extends Horizon.BaseResponse {
   id: string;
@@ -303,4 +305,20 @@ export interface LiquidityPoolTradeEffect extends BaseEffectRecord {
 export interface LiquidityPoolCreatedEffect extends BaseEffectRecord {
   type_i: EffectType.liquidity_pool_created;
   liquidity_pool: LiquidityPoolEffectRecord;
+}
+export interface LiquidityPoolRemovedEffect extends BaseEffectRecord {
+  type_i: EffectType.liquidity_pool_removed;
+  liquidity_pool_id: string;
+}
+export interface LiquidityPoolRevokedEffect extends BaseEffectRecord {
+  type_i: EffectType.liquidity_pool_revoked;
+  liquidity_pool: LiquidityPoolEffectRecord;
+  reserves_revoked: [
+    {
+      asset: string;
+      amount: string;
+      claimable_balance_id: string;
+    },
+  ];
+  shares_revoked: string;
 }


### PR DESCRIPTION
### Add

- New effect types: `DepositLiquidityEffect`, `WithdrawLiquidityEffect`, `LiquidityPoolTradeEffect`, `LiquidityPoolCreatedEffect`, `LiquidityPoolRemovedEffect` and `LiquidityPoolRevokedEffect`.

### Breaking changes

- Trustline created/updated/revoked effects' asset type can now be `liquidity_pool_shares`.
- Trustline sponsorship effects have been updated so the `asset` becomes optional and is replaced with `liquidity_pool_id` for liquidity pools.