### PR TITLE
Add a way to filter liquidity pools by participating account

### DIFF
--- a/src/liquidity_pool_call_builder.ts
+++ b/src/liquidity_pool_call_builder.ts
@@ -36,9 +36,20 @@ export class LiquidityPoolCallBuilder extends CallBuilder<
   }
 
   /**
+   * Retrieves all pools an account is participating in.
+   *
+   * @param {string} id   the participant account to filter by
+   * @returns {LiquidityPoolCallBuilder} current LiquidityPoolCallBuilder instance
+   */
+  public forAccount(id: string): this {
+    this.url.setQuery("account", id);
+    return this;
+  }
+
+  /**
    * Retrieves a specific liquidity pool by ID.
    *
-   * @param  {string} id
+   * @param {string} id   the hash/ID of the liquidity pool
    * @returns {CallBuilder} a new CallBuilder instance for the /liquidity_pools/:id endpoint
    */
   public liquidityPoolId(

--- a/test/unit/liquidity_pool_endpoints_test.js
+++ b/test/unit/liquidity_pool_endpoints_test.js
@@ -102,7 +102,7 @@ describe('/liquidity_pools tests', function() {
       .catch(done);
   });
 
-  describe('filtering by asset', function() {
+  describe('filters', function() {
     const testCases = [
       {
         assets: [StellarSdk.Asset.native()],
@@ -141,6 +141,26 @@ describe('/liquidity_pools tests', function() {
       });
     });
 
+    it('filters by account', function(done) {
+      const accountId = "GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S";
+      this.axiosMock
+        .expects('get')
+        .withArgs(sinon.match(`${LP_URL}?account=${accountId}`))
+        .returns(Promise.resolve({ data: rootResponse }))
+
+        this.server
+          .liquidityPools()
+          .forAccount(accountId)
+          .call()
+          .then((pools) => {
+            expect(pools.records).to.deep.equal(rootResponse._embedded.records);
+            done();
+          })
+          .catch(done);
+      });
+  });
+
+  describe('querying a specific pool', function() {
     const lpId = "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a";
 
     it('checks for valid IDs', function() {
@@ -150,7 +170,7 @@ describe('/liquidity_pools tests', function() {
 
     it('filters by specific ID', function(done) {
       const poolResponse = {
-        "id": "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a",
+        "id": lpId,
         "paging_token": "113725249324879873",
         "fee_bp": 30,
         "type": "constant_product",
@@ -183,10 +203,6 @@ describe('/liquidity_pools tests', function() {
         })
         .catch(done);
     });
-  });
-
-  describe('querying a specific pool', function() {
-    const lpId = "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a";
 
     const poolOpsResponse = {
       "_links": {


### PR DESCRIPTION
With Horizon [v2.11.0](https://github.com/stellar/go/releases/tag/horizon-v2.11.0), there's a new way to filter liquidity pools: by participating account. This updates the `LiquidityPoolCallBuilder` to support that filter.