### PR TITLE
Add fields to AssetRecord definition

### DIFF
--- a/src/types/assets.ts
+++ b/src/types/assets.ts
@@ -1,5 +1,6 @@
 import { AssetType } from "stellar-base";
 import { Horizon } from "./../horizon_api";
+
 export interface AssetRecord extends Horizon.BaseResponse {
   asset_type: AssetType.credit4 | AssetType.credit12;
   asset_code: string;
@@ -7,9 +8,11 @@ export interface AssetRecord extends Horizon.BaseResponse {
   paging_token: string;
   accounts: Horizon.AssetAccounts;
   num_claimable_balances: number;
+  num_liquidity_pools: number;
   balances: Horizon.AssetBalances;
   claimable_balances_amount: string;
   amount: string;
   num_accounts: number;
+  liquidity_pools_amount: string;
   flags: Horizon.Flags;
 }


### PR DESCRIPTION
This PR adds the fields `num_liquidity_pools` and `liquidity_pools_amount` that are missing in the `AssetRecord` definition.
Fixes #747 