### PR TITLE
Add instructions for Expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,29 @@ module.exports = {
 
 There is also a [sample](https://github.com/fnando/rn-stellar-sdk-sample) that you can follow.
 
+#### Using in an Expo managed workflow
+
+1. Add the following postinstall script:
+```
+yarn rn-nodeify --install process,url,events,https,http,util,stream,crypto,vm,buffer --hack --yarn
+```
+2. `yarn add -D rn-nodeify`
+3. Add `import "./shim";` to the your app's entry point (by default `./App.js`)
+4. `yarn add stellar-sdk`
+5. `expo install expo-random`
+
+At this point, the stellar SDK will work, except that `StellarSdk.Keypair.random()` will throw an error. So to work around this you can create your own method to generate a random keypair like this:
+
+```javascript
+import * as Random from 'expo-random';
+import StellarSdk from 'stellar-sdk';
+
+const generateRandomKeypair = () => {
+  const randomBytes = Random.getRandomBytes(32);
+
+  return StellarSdk.Keypair.fromRawEd25519Seed(Buffer.from(randomBytes));
+};
+```
 
 ## Usage
 


### PR DESCRIPTION
This PR adds a set of instructions on how to get the SDK working on the Expo managed workflow from #290