### PR TITLE
Update function docs and improve changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
-### Add
+### Updates
 
-- Adds [client domain verification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#verifying-the-client-domain) to the SEP-10 helper functions ([#720](https://github.com/stellar/js-stellar-sdk/pull/720)):
-  - `Utils.buildChallengeTx()`
-  - `Utils.readChallengeTx()`
-  - `Utils.verifyChallengeTxSigners()`
+- Updates the following SEP-10 utility functions to include [client domain verification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#verifying-the-client-domain) functionality ([#720](https://github.com/stellar/js-stellar-sdk/pull/720)):
+  - Updated `Utils.buildChallengeTx()` to accept the `clientDomain` and `clientSigningKey` optional parameters
+  - Updated `Utils.readChallengeTx()` to parse challenge transactions containing a `client_domain` ManageData operation
+  - Updated `Utils.verifyChallengeTxSigners()` to verify an additional signature from the `clientSigningKey` keypair if a `client_domain` Manage Data operation is included in the challenge
 
 ## [v9.0.0](https://github.com/stellar/js-stellar-sdk/compare/v9.0.0-beta.1...v9.0.0)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,6 +34,8 @@ export namespace Utils {
    * @param {string} networkPassphrase The network passphrase. If you pass this argument then timeout is required.
    * @param {string} webAuthDomain The fully qualified domain name of the service issuing the challenge.
    * @param {string} [memo] The memo to attach to the challenge transaction. The memo must be of type `id`. If the `clientaccountID` is a muxed account, memos cannot be used.
+   * @param {string} [clientDomain] The fully qualified domain of the client requesting the challenge. Only necessary when the the 'client_domain' parameter is passed.
+   * @param {string} [clientSigningKey] The public key assigned to the SIGNING_KEY attribute specified on the stellar.toml hosted on the client domain. Only necessary when the 'client_domain' parameter is passed.
    * @example
    * import { Utils, Keypair, Networks }  from 'stellar-sdk'
    *


### PR DESCRIPTION
I forgot to add parameter documentation to the `buildChallengeTx()` function after adding the `clientDomain` and `clientSigningKey` parameters. I also improved the changelog to be more accurate and verbose.

I noticed that the `memo` parameter doesn't show up in the [docs](https://stellar.github.io/js-stellar-sdk/Utils.html#.buildChallengeTx). If you take a look at the [hosted source code](https://stellar.github.io/js-stellar-sdk/libdocs_utils.js.html#line30), you'll notice that the `memo` parameter isn't included in the function signature. Are the published docs not updated on each release?