### PR TITLE
Fix GitHub Actions bugs

### DIFF
--- a/.github/workflows/bower_publish.yml
+++ b/.github/workflows/bower_publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install and build package
         run: |
           yarn install
-          yarn build
+          yarn
           cp dist/* bower/
 
       - name: Publish to bower
@@ -37,5 +37,4 @@ jobs:
           git config user.email github-actions@github.com
           git add .
           git commit -m $TAG
-          git tag -a $TAG -m $TAG
-          git push origin master --tags
+          git push origin master

--- a/.github/workflows/bower_publish.yml
+++ b/.github/workflows/bower_publish.yml
@@ -37,4 +37,5 @@ jobs:
           git config user.email github-actions@github.com
           git add .
           git commit -m $TAG
-          git push origin master
+          git tag -a $TAG -m $TAG
+          git push origin master --tags

--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -7,10 +7,16 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout SDK
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
+      - name: Checkout Base
+        uses: actions/checkout@v2
+        with:
+          repository: stellar/js-stellar-base
+          path: js-stellar-base
 
       - name: Install Node (14.x)
         uses: actions/setup-node@v2

--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -31,12 +31,13 @@ jobs:
           path: jsdoc
 
       - name: Generate JS docs
+        continue-on-error: true
         run: yarn docs
 
       - name: Publish JS docs
         run: |
           TAG=`git describe --tags`
-          cd jsdoc
+          cd jsdoc/
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .


### PR DESCRIPTION
Two things:
 - the Bower script was using `yarn build` which isn't a real command... just use `yarn` :facepalm: 
 - add `continue-on-error` so that docs get published even if the `jsdoc` complains (because the complaints are rarely "true" errors)