### PR TITLE
Release v10.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 
+## [v10.4.0](https://github.com/stellar/js-stellar-sdk/compare/v10.3.0...v10.4.0)
+
+### Add
+
+- Add [SEP-1](https://stellar.org/protocol/sep-1) fields to `StellarTomlResolver` for type checks ([#794](https://github.com/stellar/js-stellar-sdk/pull/794)).
+
+- Add support for passing `X-Auth-Token` as a custom header ([#795](https://github.com/stellar/js-stellar-sdk/pull/795)).
+
+### Update
+
+- Bumps `stellar-base` version to [v8.2.1](https://github.com/stellar/js-stellar-base/releases/tag/v8.2.1) to include latest fixes.
+
+
 ## [v10.3.0](https://github.com/stellar/js-stellar-sdk/compare/v10.2.0...v10.3.0)
 
 ### Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-sdk",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "description": "stellar-sdk is a library for working with the Stellar Horizon server.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -138,7 +138,7 @@
     "eventsource": "^1.1.1",
     "lodash": "^4.17.21",
     "randombytes": "^2.1.0",
-    "stellar-base": "^8.2.0",
+    "stellar-base": "^8.2.1",
     "toml": "^2.3.0",
     "tslib": "^1.10.0",
     "urijs": "^1.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7829,10 +7829,10 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-stellar-base@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-8.2.0.tgz#59b816867dd4a649e50c0d6d6409152818973922"
-  integrity sha512-hISUIR4In07/kopp2jJRDmoDErWc27N90GAfa9Ibn3yBrwr9YBqpDRst+4wr3Y6Fb4NFaJS5CjqSmLTL8jSvPQ==
+stellar-base@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-8.2.1.tgz#9d4259760ce61bc232e1045273cb2424a9950cb3"
+  integrity sha512-rtTrAxkKq+ppE88xJSqEt9Lsp9bjpx3n0jn5QdqsWHvuo6EQ4yd1ODZe3P7ueEPyMfillc2BIZEV+p4Y9ndJQA==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^4.0.0"


### PR DESCRIPTION
This includes #794, #795, and a version bump to `stellar-base`.

TODO: Run `yarn` after stellar/js-stellar-base#554 is merged and released.