### PR TITLE
Make builds actually evaluate Typescript type checks...

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -3,11 +3,10 @@
   "compilerOptions": {
     "declaration": true,
     "declarationDir": "../lib",
-    "lib": ["es2015"],
     "moduleResolution": "node",
     "rootDir": "../src",
     "outDir": "../lib",
-    "target": "es5"
+    "target": "es6"
   },
   "include": ["../src"]
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build": "cross-env NODE_ENV=development yarn _build",
     "build:prod": "cross-env NODE_ENV=production yarn _build",
-    "build:node": "babel --extensions '.ts' --out-dir lib/ src/",
+    "build:node": "babel --extensions '.ts' --out-dir lib/ src/ && tsc -p ./config/tsconfig.json",
     "build:browser": "webpack --stats-modules-space 999 -c config/webpack.config.browser.js",
     "clean": "rm -rf lib/ dist/ coverage/ .nyc_output/",
     "docs": "jsdoc -c ./config/.jsdoc.json --verbose",

--- a/src/server.ts
+++ b/src/server.ts
@@ -81,7 +81,7 @@ export class Server {
         ? Config.isAllowHttp()
         : opts.allowHttp;
 
-    const customHeaders: object = {};
+    const customHeaders: Record<string, string> = {};
 
     if (opts.appName) {
       customHeaders["X-App-Name"] = opts.appName;

--- a/src/stellar_toml_resolver.ts
+++ b/src/stellar_toml_resolver.ts
@@ -63,7 +63,7 @@ export class StellarTomlResolver {
         try {
           const tomlObject = toml.parse(response.data);
           return Promise.resolve(tomlObject);
-        } catch (e) {
+        } catch (e: any) {
           return Promise.reject(
             new Error(
               `stellar.toml is invalid - Parsing error on line ${e.line}, column ${e.column}: ${e.message}`,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -509,7 +509,7 @@ export namespace Utils {
     let serverKP: Keypair;
     try {
       serverKP = Keypair.fromPublicKey(serverAccountID); // can throw 'Invalid Stellar public key'
-    } catch (err) {
+    } catch (err: any) {
       throw new Error(
         "Couldn't infer keypair from the provided 'serverAccountID': " +
           err.message,
@@ -686,7 +686,7 @@ export namespace Utils {
       let keypair: Keypair;
       try {
         keypair = Keypair.fromPublicKey(signer); // This can throw a few different errors
-      } catch (err) {
+      } catch (err: any) {
         throw new InvalidSep10ChallengeError(
           "Signer is not a valid address: " + err.message,
         );


### PR DESCRIPTION
Apparently, Babel just does transpiling, and the [Typescript docs](https://www.typescriptlang.org/docs/handbook/babel-with-typescript.html) say you need an additional step to do type evaluation :facepalm: 

This adds that step to the build pipeline and fixes the existing code to play nicely with Typescript 5.