### PR TITLE
#760 - update EventSource definition for streaming operations in React Native

### DIFF
--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -32,8 +32,9 @@ if (anyGlobal.EventSource) {
   EventSource = require("eventsource");
 } else {
   // EventSource = anyGlobal.window.EventSource;
-    /* require("eventsource") for React Native env */
-    EventSource = require("eventsource");
+  // require("eventsource") for React Native env
+  /* tslint:disable-next-line:no-var-requires */
+  EventSource = require("eventsource");
 }
 
 /**

--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -31,7 +31,9 @@ if (anyGlobal.EventSource) {
   /* tslint:disable-next-line:no-var-requires */
   EventSource = require("eventsource");
 } else {
-  EventSource = anyGlobal.window.EventSource;
+  // EventSource = anyGlobal.window.EventSource;
+    /* require("eventsource") for React Native env */
+    EventSource = require("eventsource");
 }
 
 /**

--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -30,8 +30,9 @@ if (anyGlobal.EventSource) {
 } else if (isNode) {
   /* tslint:disable-next-line:no-var-requires */
   EventSource = require("eventsource");
+} else if (anyGlobal.window.EventSource) { 
+  EventSource = anyGlobal.window.EventSource;
 } else {
-  // EventSource = anyGlobal.window.EventSource;
   // require("eventsource") for React Native env
   /* tslint:disable-next-line:no-var-requires */
   EventSource = require("eventsource");


### PR DESCRIPTION
Updated call_builder.ts to include another condition for defining EventSource. 

The addition of the second **else if** clause allows the correct definition to be applied in React-Native environments under the **else** condition.

Previous definition:
```
if (anyGlobal.EventSource) {
  EventSource = anyGlobal.EventSource;
} else if (isNode) {
  /* tslint:disable-next-line:no-var-requires */
  EventSource = require("eventsource");
} else (anyGlobal.window.EventSource) { 
  // RN environment does not trigger anyGlobal.EventSource or isNode
  // anyGlobal.window.EventSource is undefined here
  EventSource = anyGlobal.window.EventSource;
}
```

Additional clause preserving **anyGlobal.window.EventSource** conditions while correctly assigning EventSource in RN:
```
else if (anyGlobal.window.EventSource) { 
  EventSource = anyGlobal.window.EventSource;
} else {
  // require("eventsource") for React Native env
  /* tslint:disable-next-line:no-var-requires */
  EventSource = require("eventsource");
}