### PR TITLE
Update more call builders to use the new helper API.

### DIFF
--- a/src/ledger_call_builder.ts
+++ b/src/ledger_call_builder.ts
@@ -15,7 +15,7 @@ export class LedgerCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.LedgerRecord>
 > {
   constructor(serverUrl: URI) {
-    super(serverUrl, "ledgers");
+    super(serverUrl);
     this.url.segment("ledgers");
   }
 
@@ -25,6 +25,7 @@ export class LedgerCallBuilder extends CallBuilder<
    * @returns {LedgerCallBuilder} current LedgerCallBuilder instance
    */
   public ledger(sequence: number | string): this {
-    return this.forEndpoint("ledgers", sequence.toString());
+    this.filter.push(["ledgers", sequence.toString()]);
+    return this;
   }
 }

--- a/src/ledger_call_builder.ts
+++ b/src/ledger_call_builder.ts
@@ -15,7 +15,7 @@ export class LedgerCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.LedgerRecord>
 > {
   constructor(serverUrl: URI) {
-    super(serverUrl);
+    super(serverUrl, "ledgers");
     this.url.segment("ledgers");
   }
 
@@ -25,7 +25,6 @@ export class LedgerCallBuilder extends CallBuilder<
    * @returns {LedgerCallBuilder} current LedgerCallBuilder instance
    */
   public ledger(sequence: number | string): this {
-    this.filter.push(["ledgers", sequence.toString()]);
-    return this;
+    return this.forEndpoint("ledgers", sequence.toString());
   }
 }

--- a/src/offer_call_builder.ts
+++ b/src/offer_call_builder.ts
@@ -16,7 +16,7 @@ export class OfferCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.OfferRecord>
 > {
   constructor(serverUrl: URI) {
-    super(serverUrl);
+    super(serverUrl, "offers");
     this.url.segment("offers");
   }
 
@@ -41,8 +41,7 @@ export class OfferCallBuilder extends CallBuilder<
    * @returns {OfferCallBuilder} current OfferCallBuilder instance
    */
   public forAccount(id: string): this {
-    this.filter.push(["accounts", id, "offers"]);
-    return this;
+    return this.forEndpoint("accounts", id);
   }
 
   /**

--- a/src/payment_call_builder.ts
+++ b/src/payment_call_builder.ts
@@ -14,7 +14,7 @@ export class PaymentCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.PaymentOperationRecord>
 > {
   constructor(serverUrl: URI) {
-    super(serverUrl);
+    super(serverUrl, "payments");
     this.url.segment("payments");
   }
 
@@ -25,8 +25,7 @@ export class PaymentCallBuilder extends CallBuilder<
    * @returns {PaymentCallBuilder} this PaymentCallBuilder instance
    */
   public forAccount(accountId: string): this {
-    this.filter.push(["accounts", accountId, "payments"]);
-    return this;
+    return this.forEndpoint("accounts", accountId);
   }
 
   /**
@@ -36,12 +35,10 @@ export class PaymentCallBuilder extends CallBuilder<
    * @returns {PaymentCallBuilder} this PaymentCallBuilder instance
    */
   public forLedger(sequence: number | string): this {
-    this.filter.push([
+    return this.forEndpoint(
       "ledgers",
       typeof sequence === "number" ? sequence.toString() : sequence,
-      "payments",
-    ]);
-    return this;
+    );
   }
 
   /**
@@ -51,7 +48,6 @@ export class PaymentCallBuilder extends CallBuilder<
    * @returns {PaymentCallBuilder} this PaymentCallBuilder instance
    */
   public forTransaction(transactionId: string): this {
-    this.filter.push(["transactions", transactionId, "payments"]);
-    return this;
+    return this.forEndpoint("transactions", transactionId);
   }
 }

--- a/src/payment_call_builder.ts
+++ b/src/payment_call_builder.ts
@@ -37,7 +37,7 @@ export class PaymentCallBuilder extends CallBuilder<
   public forLedger(sequence: number | string): this {
     return this.forEndpoint(
       "ledgers",
-      typeof sequence === "number" ? sequence.toString() : sequence,
+      sequence.toString(),
     );
   }
 

--- a/src/trades_call_builder.ts
+++ b/src/trades_call_builder.ts
@@ -16,7 +16,7 @@ export class TradesCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.TradeRecord>
 > {
   constructor(serverUrl: URI) {
-    super(serverUrl);
+    super(serverUrl, "trades");
     this.url.segment("trades");
   }
 
@@ -71,7 +71,6 @@ export class TradesCallBuilder extends CallBuilder<
    * @returns {TradesCallBuilder} current TradesCallBuilder instance
    */
   public forAccount(accountId: string): this {
-    this.filter.push(["accounts", accountId, "trades"]);
-    return this;
+    return this.forEndpoint("accounts", accountId);
   }
 }


### PR DESCRIPTION
After these changes, it seems like we could do something like `class PaymentCallBuilder extends TransactionQuery` which would implement `forTransaction()` across the board instead of duplicating the same method across a bunch of builders.. But that's a refactor for another day.