### PR TITLE
Release v10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This release introduces breaking changes from `stellar-base`. It adds **uncondit
 
 ### Breaking Updates
 
-- Upgrades the stellar-base library to v7.0.0 ([]()).
+- Upgrades the stellar-base library to v7.0.0 ([#735](https://github.com/stellar/js-stellar-sdk/pull/735)).
 
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This release introduces breaking changes from `stellar-base`. It adds **uncondit
 
 - Upgrades the stellar-base library to v7.0.0 ([#735](https://github.com/stellar/js-stellar-sdk/pull/735)).
 
+- Removes the `AccountResponse.createSubaccount` method since this is also gone from the underlying `Account` interface. The `stellar-base` release notes describe alternative construction methods ([#735](https://github.com/stellar/js-stellar-sdk/pull/735)).
+
 ### Fix
 
 - Use the right string for liquidity pool trades ([#734](https://github.com/stellar/js-stellar-sdk/pull/734)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@ A breaking change will get clearly marked in this log.
 
 ## [v10.0.0](https://github.com/stellar/js-stellar-sdk/compare/v9.1.0...v10.0.0)
 
-This release introduces breaking changes from `stellar-base`. It adds **unconditional support for muxed accounts**. Please refer to its [release notes](https://github.com/stellar/js-stellar-base/releases/tag/v7.0.0) for details on the breaking changes.
+This release introduces breaking changes from `stellar-base`. It adds **unconditional support for muxed accounts**. Please refer to the corresponding [release notes](https://github.com/stellar/js-stellar-base/releases/tag/v7.0.0) for details on the breaking changes there.
 
 ### Breaking Updates
 
 - Upgrades the stellar-base library to v7.0.0 ([#735](https://github.com/stellar/js-stellar-sdk/pull/735)).
-
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 
+## [v10.0.0](https://github.com/stellar/js-stellar-sdk/compare/v9.1.0...v10.0.0)
+
+This release introduces breaking changes from `stellar-base`. It adds **unconditional support for muxed accounts**. Please refer to its [release notes](https://github.com/stellar/js-stellar-base/releases/tag/v7.0.0) for details on the breaking changes.
+
+### Breaking Updates
+
+- Upgrades the stellar-base library to v7.0.0 ([]()).
+
+
+### Fix
+
+- Use the right string for liquidity pool trades ([#734](https://github.com/stellar/js-stellar-sdk/pull/734)).
+
+
 ## [v9.1.0](https://github.com/stellar/js-stellar-sdk/compare/v9.0.1...v9.1.0)
 
 ### Add

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-sdk",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "description": "stellar-sdk is a library for working with the Stellar Horizon server.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -138,7 +138,7 @@
     "eventsource": "^1.0.7",
     "lodash": "^4.17.21",
     "randombytes": "^2.1.0",
-    "stellar-base": "^6.0.4",
+    "stellar-base": "^7.0.0",
     "toml": "^2.3.0",
     "tslib": "^1.10.0",
     "urijs": "^1.19.1",

--- a/src/account_response.ts
+++ b/src/account_response.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:variable-name */
 
 import forIn from "lodash/forIn";
-import { Account as BaseAccount, MuxedAccount } from "stellar-base";
+import { Account as BaseAccount } from "stellar-base";
 import { Horizon } from "./horizon_api";
 import { ServerApi } from "./server_api";
 
@@ -82,9 +82,5 @@ export class AccountResponse {
   public incrementSequenceNumber(): void {
     this._baseAccount.incrementSequenceNumber();
     this.sequence = this._baseAccount.sequenceNumber();
-  }
-
-  public createSubaccount(id: string): MuxedAccount {
-    return this._baseAccount.createSubaccount(id);
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,7 +81,6 @@ export namespace Utils {
           name: `${homeDomain} auth`,
           value,
           source: clientAccountID,
-          withMuxing: true,
         }),
       )
       .addOperation(
@@ -160,14 +159,10 @@ export namespace Utils {
 
     let transaction;
     try {
-      transaction = new Transaction(challengeTx, networkPassphrase, true);
+      transaction = new Transaction(challengeTx, networkPassphrase);
     } catch {
       try {
-        transaction = new FeeBumpTransaction(
-          challengeTx,
-          networkPassphrase,
-          true,
-        );
+        transaction = new FeeBumpTransaction(challengeTx, networkPassphrase);
       } catch {
         throw new InvalidSep10ChallengeError(
           "Invalid challenge: unable to deserialize challengeTx transaction string",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7876,10 +7876,10 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stellar-base@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-6.0.4.tgz#2b44ef6434e52cbfca103ff9349f16fca806557e"
-  integrity sha512-zYoo4sjeF3mX9L/m/VF5qySpKdmGi+1c8Q58dB+wRNSLZMYssx7cplONuFMZpcCDukSdFNx+8mjyZdPuy7j1tA==
+stellar-base@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-7.0.0.tgz#6ebb359fc0a5e8fe6ed855c62de78cbec779b463"
+  integrity sha512-Sfk/u/6HT+8xSQ4HvTI3XgthTS3fhv/ie6Jx4OzLvg81pt09bDDN5YvRbG6v3gZdiRA0pwg2RRz5YS3ph5ePEg==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^4.0.0"


### PR DESCRIPTION
This release introduces breaking changes from `stellar-base`. It adds **unconditional support for muxed accounts**. Please refer to its [release notes](https://github.com/stellar/js-stellar-base/releases/tag/v7.0.0) for details on the breaking changes.

### Breaking Updates

- Upgrades the stellar-base library to v7.0.0.

### Fix

- Use the right string for liquidity pool trades ([#734](https://github.com/stellar/js-stellar-sdk/pull/734)).
