### PR TITLE
Fix how the `?reserves` filter works on the `/accounts` endpoint.

### DIFF
--- a/src/liquidity_pool_call_builder.ts
+++ b/src/liquidity_pool_call_builder.ts
@@ -21,7 +21,7 @@ export class LiquidityPoolCallBuilder extends CallBuilder<
   }
 
   /**
-   * Filters out liquidity pools whose reserves aren't in this list of assets.
+   * Filters out pools whose reserves don't exactly match these assets.
    *
    * @see Asset
    * @param {Asset[]} assets

--- a/test/unit/liquidity_pool_endpoints_test.js
+++ b/test/unit/liquidity_pool_endpoints_test.js
@@ -115,7 +115,7 @@ describe('/liquidity_pools tests', function() {
         response: phpResponse,
       }, {
         assets: [EURT, PHP],
-        response: rootResponse,
+        response: phpResponse,
       },
     ];
 


### PR DESCRIPTION
I learned that the `reserves` filter is supposed to be an AND filter rather than an OR filter, so the response for the `?reserves=EURT,PHP` query should only include **exactly** the EURT <--> PHP pool rather than _any_ pool that contains EURT **or** PHP assets.

I've updated the jsdoc and test case to reflect this.