### PR TITLE
Update Horizon API fields to reflect the coming post-AMM API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ A breaking change will get clearly marked in this log.
 
 - Updated the underlying `stellar-base` library to [v6.0.1](https://github.com/stellar/js-stellar-base/releases/tag/v6.0.1) to include CAP-38 changes ([#681](https://github.com/stellar/js-stellar-sdk/pull/681)).
 
+- Updated various developer dependencies to secure versions ([#671](https://github.com/stellar/js-stellar-sdk/pull/671)).
+
 - Updated `AccountResponse` to include liquidity pool shares in its `balances` field ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)).
 
 - Updated `AccountCallBuilder` to allow filtering based on participation in a certain liquidity pool ([#688](https://github.com/stellar/js-stellar-sdk/pull/688)), corresponding to the following new filter:
@@ -76,8 +78,7 @@ A breaking change will get clearly marked in this log.
   * the `asset` field is now optional, and is replaced by
   * the `liquidity_pool_id` field for liquidity pools
 
-### Fix
-- Updated various developer dependencies to secure versions ([#671](https://github.com/stellar/js-stellar-sdk/pull/671)).
+- `TradeRecord`s no longer have an `offer_id` field. This field is redundant, being represented by `base_offer_id` in given an `Orderbook` trade.
 
 
 ## [v8.2.5](https://github.com/stellar/js-stellar-sdk/compare/v8.2.4...v8.2.5)

--- a/src/effect_call_builder.ts
+++ b/src/effect_call_builder.ts
@@ -38,10 +38,7 @@ export class EffectCallBuilder extends CallBuilder<
    * @returns {EffectCallBuilder} this EffectCallBuilder instance
    */
   public forLedger(sequence: number | string): this {
-    return this.forEndpoint(
-      "ledgers",
-      typeof sequence === "number" ? sequence.toString() : sequence,
-    );
+    return this.forEndpoint("ledgers", sequence.toString());
   }
 
   /**

--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -72,6 +72,7 @@ export namespace Horizon {
     is_authorized: boolean;
     is_authorized_to_maintain_liabilities: boolean;
     is_clawback_enabled: boolean;
+    sponsor?: string;
   }
   export interface BalanceLineAsset<
     T extends AssetType.credit4 | AssetType.credit12 =

--- a/src/operation_call_builder.ts
+++ b/src/operation_call_builder.ts
@@ -64,10 +64,7 @@ export class OperationCallBuilder extends CallBuilder<
    * @returns {OperationCallBuilder} this OperationCallBuilder instance
    */
   public forLedger(sequence: number | string): this {
-    return this.forEndpoint(
-      "ledgers",
-      typeof sequence === "number" ? sequence.toString() : sequence,
-    );
+    return this.forEndpoint("ledgers", sequence.toString());
   }
 
   /**

--- a/src/payment_call_builder.ts
+++ b/src/payment_call_builder.ts
@@ -35,10 +35,7 @@ export class PaymentCallBuilder extends CallBuilder<
    * @returns {PaymentCallBuilder} this PaymentCallBuilder instance
    */
   public forLedger(sequence: number | string): this {
-    return this.forEndpoint(
-      "ledgers",
-      sequence.toString(),
-    );
+    return this.forEndpoint("ledgers", sequence.toString());
   }
 
   /**

--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -308,7 +308,6 @@ export namespace ServerApi {
       id: string;
       paging_token: string;
       ledger_close_time: string;
-      offer_id: string;
       trade_type: TradeType;
       base_account?: string;
       base_amount: string;

--- a/src/transaction_call_builder.ts
+++ b/src/transaction_call_builder.ts
@@ -62,9 +62,7 @@ export class TransactionCallBuilder extends CallBuilder<
    * @returns {TransactionCallBuilder} current TransactionCallBuilder instance
    */
   public forLedger(sequence: number | string): this {
-    const ledgerSequence =
-      typeof sequence === "number" ? sequence.toString() : sequence;
-    return this.forEndpoint("ledgers", ledgerSequence);
+    return this.forEndpoint("ledgers", sequence.toString());
   }
 
   /**


### PR DESCRIPTION
API field changes:
 - `sponsor?` added to liquidity pool balances
 - `offer_id` dropped from trades (deprecated by Horizon)

It also refactors `forLedger` methods to avoid the type check, since both `string` and `number` can be `toString()`'d. I know these should be separate PRs but I think it really doesn't matter here.