### PR TITLE
Refactors call builders to simplify referencing 'neighbor' endpoints

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -86,7 +86,7 @@ gulp.task('test:watch', function() {
 gulp.task(
   'test:unit',
   gulp.series('build:node', function testUnit() {
-    return gulp.src(['test/test-nodejs.js', 'test/unit/liquidity_pool_endpoints_test.js']).pipe(
+    return gulp.src(['test/test-nodejs.js', 'test/unit/**/*.js']).pipe(
       plugins.mocha({
         reporter: ['spec']
       })

--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -50,11 +50,13 @@ export class CallBuilder<
   protected url: URI;
   public filter: string[][];
   protected originalSegments: string[];
+  protected neighborRoot: string;
 
-  constructor(serverUrl: URI) {
+  constructor(serverUrl: URI, neighborRoot: string = "") {
     this.url = serverUrl.clone();
     this.filter = [];
     this.originalSegments = this.url.segment() || [];
+    this.neighborRoot = neighborRoot;
   }
 
   /**
@@ -239,6 +241,26 @@ export class CallBuilder<
    */
   public join(include: "transactions"): this {
     this.url.setQuery("join", include);
+    return this;
+  }
+
+  /**
+   * A helper method to craft queries to "neighbor" endpoints.
+   *
+   *  For example, we have an `/effects` suffix endpoint on many different
+   *  "root" endpoints, such as `/transactions/:id` and `/accounts/:id`. So,
+   *  it's helpful to be able to conveniently create queries to the
+   *  `/accounts/:id/effects` endpoint:
+   *
+   *    this.forEndpoint("accounts", accountId)`.
+   *
+   * @param  {string} endpoint neighbor endpoint in question, like /operations
+   * @param  {string} param    filter parameter, like an operation ID
+   *
+   * @returns {CallBuilder} this CallBuilder instance
+   */
+  protected forEndpoint(endpoint: string, param: string): this {
+    this.filter.push([endpoint, param, this.neighborRoot]);
     return this;
   }
 

--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -260,6 +260,9 @@ export class CallBuilder<
    * @returns {CallBuilder} this CallBuilder instance
    */
   protected forEndpoint(endpoint: string, param: string): this {
+    if (this.neighborRoot === "") {
+      throw new Error("Invalid usage: neighborRoot not set in constructor");
+    }
     this.filter.push([endpoint, param, this.neighborRoot]);
     return this;
   }

--- a/src/effect_call_builder.ts
+++ b/src/effect_call_builder.ts
@@ -15,7 +15,7 @@ export class EffectCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.EffectRecord>
 > {
   constructor(serverUrl: URI) {
-    super(serverUrl);
+    super(serverUrl, "effects");
     this.url.segment("effects");
   }
 
@@ -26,8 +26,7 @@ export class EffectCallBuilder extends CallBuilder<
    * @returns {EffectCallBuilder} this EffectCallBuilder instance
    */
   public forAccount(accountId: string): this {
-    this.filter.push(["accounts", accountId, "effects"]);
-    return this;
+    return this.forEndpoint("accounts", accountId);
   }
 
   /**
@@ -39,12 +38,10 @@ export class EffectCallBuilder extends CallBuilder<
    * @returns {EffectCallBuilder} this EffectCallBuilder instance
    */
   public forLedger(sequence: number | string): this {
-    this.filter.push([
+    return this.forEndpoint(
       "ledgers",
       typeof sequence === "number" ? sequence.toString() : sequence,
-      "effects",
-    ]);
-    return this;
+    );
   }
 
   /**
@@ -54,8 +51,7 @@ export class EffectCallBuilder extends CallBuilder<
    * @returns {EffectCallBuilder} this EffectCallBuilder instance
    */
   public forTransaction(transactionId: string): this {
-    this.filter.push(["transactions", transactionId, "effects"]);
-    return this;
+    return this.forEndpoint("transactions", transactionId);
   }
 
   /**
@@ -65,8 +61,7 @@ export class EffectCallBuilder extends CallBuilder<
    * @returns {EffectCallBuilder} this EffectCallBuilder instance
    */
   public forOperation(operationId: string): this {
-    this.filter.push(["operations", operationId, "effects"]);
-    return this;
+    return this.forEndpoint("operations", operationId);
   }
 
   /**
@@ -76,7 +71,6 @@ export class EffectCallBuilder extends CallBuilder<
    * @returns {EffectCallBuilder} this EffectCallBuilder instance
    */
   public forLiquidityPool(poolId: string): this {
-    this.filter.push(["liquidity_pools", poolId, "effects"]);
-    return this;
+    return this.forEndpoint("liquidity_pools", poolId);
   }
 }

--- a/src/operation_call_builder.ts
+++ b/src/operation_call_builder.ts
@@ -15,7 +15,7 @@ export class OperationCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.OperationRecord>
 > {
   constructor(serverUrl: URI) {
-    super(serverUrl);
+    super(serverUrl, "operations");
     this.url.segment("operations");
   }
 
@@ -43,8 +43,7 @@ export class OperationCallBuilder extends CallBuilder<
    * @returns {OperationCallBuilder} this OperationCallBuilder instance
    */
   public forAccount(accountId: string): this {
-    this.filter.push(["accounts", accountId, "operations"]);
-    return this;
+    return this.forEndpoint("accounts", accountId);
   }
 
   /**
@@ -54,8 +53,7 @@ export class OperationCallBuilder extends CallBuilder<
    * @returns {OperationCallBuilder} this OperationCallBuilder instance
    */
   public forClaimableBalance(claimableBalanceId: string): this {
-    this.filter.push(["claimable_balances", claimableBalanceId, "operations"]);
-    return this;
+    return this.forEndpoint("claimable_balances", claimableBalanceId);
   }
 
   /**
@@ -66,12 +64,10 @@ export class OperationCallBuilder extends CallBuilder<
    * @returns {OperationCallBuilder} this OperationCallBuilder instance
    */
   public forLedger(sequence: number | string): this {
-    this.filter.push([
+    return this.forEndpoint(
       "ledgers",
       typeof sequence === "number" ? sequence.toString() : sequence,
-      "operations",
-    ]);
-    return this;
+    );
   }
 
   /**
@@ -81,8 +77,7 @@ export class OperationCallBuilder extends CallBuilder<
    * @returns {OperationCallBuilder} this OperationCallBuilder instance
    */
   public forTransaction(transactionId: string): this {
-    this.filter.push(["transactions", transactionId, "operations"]);
-    return this;
+    return this.forEndpoint("transactions", transactionId);
   }
 
   /**
@@ -92,8 +87,7 @@ export class OperationCallBuilder extends CallBuilder<
    * @returns {OperationCallBuilder} this OperationCallBuilder instance
    */
   public forLiquidityPool(poolId: string): this {
-    this.filter.push(["liquidity_pools", poolId, "operations"]);
-    return this;
+    return this.forEndpoint("liquidity_pools", poolId);
   }
 
   /**

--- a/src/transaction_call_builder.ts
+++ b/src/transaction_call_builder.ts
@@ -15,7 +15,7 @@ export class TransactionCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.TransactionRecord>
 > {
   constructor(serverUrl: URI) {
-    super(serverUrl);
+    super(serverUrl, "transactions");
     this.url.segment("transactions");
   }
 
@@ -42,8 +42,7 @@ export class TransactionCallBuilder extends CallBuilder<
    * @returns {TransactionCallBuilder} current TransactionCallBuilder instance
    */
   public forAccount(accountId: string): this {
-    this.filter.push(["accounts", accountId, "transactions"]);
-    return this;
+    return this.forEndpoint("accounts", accountId);
   }
 
   /**
@@ -53,12 +52,7 @@ export class TransactionCallBuilder extends CallBuilder<
    * @returns {TransactionCallBuilder} this TransactionCallBuilder instance
    */
   public forClaimableBalance(claimableBalanceId: string): this {
-    this.filter.push([
-      "claimable_balances",
-      claimableBalanceId,
-      "transactions",
-    ]);
-    return this;
+    return this.forEndpoint("claimable_balances", claimableBalanceId);
   }
 
   /**
@@ -70,9 +64,7 @@ export class TransactionCallBuilder extends CallBuilder<
   public forLedger(sequence: number | string): this {
     const ledgerSequence =
       typeof sequence === "number" ? sequence.toString() : sequence;
-
-    this.filter.push(["ledgers", ledgerSequence, "transactions"]);
-    return this;
+    return this.forEndpoint("ledgers", ledgerSequence);
   }
 
   /**
@@ -82,8 +74,7 @@ export class TransactionCallBuilder extends CallBuilder<
    * @returns {TransactionCallBuilder} this TransactionCallBuilder instance
    */
   public forLiquidityPool(poolId: string): this {
-    this.filter.push(["liquidity_pools", poolId, "transactions"]);
-    return this;
+    return this.forEndpoint("liquidity_pools", poolId);
   }
 
   /**


### PR DESCRIPTION
See the new `CallBuilder.forEndpoint` (name suggestion welcome) for the bulk of the change. The idea is that this code was duplicated everywhere:

```typescript
    this.filter.push(["accounts", accountId, "effects"]);
    return this;
```

Across many call builders. This is both (a) verbose & repetitive, (b) not obvious, and (c) ripe for copy-paste bugs. All of these have been changed to use the new helper method, instead:

```typescript
     return this.forEndpoint("accounts", accountId);
```