### PR TITLE
Fix trade type enum for liquidity pools

### DIFF
--- a/src/server_api.ts
+++ b/src/server_api.ts
@@ -122,7 +122,7 @@ export namespace ServerApi {
   }
   export enum TradeType {
     all = "all",
-    liquidityPools = "liquidity_pools",
+    liquidityPools = "liquidity_pool",
     orderbook = "orderbook",
   }
   interface EffectRecordMethods {


### PR DESCRIPTION
Should be `liquidity_pool`, singular. Closes #733.