### PR TITLE
Add integration tests against the real mock API server

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -159,8 +159,8 @@ gulp.task(
     return gulp
       .src([
         'test/test-nodejs.js',
-        'test/unit/**/*.js',
-        'test/integration/**/*.js'
+        // 'test/unit/**/*.js',
+        'test/integration/apiary.js'
       ])
       .pipe(
         plugins.mocha({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -159,8 +159,8 @@ gulp.task(
     return gulp
       .src([
         'test/test-nodejs.js',
-        // 'test/unit/**/*.js',
-        'test/integration/apiary.js'
+        'test/unit/**/*.js',
+        'test/integration/**/*.js'
       ])
       .pipe(
         plugins.mocha({

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@types/urijs": "^1.19.6",
     "axios": "0.21.1",
     "bignumber.js": "^4.0.0",
+    "chai-http": "^4.3.0",
     "detect-node": "^2.0.4",
     "es6-promise": "^4.2.4",
     "eventsource": "^1.0.7",

--- a/test/integration/apiary.js
+++ b/test/integration/apiary.js
@@ -3,7 +3,6 @@
 
 // All endpoints from here are tested:
 // https://docs.google.com/document/d/1pXL8kr1a2vfYSap9T67R-g72B_WWbaE1YsLMa04OgoU/edit
-
 const MOCK_SERVER = "http://private-anon-a06e1b25a0-ammmock.apiary-mock.com";
 
 describe("tests the /liquidity_pools endpoint", function() {
@@ -15,19 +14,17 @@ describe("tests the /liquidity_pools endpoint", function() {
     chai.request(MOCK_SERVER)
       .get("/liquidity_pools")
       .end(function(err, res) {
-        if (err != null) {
-          done(err);
-        }
+        if (err != null) done(err);
         expect(res.body).not.to.be.null;
 
         server
           .liquidityPools()
           .call()
-          .then((resp) => {
+          .then(resp => {
             expect(resp.records).to.deep.equal(res.body._embedded.records);
             done();
           })
-          .catch((err) => done(err));
+          .catch(err => done(err));
       });
   });
 
@@ -37,20 +34,18 @@ describe("tests the /liquidity_pools endpoint", function() {
     chai.request(MOCK_SERVER)
       .get(`/liquidity_pools/${lpId}`)
       .end(function(err, res) {
-        if (err != null) {
-          done(err);
-        }
+        if (err != null) done(err);
         expect(res.body).not.to.be.null;
 
         server
           .liquidityPools()
           .liquidityPoolId(lpId)
           .call()
-          .then((resp) => {
+          .then(resp => {
             expect(resp).to.deep.equal(res.body);
             done();
           })
-          .catch((err) => done(err));
+          .catch(err => done(err));
       });
   });
 
@@ -72,7 +67,7 @@ describe("tests the /liquidity_pools endpoint", function() {
           testCases[suffix]
             .forLiquidityPool(lpId)
             .call()
-            .then((resp) => {
+            .then(resp => {
               resp.records.forEach((record, i) => {
                 // In an ideal world, we'd do a `.deep.equal(...)` here against
                 // the server response. However, these methods provide
@@ -94,7 +89,7 @@ describe("tests the /liquidity_pools endpoint", function() {
               });
               done();
             })
-            .catch((err) => done(err));
+            .catch(err => done(err));
         });
     });
   });
@@ -113,9 +108,9 @@ describe("tests the /accounts endpoint", function() {
         server
           .accounts()
           .call()
-          .then((resp) => {
+          .then(resp => {
             expect(resp.records).to.deep.equal(res.body._embedded.records);
-          }).catch((err) => done(err));
+          }).catch(err => done(err));
 
         done();
       });
@@ -136,10 +131,10 @@ describe("tests the /accounts endpoint", function() {
           .accounts()
           .forLiquidityPool(lpId)
           .call()
-          .then((resp) => {
+          .then(resp => {
             expect(resp.records).to.deep.equal(res.body._embedded.records);
             done();
-          }).catch((err) => done(err));
+          }).catch(err => done(err));
       });
   });
 
@@ -157,23 +152,22 @@ describe("tests the /accounts endpoint", function() {
           .accounts()
           .accountId(accountId)
           .call()
-          .then((resp) => {
-            expect(resp).to.deep.equal(res.body);
-
+          .then(resp => {
             // find the pool share balance(s)
             const poolShares = resp.balances
-              .filter((b) => b.asset_type === "liquidity_pool_shares");
+              .filter(b => b.asset_type === "liquidity_pool_shares");
 
             expect(poolShares).to.have.lengthOf(1);
-            poolShares.forEach((poolShare) => {
+            poolShares.forEach(poolShare => {
               expect(poolShare.buying_liabilities).to.be.undefined;
               expect(poolShare.selling_liabilities).to.be.undefined;
               expect(poolShare.asset_code).to.be.undefined;
               expect(poolShare.asset_issuer).to.be.undefined;
             });
 
+            expect(resp).to.deep.equal(res.body);
             done();
-          }).catch((err) => done(err));
+          }).catch(err => done(err));
       });
   });
 });
@@ -181,8 +175,8 @@ describe("tests the /accounts endpoint", function() {
 // isSubsetOf returns true if all of the `needles` array is part of `haystack`.
 function isSubsetOf(haystack, needles) {
   return needles
-    .map((item) => haystack.indexOf(item) !== -1)
-    .reduce((failed, value) => failed && value, true);
+    .map(item => haystack.indexOf(item) !== -1)       // found the needle?
+    .reduce((hasFailed, b) => hasFailed && b, true);  // were all found?
 }
 
 describe('isSubsetOf works', function() {
@@ -197,7 +191,7 @@ describe('isSubsetOf works', function() {
     { values: [], expected: true },
   ];
 
-  testCases.forEach((test) => {
+  testCases.forEach(test => {
     it(`[${test.values}] should be ${test.expected}`, function() {
       expect(isSubsetOf(masterArray, test.values)).to.equal(test.expected);
     });

--- a/test/integration/apiary.js
+++ b/test/integration/apiary.js
@@ -1,0 +1,127 @@
+// Tests CAP-38 endpoints against the mock API server:
+// https://ammmock.docs.apiary.io/
+
+// All endpoints from here are tested:
+// https://docs.google.com/document/d/1pXL8kr1a2vfYSap9T67R-g72B_WWbaE1YsLMa04OgoU/edit
+
+const MOCK_SERVER = "http://private-anon-a06e1b25a0-ammmock.apiary-mock.com";
+
+describe("tests the /liquidity_pools endpoint", function() {
+  const lpId = "0569b19c75d7ecadce50501fffad6fe8ba4652455df9e1cc96dc408141124dd5";
+
+  it("GET /", function(done) {
+    let server = new StellarSdk.Server(MOCK_SERVER, {allowHttp: true});
+
+    chai.request(MOCK_SERVER)
+      .get("/liquidity_pools")
+      .end(function(err, res) {
+        if (err != null) {
+          done(err);
+        }
+        expect(res.body).not.to.be.null;
+
+        server
+          .liquidityPools()
+          .call()
+          .then((resp) => {
+            expect(resp.records).to.deep.equal(res.body._embedded.records);
+            done();
+          })
+          .catch((err) => done(err));
+      });
+  });
+
+  it('GET /<id>/', function(done) {
+    let server = new StellarSdk.Server(MOCK_SERVER, {allowHttp: true});
+
+    chai.request(MOCK_SERVER)
+      .get(`/liquidity_pools/${lpId}`)
+      .end(function(err, res) {
+        if (err != null) {
+          done(err);
+        }
+        expect(res.body).not.to.be.null;
+
+        server
+          .liquidityPools()
+          .liquidityPoolId(lpId)
+          .call()
+          .then((resp) => {
+            expect(resp).to.deep.equal(res.body);
+            done();
+          })
+          .catch((err) => done(err));
+      });
+  });
+
+  let server = new StellarSdk.Server(MOCK_SERVER, {allowHttp: true});
+  const testCases = {
+    transactions: server.transactions(),
+    operations: server.operations(),
+    effects: server.effects(),
+  };
+
+  Object.keys(testCases).forEach(suffix => {
+    it(`GET /<id>/${suffix}`, function(done) {
+      chai.request(MOCK_SERVER)
+        .get(`/liquidity_pools/${lpId}/${suffix}`)
+        .end(function(err, res) {
+          if (err != null) return done(err);
+          expect(res.body).not.to.be.null;
+
+          testCases[suffix]
+            .forLiquidityPool(lpId)
+            .call()
+            .then((resp) => {
+              resp.records.forEach((record, i) => {
+                // In an ideal world, we'd do a `.deep.equal(...)` here against
+                // the server response. However, these methods provide
+                // convenience methods that cause them to not perfectly align
+                // with the server response.
+                //
+                // For example, transaction responses include the ledger number,
+                // but this is attached to the `ledger_attr` field in a
+                // `TransactionRecord`, while `ledger` is a function that
+                // corresponds to a `LedgerCallBuilder`.
+                //
+                // For this reason, we do a "best effort" validity check by at
+                // least ensuring that the response objects have *at least* all
+                // of the keys in the server response.
+                expect(isSubsetOf(
+                  Object.keys(record),
+                  Object.keys(res.body._embedded.records[i])
+                )).to.be.true;
+              });
+              done();
+            })
+            .catch((err) => done(err));
+        });
+    });
+  });
+});
+
+// isSubsetOf returns true if all of the `needles` array is part of `haystack`.
+function isSubsetOf(haystack, needles) {
+  return needles
+    .map((item) => haystack.indexOf(item) !== -1)
+    .reduce((failed, value) => failed && value, true);
+}
+
+describe('isSubsetOf works', function() {
+  const masterArray = ['a', 'b', 'c'];
+
+  const testCases = [
+    { values: ['a'], expected: true },
+    { values: ['a', 'b'], expected: true },
+    { values: ['z'], expected: false },
+    { values: ['a', 'z'], expected: false },
+    { values: ['a', 'b', 'c', 'z'], expected: false },
+    { values: [], expected: true },
+  ];
+
+  testCases.forEach((test) => {
+    it(`[${test.values}] should be ${test.expected}`, function() {
+      expect(isSubsetOf(masterArray, test.values)).to.equal(test.expected);
+    });
+  });
+});

--- a/test/integration/apiary.js
+++ b/test/integration/apiary.js
@@ -7,10 +7,9 @@ const MOCK_SERVER = "http://private-anon-a06e1b25a0-ammmock.apiary-mock.com";
 
 describe("tests the /liquidity_pools endpoint", function() {
   const lpId = "0569b19c75d7ecadce50501fffad6fe8ba4652455df9e1cc96dc408141124dd5";
+  const server = new StellarSdk.Server(MOCK_SERVER, {allowHttp: true});
 
   it("GET /", function(done) {
-    let server = new StellarSdk.Server(MOCK_SERVER, {allowHttp: true});
-
     chai.request(MOCK_SERVER)
       .get("/liquidity_pools")
       .end(function(err, res) {
@@ -29,8 +28,6 @@ describe("tests the /liquidity_pools endpoint", function() {
   });
 
   it('GET /<pool-id>', function(done) {
-    let server = new StellarSdk.Server(MOCK_SERVER, {allowHttp: true});
-
     chai.request(MOCK_SERVER)
       .get(`/liquidity_pools/${lpId}`)
       .end(function(err, res) {
@@ -49,7 +46,6 @@ describe("tests the /liquidity_pools endpoint", function() {
       });
   });
 
-  let server = new StellarSdk.Server(MOCK_SERVER, {allowHttp: true});
   const testCases = {
     transactions: server.transactions(),
     operations: server.operations(),
@@ -96,9 +92,9 @@ describe("tests the /liquidity_pools endpoint", function() {
 });
 
 describe("tests the /accounts endpoint", function() {
-  it('GET /', function(done) {
-    let server = new StellarSdk.Server(MOCK_SERVER, {allowHttp: true});
+  const server = new StellarSdk.Server(MOCK_SERVER, {allowHttp: true});
 
+  it('GET /', function(done) {
     chai.request(MOCK_SERVER)
       .get("/accounts")
       .end(function(err, res) {
@@ -117,7 +113,6 @@ describe("tests the /accounts endpoint", function() {
   });
 
   it('GET /?liquidity_pool=<pool-id>', function(done) {
-    let server = new StellarSdk.Server(MOCK_SERVER, {allowHttp: true});
     const lpId = "0569b19c75d7ecadce50501fffad6fe8ba4652455df9e1cc96dc408141124dd5";
 
     chai.request(MOCK_SERVER)
@@ -139,7 +134,6 @@ describe("tests the /accounts endpoint", function() {
   });
 
   it('GET /<id>', function(done) {
-    let server = new StellarSdk.Server(MOCK_SERVER, {allowHttp: true});
     const accountId = "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3";
 
     chai.request(MOCK_SERVER)

--- a/test/integration/apiary.js
+++ b/test/integration/apiary.js
@@ -28,7 +28,7 @@ describe("tests the /liquidity_pools endpoint", function() {
       });
   });
 
-  it('GET /<id>', function(done) {
+  it('GET /<pool-id>', function(done) {
     let server = new StellarSdk.Server(MOCK_SERVER, {allowHttp: true});
 
     chai.request(MOCK_SERVER)
@@ -116,7 +116,7 @@ describe("tests the /accounts endpoint", function() {
       });
   });
 
-  it('GET /?liquidity_pool=<id>', function(done) {
+  it('GET /?liquidity_pool=<pool-id>', function(done) {
     let server = new StellarSdk.Server(MOCK_SERVER, {allowHttp: true});
     const lpId = "0569b19c75d7ecadce50501fffad6fe8ba4652455df9e1cc96dc408141124dd5";
 

--- a/test/test-nodejs.js
+++ b/test/test-nodejs.js
@@ -2,11 +2,16 @@
 
 require("babel-register");
 global.StellarSdk = require("../lib/");
+
 global.axios = require("axios");
 global.HorizonAxiosClient = StellarSdk.HorizonAxiosClient;
+
 var chaiAsPromised = require("chai-as-promised");
+var chaiHttp = require("chai-http");
 global.chai = require("chai");
 global.chai.should();
 global.chai.use(chaiAsPromised);
-global.sinon = require("sinon");
+global.chai.use(chaiHttp);
 global.expect = global.chai.expect;
+
+global.sinon = require("sinon");

--- a/yarn.lock
+++ b/yarn.lock
@@ -146,10 +146,20 @@
   resolved "https://registry.yarnpkg.com/@stellar/tslint-config/-/tslint-config-1.0.4.tgz#d395a269c00f1768b659e544eb1fe1f007033152"
   integrity sha512-m1bw9vHt3zGIu5rhItqYM5rc4vxYJpqXIUwZXEn1MK/IC414Eth+uvNve4dKl6GgWJYEOnqlj9uAlEk3gmU/eQ==
 
+"@types/chai@4":
+  version "4.2.21"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.21.tgz#9f35a5643129df132cf3b5c1ec64046ea1af0650"
+  integrity sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/cookiejar@*":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
+  integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
 
 "@types/detect-node@^2.0.0":
   version "2.0.0"
@@ -205,6 +215,14 @@
   resolved "https://registry.yarnpkg.com/@types/randombytes/-/randombytes-2.0.0.tgz#0087ff5e60ae68023b9bc4398b406fea7ad18304"
   integrity sha512-bz8PhAVlwN72vqefzxa14DKNT8jK/mV66CSjwdVQM/k3Th3EPKfUtdMniwZgMedQTFuywAsfjnZsg+pEnltaMA==
   dependencies:
+    "@types/node" "*"
+
+"@types/superagent@^3.8.3":
+  version "3.8.7"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-3.8.7.tgz#1f1ed44634d5459b3a672eb7235a8e7cfd97704c"
+  integrity sha512-9KhCkyXv268A2nZ1Wvu7rQWM+BmdYUVkycFeNnYrUL5Zwu7o8wPQ3wBfW59dDP+wuoxw0ww8YKgTNv8j/cgscA==
+  dependencies:
+    "@types/cookiejar" "*"
     "@types/node" "*"
 
 "@types/urijs@^1.19.6":
@@ -1714,6 +1732,14 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+call-bind@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
+
 caller-callsite@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
@@ -1769,6 +1795,19 @@ chai-as-promised@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-5.3.0.tgz#09d7a402908aa70dfdbead53e5853fc79d3ef21c"
   integrity sha1-CdekApCKpw39vq1T5YU/x50+8hw=
+
+chai-http@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/chai-http/-/chai-http-4.3.0.tgz#3c37c675c1f4fe685185a307e345de7599337c1a"
+  integrity sha512-zFTxlN7HLMv+7+SPXZdkd5wUlK+KxH6Q7bIEMiEx0FK3zuuMqL7cwICAQ0V1+yYRozBburYuxN1qZstgHpFZQg==
+  dependencies:
+    "@types/chai" "4"
+    "@types/superagent" "^3.8.3"
+    cookiejar "^2.1.1"
+    is-ip "^2.0.0"
+    methods "^1.1.2"
+    qs "^6.5.1"
+    superagent "^3.7.0"
 
 chai@^2.2.0:
   version "2.3.0"
@@ -2076,7 +2115,7 @@ component-emitter@1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
 
-component-emitter@^1.2.1, component-emitter@~1.3.0:
+component-emitter@^1.2.0, component-emitter@^1.2.1, component-emitter@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
@@ -2147,6 +2186,11 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
+
+cookiejar@^2.1.0, cookiejar@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
+  integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"
@@ -3560,6 +3604,15 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
+form-data@^2.3.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -3575,6 +3628,11 @@ formatio@1.1.1:
   integrity sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=
   dependencies:
     samsam "~1.1"
+
+formidable@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.2.tgz#bf69aea2972982675f00865342b982986f6b8dd9"
+  integrity sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -3682,6 +3740,15 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-intrinsic@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
@@ -4448,6 +4515,11 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
+ip-regex@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
+  integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
+
 is-absolute@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-absolute/-/is-absolute-1.0.0.tgz#395e1ae84b11f26ad1795e73c17378e48a301576"
@@ -4639,6 +4711,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-ip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ip/-/is-ip-2.0.0.tgz#68eea07e8a0a0a94c2d080dd674c731ab2a461ab"
+  integrity sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=
+  dependencies:
+    ip-regex "^2.0.0"
 
 is-negated-glob@^1.0.0:
   version "1.0.0"
@@ -5648,6 +5727,11 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
+methods@^1.1.1, methods@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+  integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
+
 micromatch@^2.1.5, micromatch@^2.3.7, micromatch@^2.3.8:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
@@ -5713,6 +5797,11 @@ mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24:
   integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
   dependencies:
     mime-db "1.44.0"
+
+mime@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mime@^2.1.0:
   version "2.4.4"
@@ -6111,6 +6200,11 @@ object-inspect@^1.7.0, object-inspect@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
+
+object-inspect@^1.9.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
+  integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
 
 object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
@@ -6831,6 +6925,13 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.5.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
+  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -7470,6 +7571,15 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
@@ -7977,6 +8087,22 @@ strip-json-comments@2.0.1, strip-json-comments@^2.0.1, strip-json-comments@~2.0.
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+superagent@^3.7.0:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.3.tgz#460ea0dbdb7d5b11bc4f78deba565f86a178e128"
+  integrity sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.2.0"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.3.5"
 
 supports-color@3.1.x:
   version "3.1.2"


### PR DESCRIPTION
I realized that by copy-pasting responses from the mock server and hardcoding URLs, we weren't exactly testing things properly end-to-end. I added some "true" integration tests to hit the APIary server.