### PR TITLE
Update liquidity pool effect types to their correct values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ A breaking change will get clearly marked in this log.
 
 ### Fix
 
-- Fixes the `type_i` enumeration field to accurately reflect liquidity pool effects ([]()).
+- Fixes the `type_i` enumeration field to accurately reflect liquidity pool effects ([#723](https://github.com/stellar/js-stellar-sdk/pull/723)).
 
 ### Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Fix
+
+- Fixes the `type_i` enumeration field to accurately reflect liquidity pool effects ([]()).
+
 ### Updates
 
 - Updates the following SEP-10 utility functions to include [client domain verification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md#verifying-the-client-domain) functionality ([#720](https://github.com/stellar/js-stellar-sdk/pull/720)):
   - Updated `Utils.buildChallengeTx()` to accept the `clientDomain` and `clientSigningKey` optional parameters
   - Updated `Utils.readChallengeTx()` to parse challenge transactions containing a `client_domain` ManageData operation
   - Updated `Utils.verifyChallengeTxSigners()` to verify an additional signature from the `clientSigningKey` keypair if a `client_domain` Manage Data operation is included in the challenge
+
 
 ## [v9.0.0](https://github.com/stellar/js-stellar-sdk/compare/v9.0.0-beta.1...v9.0.0)
 

--- a/src/types/effects.ts
+++ b/src/types/effects.ts
@@ -54,13 +54,15 @@ export enum EffectType {
   signer_sponsorship_created = 72,
   signer_sponsorship_updated = 73,
   signer_sponsorship_removed = 74,
+  // clawback effects
   claimable_balance_clawed_back = 80,
-  liquidity_pool_deposited = 81,
-  liquidity_pool_withdrew = 82,
-  liquidity_pool_trade = 83,
-  liquidity_pool_created = 84,
-  liquidity_pool_removed = 85,
-  liquidity_pool_revoked = 86,
+  // liquidity pool effects
+  liquidity_pool_deposited = 90,
+  liquidity_pool_withdrew = 91,
+  liquidity_pool_trade = 92,
+  liquidity_pool_created = 93,
+  liquidity_pool_removed = 94,
+  liquidity_pool_revoked = 95,
 }
 export interface BaseEffectRecord extends Horizon.BaseResponse {
   id: string;


### PR DESCRIPTION
Source of truth:

https://github.com/stellar/go/blob/5db7e40d0d8f4310084ca10d5ef5be92a0a5b624/services/horizon/internal/db2/history/main.go#L192-L208

The effects are grouped by category, not sequential. 

Closes #718.