### PR TITLE
Update with CAP-38 operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ A breaking change will get clearly marked in this log.
 - Expands the `Operation`, `Transaction`, and `Effects` call builders to allow querying for a specific liquidity pool by ID ([#689](https://github.com/stellar/js-stellar-sdk/pull/689)).
 - New effect types: `DepositLiquidityEffect`, `WithdrawLiquidityEffect`, `LiquidityPoolTradeEffect`, `LiquidityPoolCreatedEffect`, `LiquidityPoolRemovedEffect` and `LiquidityPoolRevokedEffect`.
 - The `RevokeSponsorshipOperationResponse` interface can now contain an optional attribute `trustline_liquidity_pool_id` for when a liquidity pool trustline is revoked.
+- Add operations `DepositLiquidityOperationResponse` and `WithdrawLiquidityOperationResponse`.
 
 ### Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ A breaking change will get clearly marked in this log.
   - Added `liquidity_pool_id` as an optional field.
 - Trustline created/updated/revoked effects' asset type can now be `liquidity_pool_shares`.
 - Trustline sponsorship effects have been updated so the `asset` becomes optional and is replaced with `liquidity_pool_id` for liquidity pools.
+- The `trustee` attribute was made optional in the `ChangeTrustOperationResponse`.
 
 ### Fix
 - Updated various developer dependencies to secure versions ([#671](https://github.com/stellar/js-stellar-sdk/pull/671)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ A breaking change will get clearly marked in this log.
   - retrieving a specific pool via `/<id>/` ([#687](https://github.com/stellar/js-stellar-sdk/pull/687)).
 
 - Expands the `Operation`, `Transaction`, and `Effects` call builders to allow querying for a specific liquidity pool by ID ([#689](https://github.com/stellar/js-stellar-sdk/pull/689)).
-- New effect types: `DepositLiquidityEffect`, `WithdrawLiquidityEffect`, `LiquidityPoolTradeEffect`, `LiquidityPoolCreatedEffect`, `LiquidityPoolRemovedEffect` and `LiquidityPoolRevokedEffect`.
+- New effect types: `DepositLiquidityEffect`, `WithdrawLiquidityEffect`, `LiquidityPoolTradeEffect`, `LiquidityPoolCreatedEffect`, `LiquidityPoolRemovedEffect` and `LiquidityPoolRevokedEffect` ([#690](https://github.com/stellar/js-stellar-sdk/pull/690)).
 - The `RevokeSponsorshipOperationResponse` interface can now contain an optional attribute `trustline_liquidity_pool_id` for when a liquidity pool trustline is revoked.
-- Add operations `DepositLiquidityOperationResponse` and `WithdrawLiquidityOperationResponse`.
+- Add operations `DepositLiquidityOperationResponse` and `WithdrawLiquidityOperationResponse`  ([#692](https://github.com/stellar/js-stellar-sdk/pull/692)).
 
 ### Updates
 
@@ -42,9 +42,9 @@ A breaking change will get clearly marked in this log.
   - `asset_type` can now be `liquidity_pool_shares`.
   - `asset_code` and `asset_issuer` are now optional.
   - Added `liquidity_pool_id` as an optional field.
-- Trustline created/updated/revoked effects' asset type can now be `liquidity_pool_shares`.
-- Trustline sponsorship effects have been updated so the `asset` becomes optional and is replaced with `liquidity_pool_id` for liquidity pools.
-- The `trustee` attribute was made optional in the `ChangeTrustOperationResponse`.
+- Trustline created/updated/revoked effects' asset type can now be `liquidity_pool_shares` ([#690](https://github.com/stellar/js-stellar-sdk/pull/690)).
+- Trustline sponsorship effects have been updated so the `asset` becomes optional and is replaced with `liquidity_pool_id` for liquidity pools ([#690](https://github.com/stellar/js-stellar-sdk/pull/690)).
+- The `trustee` attribute was made optional in the `ChangeTrustOperationResponse` ([#692](https://github.com/stellar/js-stellar-sdk/pull/692)).
 
 ### Fix
 - Updated various developer dependencies to secure versions ([#671](https://github.com/stellar/js-stellar-sdk/pull/671)).

--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -366,7 +366,7 @@ export namespace Horizon {
     asset_code?: string;
     asset_issuer?: string;
     liquidity_pool_id?: string;
-    trustee: string;
+    trustee?: string;
     trustor: string;
     limit: string;
   }

--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -71,6 +71,7 @@ export namespace Horizon {
     last_modified_ledger: number;
     is_authorized: boolean;
     is_authorized_to_maintain_liabilities: boolean;
+    is_clawback_enabled: boolean;
   }
   export interface BalanceLineAsset<
     T extends AssetType.credit4 | AssetType.credit12 =
@@ -87,6 +88,7 @@ export namespace Horizon {
     last_modified_ledger: number;
     is_authorized: boolean;
     is_authorized_to_maintain_liabilities: boolean;
+    is_clawback_enabled: boolean;
     sponsor?: string;
   }
   export type BalanceLine<

--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -191,6 +191,8 @@ export namespace Horizon {
     clawback = "clawback",
     clawbackClaimableBalance = "clawback_claimable_balance",
     setTrustLineFlags = "set_trust_line_flags",
+    liquidityPoolDeposit = "liquidity_pool_deposit",
+    liquidityPoolWithdraw = "liquidity_pool_withdraw",
   }
   export enum OperationResponseTypeI {
     createAccount = 0,
@@ -215,6 +217,8 @@ export namespace Horizon {
     clawback = 19,
     clawbackClaimableBalance = 20,
     setTrustLineFlags = 21,
+    liquidityPoolDeposit = 22,
+    liquidityPoolWithdraw = 23,
   }
   export interface BaseOperationResponse<
     T extends OperationResponseType = OperationResponseType,
@@ -503,6 +507,34 @@ export namespace Horizon {
     trustor: string;
     set_flags: Array<1 | 2 | 4>;
     clear_flags: Array<1 | 2 | 4>;
+  }
+  export interface Reserve {
+    asset: string;
+    amount: string;
+  }
+  export interface DepositLiquidityOperationResponse
+    extends BaseOperationResponse<
+      OperationResponseType.liquidityPoolDeposit,
+      OperationResponseTypeI.liquidityPoolDeposit
+    > {
+    liquidity_pool_id: string;
+    reserves_max: Reserve[];
+    min_price: string;
+    min_price_r: PriceRShorthand;
+    max_price: string;
+    max_price_r: PriceRShorthand;
+    reserves_deposited: Reserve[];
+    shares_received: string;
+  }
+  export interface WithdrawLiquidityOperationResponse
+    extends BaseOperationResponse<
+      OperationResponseType.liquidityPoolWithdraw,
+      OperationResponseTypeI.liquidityPoolWithdraw
+    > {
+    liquidity_pool_id: string;
+    reserves_min: Reserve[];
+    shares: string;
+    reserves_received: Reserve[];
   }
 
   export interface ResponseCollection<T extends BaseResponse = BaseResponse> {

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -257,35 +257,31 @@ export type SignerSponsorshipRemoved = Omit<
   SignerSponsorshipEvents,
   "new_sponsor" | "sponsor"
 > & { type_i: EffectType.signer_sponsorship_removed };
-export interface Reserve {
-  asset: string;
-  amount: string;
-}
 export interface LiquidityPoolEffectRecord extends Horizon.BaseResponse {
   id: string;
   fee_bp: number;
   type: Horizon.LiquidityPoolType;
   total_trustlines: string;
   total_shares: string;
-  reserves: Reserve[];
+  reserves: Horizon.Reserve[];
 }
 export interface DepositLiquidityEffect extends BaseEffectRecord {
   type_i: EffectType.liquidity_pool_deposited;
   liquidity_pool: LiquidityPoolEffectRecord;
-  reserves_deposited: Reserve[];
+  reserves_deposited: Horizon.Reserve[];
   shares_received: string;
 }
 export interface WithdrawLiquidityEffect extends BaseEffectRecord {
   type_i: EffectType.liquidity_pool_withdrew;
   liquidity_pool: LiquidityPoolEffectRecord;
-  reserves_received: Reserve[];
+  reserves_received: Horizon.Reserve[];
   shares_redeemed: string;
 }
 export interface LiquidityPoolTradeEffect extends BaseEffectRecord {
   type_i: EffectType.liquidity_pool_trade;
   liquidity_pool: LiquidityPoolEffectRecord;
-  sold: Reserve;
-  bought: Reserve;
+  sold: Horizon.Reserve;
+  bought: Horizon.Reserve;
 }
 export interface LiquidityPoolCreatedEffect extends BaseEffectRecord {
   type_i: EffectType.liquidity_pool_created;


### PR DESCRIPTION
### Add

- Add operations `DepositLiquidityOperationResponse` and `WithdrawLiquidityOperationResponse`.

### Breaking Changes

- The `trustee` attribute was made optional in the `ChangeTrustOperationResponse`.