### PR TITLE
Reverts #772, forcing recreation of event sources when streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ A breaking change will get clearly marked in this log.
 
 ### Fix
 
-- Reverts a change from [v10.0.0](#v10.0.0) which caused streams to die prematurely ([TODO](https://github.com/stellar/js-stellar-sdk/pull/TODO)).
+- Reverts a change from [v10.0.0](#v10.0.0) which caused streams to die prematurely ([#780](https://github.com/stellar/js-stellar-sdk/pull/780)).
 
 
 ## [v10.1.0](https://github.com/stellar/js-stellar-sdk/compare/v10.0.1...v10.1.0-beta.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Fix
+
+- Reverts a change from [v10.0.0](#v10.0.0) which caused streams to die prematurely ([TODO](https://github.com/stellar/js-stellar-sdk/pull/TODO)).
+
 
 ## [v10.1.0](https://github.com/stellar/js-stellar-sdk/compare/v10.0.1...v10.1.0-beta.0)
 

--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -137,9 +137,18 @@ export class CallBuilder<
       createTimeout();
 
       if (es) {
+        // when receiving the close message from Horizon we should
+        // close the connection and recreate the event source
+        let closed = false;
         const onClose = () => {
+          if (closed) {
+            return;
+          }
+
           clearTimeout(timeout);
           es.close();
+          createEventSource();
+          closed = true;
         };
 
         const onMessage = (message: any) => {

--- a/test/integration/streaming_test.js
+++ b/test/integration/streaming_test.js
@@ -88,12 +88,13 @@ describe("integration tests:live streaming", function(done) {
     return;
   }
 
-  // stream ledgers from pubnet for a while and ensure that the quantity we see
-  // looks reasonable (since they're supposed to arrive every ~6s).
+  // stream transactions from pubnet for a while and ensure that we cross a
+  // ledger boundary (if streaming is broken, we will get stuck on a single
+  // ledger's transaction batch).
   it("streams in perpetuity", function(done) {
     const DURATION = 30;
     const server = new StellarSdk.Server("https://horizon.stellar.org");
-    this.timeout((DURATION + 5) * 1000);
+    this.timeout((DURATION + 5) * 1000); // pad timeout
 
     let transactions = [];
 


### PR DESCRIPTION
Resolves #779, though investigation is still necessary as to why the tests fail under Node 16 (the initial reason #772 was merged).