### PR TITLE
Fix version in package.json

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -23,6 +23,6 @@ jobs:
         run: gulp
 
       - name: Publish npm package
-        run: npm unpublish v9.0.0 && yarn publish --tag beta
+        run: npm unpublish stellar-sdk@v9.0.0 && yarn publish --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -23,6 +23,6 @@ jobs:
         run: gulp
 
       - name: Publish npm package
-        run: yarn publish --tag beta
+        run: npm unpublish v9.0.0 && yarn publish --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-sdk",
-  "version": "9.0.0",
+  "version": "9.0.0-beta.0",
   "description": "stellar-sdk is a library for working with the Stellar Horizon server.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
I'm an idiot and set a `-beta.0` suffix everywhere except where it actually matters: the package.json file.

This will unpublish v9.0.0 so nobody upgrades and republish it with an explicit beta tag.