### PR TITLE
Prepares the repository for a beta release

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -23,6 +23,6 @@ jobs:
         run: gulp
 
       - name: Publish npm package
-        run: yarn publish
+        run: yarn publish --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
-
-## [v9.0.0](https://github.com/stellar/js-stellar-sdk/compare/v8.2.5...v9.0.0)
-
-This release adds **support for Automated Market Makers**. For details, you can refer to [CAP-38](https://stellar.org/protocol/cap-38) for XDR changes and [this document](https://docs.google.com/document/d/1pXL8kr1a2vfYSap9T67R-g72B_WWbaE1YsLMa04OgoU/view) for detailed changes to the Horizon API.
-
-
 ### Add
 
 - Introduced a `LiquidityPoolCallBuilder` to make calls to a new endpoint:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-sdk",
-  "version": "9.0.0",
+  "version": "8.2.5",
   "description": "stellar-sdk is a library for working with the Stellar Horizon server.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
Updates our CI/CD to do a beta release in preparation for v9.0.0-beta.0.

I also think we shouldn't do a version bump as part of merging #693. I prefer a safer approach where the final "release commit" is a small delta that only changes the JSON and CHANGELOG (see e.g. #670).

