### PR TITLE
Added paging_token to interface SubmitTransactionResponse

### DIFF
--- a/src/horizon_api.ts
+++ b/src/horizon_api.ts
@@ -17,6 +17,7 @@ export namespace Horizon {
     envelope_xdr: string;
     result_xdr: string;
     result_meta_xdr: string;
+    paging_token: string;
   }
 
   export interface FeeBumpTransactionResponse {


### PR DESCRIPTION
After submitting a transaction, paging_token can be accessed through the response with `Horizon.SubmitTransactionResponse.paging_token` but throws an error in which **Property 'paging_token' does not exist on type 'SubmitTransactionResponse'.ts(2339)**. I just added `paging_token : string` in the `interface SubmitTransactionResponse`.