### PR TITLE
Stop re-creating `EventSource`s upon receiving a `close` event

### DIFF
--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -133,18 +133,9 @@ export class CallBuilder<
       createTimeout();
 
       if (es) {
-        // when receiving the close message from Horizon we should
-        // close the connection and recreate the event source
-        let closed = false;
         const onClose = () => {
-          if (closed) {
-            return;
-          }
-
           clearTimeout(timeout);
           es.close();
-          createEventSource();
-          closed = true;
         };
 
         const onMessage = (message: any) => {


### PR DESCRIPTION
Context: #567. In that PR, the SDK was updated to handle the `event: close` event as well as recreate the `EventSource` object when the event occurred to keep the stream open.

However, according to the MDN documentation on [server-side events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events):

> By default, if the connection between the client and server closes, **the connection is restarted**. The connection is terminated with the `.close()` method.

Now, it's unclear if the above became spec'd behavior after #567 or not, but the point is, it appears we no longer need to recreate the event stream. Doing so causes test failures such as [this one](https://github.com/stellar/js-stellar-sdk/runs/5874317275?check_suite_focus=true):

```txt
  1) integration tests: streaming
       handles close message:
     Error: done() called multiple times
      at IncomingMessage.<anonymous> (test/integration/streaming_test.js:51:9)
      at IncomingMessage.emit (node:events:526:28)
      at emitCloseNT (node:internal/streams/destroy:138:10)
      at processTicksAndRejections (node:internal/process/task_queues:82:21)
```

This is likely because the call builder is recreating the event stream on the `close`, making it `close` twice.

--------------

(Adding reviewers from #567.)