### PR TITLE
Drop `Promise` polyfill, as its well-supported natively in all environments.

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "axios": "1.3.6",
     "bignumber.js": "^9.1.1",
     "detect-node": "^2.0.4",
-    "es6-promise": "^4.2.4",
     "eventsource": "^2.0.2",
     "lodash": "^4.17.21",
     "randombytes": "^2.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@
 /// <reference path="../types/dom-monkeypatch.d.ts" />
 
 /* tslint:disable:no-var-requires */
-require("es6-promise").polyfill();
 const version = require("../package.json").version;
 
 // Expose all types


### PR DESCRIPTION
**Epic: stellar/js-stellar-sdk#792**

This supersedes #623, dropping the `es6-promise` polyfill entirely. Promises are well-supported on all browsers: https://caniuse.com/promises, so this should be quite safe.

Related: https://github.com/stellar/js-stellar-sdk/issues/792#issuecomment-1518413229, cc @orbitlens.