### PR TITLE
Add support for auth token in header

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -65,6 +65,7 @@ function _getAmountInLumens(amt: BigNumber) {
  * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments! You can also use {@link Config} class to set this globally.
  * @param {string} [opts.appName] - Allow set custom header `X-App-Name`, default: `undefined`.
  * @param {string} [opts.appVersion] - Allow set custom header `X-App-Version`, default: `undefined`.
+ * @param {string} [opts.authToken] - Allow set custom header `X-Auth-Token`, default: `undefined`.
  */
 export class Server {
   /**
@@ -89,6 +90,9 @@ export class Server {
     }
     if (opts.appVersion) {
       customHeaders["X-App-Version"] = opts.appVersion;
+    }
+    if (opts.authToken) {
+      customHeaders["X-Auth-Token"] = opts.authToken;
     }
     if (!isEmpty(customHeaders)) {
       HorizonAxiosClient.interceptors.request.use((config) => {
@@ -821,6 +825,7 @@ export namespace Server {
     allowHttp?: boolean;
     appName?: string;
     appVersion?: string;
+    authToken?: string;
   }
 
   export interface Timebounds {


### PR DESCRIPTION
Some paid node providers require authentication to prevent abuse / DDoS attacks. A way of doing this is by proving an `auth` GET parameter in the server url when a  “stellarsdk.Server” object is created. For security purposes, node providers may remove this auth token by purging it from the responses. And since the sdk uses some values in the  response for future requests, the sdk no longer has context of the auth token. As a result, some calls to library methods like `next()` and `prev()` fail. 

This PR adds support for a new custom header when a new stellar server object is created, namely `X-Auth-Token`.  Adding support for this header allows us to authenticate against a node & have the sdk keep track of the authentication value.

