### PR TITLE
Drop all usage of `URI` to make tree-shaking `urijs` dependency possible

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -1,12 +1,16 @@
 {
   "extends": "@stellar/tsconfig",
   "compilerOptions": {
+    "lib": ["es2015"],
+    "target": "es5",
     "declaration": true,
     "declarationDir": "../lib",
+    "emitDeclarationOnly": true,
+    // Ensure that Babel can safely transpile files in the TypeScript project
+    "isolatedModules": true,
     "moduleResolution": "node",
     "rootDir": "../src",
     "outDir": "../lib",
-    "target": "es6"
   },
   "include": ["../src"]
 }

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "@stellar/tsconfig",
   "compilerOptions": {
-    "lib": ["es2015"],
-    "target": "es5",
+    "target": "es6",
     "declaration": true,
     "declarationDir": "../lib",
     "emitDeclarationOnly": true,

--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
   "dependencies": {
     "axios": "^1.4.0",
     "bignumber.js": "^9.1.1",
-    "detect-node": "^2.0.4",
     "eventsource": "^2.0.2",
     "randombytes": "^2.1.0",
     "stellar-base": "v9.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
   "dependencies": {
     "axios": "^1.4.0",
     "bignumber.js": "^9.1.1",
+    "detect-node": "^2.0.4",
     "eventsource": "^2.0.2",
     "randombytes": "^2.1.0",
     "stellar-base": "v9.0.0-beta.2",

--- a/src/account_call_builder.ts
+++ b/src/account_call_builder.ts
@@ -17,7 +17,7 @@ export class AccountCallBuilder extends CallBuilder<
 > {
   constructor(serverUrl: URI) {
     super(serverUrl);
-    this.url.segment("accounts");
+    this.segment("accounts");
   }
 
   /**
@@ -29,7 +29,7 @@ export class AccountCallBuilder extends CallBuilder<
    * @returns {CallBuilder} a new CallBuilder instance for the /accounts/:id endpoint
    */
   public accountId(id: string): CallBuilder<ServerApi.AccountRecord> {
-    const builder = new CallBuilder<ServerApi.AccountRecord>(this.url.clone());
+    const builder = new CallBuilder<ServerApi.AccountRecord>(this.clone());
     builder.filter.push([id]);
     return builder;
   }
@@ -41,7 +41,7 @@ export class AccountCallBuilder extends CallBuilder<
    * @returns {AccountCallBuilder} current AccountCallBuilder instance
    */
   public forSigner(id: string): this {
-    this.url.setQuery("signer", id);
+    this.url.searchParams.set("signer", id);
     return this;
   }
 
@@ -53,7 +53,7 @@ export class AccountCallBuilder extends CallBuilder<
    * @returns {AccountCallBuilder} current AccountCallBuilder instance
    */
   public forAsset(asset: Asset): this {
-    this.url.setQuery("asset", `${asset}`);
+    this.url.searchParams.set("asset", `${asset}`);
     return this;
   }
 
@@ -64,7 +64,7 @@ export class AccountCallBuilder extends CallBuilder<
    * @returns {AccountCallBuilder} current AccountCallBuilder instance
    */
   public sponsor(id: string): this {
-    this.url.setQuery("sponsor", id);
+    this.url.searchParams.set("sponsor", id);
     return this;
   }
 
@@ -75,7 +75,7 @@ export class AccountCallBuilder extends CallBuilder<
    * @returns {AccountCallBuilder} current AccountCallBuilder instance
    */
   public forLiquidityPool(id: string): this {
-    this.url.setQuery("liquidity_pool", id);
+    this.url.searchParams.set("liquidity_pool", id);
     return this;
   }
 }

--- a/src/account_call_builder.ts
+++ b/src/account_call_builder.ts
@@ -10,12 +10,12 @@ import { ServerApi } from "./server_api";
  * @class AccountCallBuilder
  * @extends CallBuilder
  * @constructor
- * @param {string} serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl Horizon server URL.
  */
 export class AccountCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.AccountRecord>
 > {
-  constructor(serverUrl: URI) {
+  constructor(serverUrl: URL | string) {
     super(serverUrl);
     this.segment("accounts");
   }

--- a/src/assets_call_builder.ts
+++ b/src/assets_call_builder.ts
@@ -8,12 +8,12 @@ import { ServerApi } from "./server_api";
  * @class AssetsCallBuilder
  * @constructor
  * @extends CallBuilder
- * @param {string} serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl Horizon server URL.
  */
 export class AssetsCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.AssetRecord>
 > {
-  constructor(serverUrl: URI) {
+  constructor(serverUrl: URL | string) {
     super(serverUrl);
     this.segment("assets");
   }

--- a/src/assets_call_builder.ts
+++ b/src/assets_call_builder.ts
@@ -15,7 +15,7 @@ export class AssetsCallBuilder extends CallBuilder<
 > {
   constructor(serverUrl: URI) {
     super(serverUrl);
-    this.url.segment("assets");
+    this.segment("assets");
   }
 
   /**
@@ -24,7 +24,7 @@ export class AssetsCallBuilder extends CallBuilder<
    * @returns {AssetsCallBuilder} current AssetCallBuilder instance
    */
   public forCode(value: string): AssetsCallBuilder {
-    this.url.setQuery("asset_code", value);
+    this.url.searchParams.set("asset_code", value);
     return this;
   }
 
@@ -34,7 +34,7 @@ export class AssetsCallBuilder extends CallBuilder<
    * @returns {AssetsCallBuilder} current AssetCallBuilder instance
    */
   public forIssuer(value: string): AssetsCallBuilder {
-    this.url.setQuery("asset_issuer", value);
+    this.url.searchParams.set("asset_issuer", value);
     return this;
   }
 }

--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -1,4 +1,3 @@
-import URI from "urijs";
 import URITemplate from "urijs/src/URITemplate";
 
 import { BadRequestError, NetworkError, NotFoundError } from "./errors";
@@ -45,7 +44,7 @@ export class CallBuilder<
 
   public filter: string[][];
 
-  constructor(serverUrl: URL | URI, neighborRoot: string = "") {
+  constructor(serverUrl: URL | string, neighborRoot: string = "") {
     this.url = new URL(serverUrl.toString());
 
     this.filter = [];

--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -362,8 +362,8 @@ export class CallBuilder<
 
     if (url.port === "" && url.username === "" && url.password === "") {
       url.port = thisUrl.port;
-      url.username = thisUrl.username
-      url.password = thisUrl.password
+      url.username = thisUrl.username;
+      url.password = thisUrl.password;
     }
 
     if (url.protocol === "") {

--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -52,12 +52,18 @@ export class CallBuilder<
     | ServerApi.CollectionPage<Horizon.BaseResponse>
 > {
   protected url: URI;
-  public filter: string[][];
   protected originalSegments: string[];
   protected neighborRoot: string;
 
-  constructor(serverUrl: URI, neighborRoot: string = "") {
-    this.url = serverUrl.clone();
+  public filter: string[][];
+
+  constructor(serverUrl: URI | URL, neighborRoot: string = "") {
+    if (serverUrl instanceof URL) {
+      this.url = URI(serverUrl.toString());
+    } else {
+      this.url = serverUrl.clone();
+    }
+
     this.filter = [];
     this.originalSegments = this.url.segment() || [];
     this.neighborRoot = neighborRoot;
@@ -294,13 +300,13 @@ export class CallBuilder<
    */
   private _requestFnForLink(link: Horizon.ResponseLink): (opts?: any) => any {
     return async (opts: any = {}) => {
-      let uri;
+      let uri: URL;
 
       if (link.templated) {
         const template = URITemplate(link.href);
-        uri = URI(template.expand(opts) as any); // TODO: fix upstream types.
+        uri = new URL(template.expand(opts).toString()); // TODO: fix upstream types.
       } else {
-        uri = URI(link.href);
+        uri = new URL(link.href);
       }
 
       const r = await this._sendNormalRequest(uri);
@@ -351,7 +357,7 @@ export class CallBuilder<
     // Update the given URL's username, password, and protocol using the
     // internal URL as a template if they aren't explicitly set already.
 
-    let url = new URL(initialUrl); // clone to avoid modifying caller
+    let url = new URL(initialUrl.toString()); // clone to avoid modifying caller
     let thisUrl = new URL(this.url.toString()); // while we migrate
 
     if (url.port === "" && url.username === "" && url.password === "") {

--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -1,3 +1,4 @@
+import isNode from "detect-node";
 import URITemplate from "urijs/src/URITemplate";
 
 import { BadRequestError, NetworkError, NotFoundError } from "./errors";
@@ -12,18 +13,28 @@ const version = require("../package.json").version;
 // query-param.
 const JOINABLE = ["transaction"];
 
+type Constructable<T> = new (e: string) => T;
+
 export interface EventSourceOptions<T> {
   onmessage?: (value: T) => void;
   onerror?: (event: MessageEvent) => void;
   reconnectTimeout?: number;
 }
 
+let EventSource: Constructable<EventSource>;
 const anyGlobal = global as any;
-type Constructable<T> = new (e: string) => T;
-// require("eventsource") for Node and React Native environment
-let EventSource: Constructable<EventSource> = anyGlobal.EventSource ??
-  anyGlobal.window?.EventSource ??
-  require("eventsource");
+if (anyGlobal.EventSource) {
+  EventSource = anyGlobal.EventSource;
+} else if (isNode) {
+  /* tslint:disable-next-line:no-var-requires */
+  EventSource = require("eventsource");
+} else if (anyGlobal.window.EventSource) {
+  EventSource = anyGlobal.window.EventSource;
+} else {
+  // require("eventsource") for React Native environment
+  /* tslint:disable-next-line:no-var-requires */
+  EventSource = require("eventsource");
+}
 
 /**
  * Creates a new {@link CallBuilder} pointed to server defined by serverUrl.

--- a/src/call_builder.ts
+++ b/src/call_builder.ts
@@ -1,4 +1,3 @@
-import isNode from "detect-node";
 import URI from "urijs";
 import URITemplate from "urijs/src/URITemplate";
 
@@ -14,29 +13,18 @@ const version = require("../package.json").version;
 // query-param.
 const JOINABLE = ["transaction"];
 
-type Constructable<T> = new (e: string) => T;
-
 export interface EventSourceOptions<T> {
   onmessage?: (value: T) => void;
   onerror?: (event: MessageEvent) => void;
   reconnectTimeout?: number;
 }
 
-let EventSource: Constructable<EventSource>;
 const anyGlobal = global as any;
-
-if (anyGlobal.EventSource) {
-  EventSource = anyGlobal.EventSource;
-} else if (isNode) {
-  /* tslint:disable-next-line:no-var-requires */
-  EventSource = require("eventsource");
-} else if (anyGlobal.window.EventSource) {
-  EventSource = anyGlobal.window.EventSource;
-} else {
-  // require("eventsource") for React Native environment
-  /* tslint:disable-next-line:no-var-requires */
-  EventSource = require("eventsource");
-}
+type Constructable<T> = new (e: string) => T;
+// require("eventsource") for Node and React Native environment
+let EventSource: Constructable<EventSource> = anyGlobal.EventSource ??
+  anyGlobal.window.EventSource ??
+  require("eventsource");
 
 /**
  * Creates a new {@link CallBuilder} pointed to server defined by serverUrl.

--- a/src/claimable_balances_call_builder.ts
+++ b/src/claimable_balances_call_builder.ts
@@ -17,7 +17,7 @@ export class ClaimableBalanceCallBuilder extends CallBuilder<
 > {
   constructor(serverUrl: URI) {
     super(serverUrl);
-    this.url.segment("claimable_balances");
+    this.segment("claimable_balances");
   }
 
   /**
@@ -31,7 +31,7 @@ export class ClaimableBalanceCallBuilder extends CallBuilder<
     claimableBalanceId: string,
   ): CallBuilder<ServerApi.ClaimableBalanceRecord> {
     const builder = new CallBuilder<ServerApi.ClaimableBalanceRecord>(
-      this.url.clone(),
+      this.clone(),
     );
     builder.filter.push([claimableBalanceId]);
     return builder;
@@ -45,7 +45,7 @@ export class ClaimableBalanceCallBuilder extends CallBuilder<
    * @returns {ClaimableBalanceCallBuilder} current ClaimableBalanceCallBuilder instance
    */
   public sponsor(sponsor: string): this {
-    this.url.setQuery("sponsor", sponsor);
+    this.url.searchParams.set("sponsor", sponsor);
     return this;
   }
 
@@ -57,7 +57,7 @@ export class ClaimableBalanceCallBuilder extends CallBuilder<
    * @returns {ClaimableBalanceCallBuilder} current ClaimableBalanceCallBuilder instance
    */
   public claimant(claimant: string): this {
-    this.url.setQuery("claimant", claimant);
+    this.url.searchParams.set("claimant", claimant);
     return this;
   }
 
@@ -69,7 +69,7 @@ export class ClaimableBalanceCallBuilder extends CallBuilder<
    * @returns {ClaimableBalanceCallBuilder} current ClaimableBalanceCallBuilder instance
    */
   public asset(asset: Asset): this {
-    this.url.setQuery("asset", asset.toString());
+    this.url.searchParams.set("asset", asset.toString());
     return this;
   }
 }

--- a/src/claimable_balances_call_builder.ts
+++ b/src/claimable_balances_call_builder.ts
@@ -10,12 +10,12 @@ import { ServerApi } from "./server_api";
  * @class ClaimableBalanceCallBuilder
  * @constructor
  * @extends CallBuilder
- * @param {string} serverUrl Horizon server URL.
+ * @param {URL|string} serverUrl Horizon server URL.
  */
 export class ClaimableBalanceCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.ClaimableBalanceRecord>
 > {
-  constructor(serverUrl: URI) {
+  constructor(serverUrl: URL|string) {
     super(serverUrl);
     this.segment("claimable_balances");
   }

--- a/src/effect_call_builder.ts
+++ b/src/effect_call_builder.ts
@@ -16,7 +16,7 @@ export class EffectCallBuilder extends CallBuilder<
 > {
   constructor(serverUrl: URI) {
     super(serverUrl, "effects");
-    this.url.segment("effects");
+    this.segment("effects");
   }
 
   /**

--- a/src/effect_call_builder.ts
+++ b/src/effect_call_builder.ts
@@ -9,12 +9,12 @@ import { ServerApi } from "./server_api";
  * @extends CallBuilder
  * @see [All Effects](https://developers.stellar.org/api/resources/effects/)
  * @constructor
- * @param {string} serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl Horizon server URL.
  */
 export class EffectCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.EffectRecord>
 > {
-  constructor(serverUrl: URI) {
+  constructor(serverUrl: URL | string) {
     super(serverUrl, "effects");
     this.segment("effects");
   }

--- a/src/federation_server.ts
+++ b/src/federation_server.ts
@@ -1,25 +1,32 @@
 import axios from "axios";
 import { StrKey } from "stellar-base";
-import URI from "urijs";
 
 import { Config } from "./config";
 import { BadResponseError } from "./errors";
 import { StellarTomlResolver } from "./stellar_toml_resolver";
 
-// FEDERATION_RESPONSE_MAX_SIZE is the maximum size of response from a federation server
+/**
+ * The maximum size of response from a federation server
+ */
 export const FEDERATION_RESPONSE_MAX_SIZE = 100 * 1024;
 
 /**
- * FederationServer handles a network connection to a
- * [federation server](https://developers.stellar.org/docs/glossary/federation/)
- * instance and exposes an interface for requests to that instance.
+ * FederationServer handles a network connection to a [federation
+ * server](https://developers.stellar.org/docs/glossary/federation/) instance
+ * and exposes an interface for requests to that instance.
+ *
  * @constructor
- * @param {string} serverURL The federation server URL (ex. `https://acme.com/federation`).
+ *
+ * @param {string} serverURL The federation server URL (ex.
+ *    `https://acme.com/federation`).
  * @param {string} domain Domain this server represents
  * @param {object} [opts] options object
- * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments! You can also use {@link Config} class to set this globally.
- * @param {number} [opts.timeout] - Allow a timeout, default: 0. Allows user to avoid nasty lag due to TOML resolve issue. You can also use {@link Config} class to set this globally.
- * @returns {void}
+ * @param {boolean} [opts.allowHttp] - Allow connecting to http servers,
+ *    default: `false`. This must be set to false in production deployments! You
+ *    can also use {@link Config} class to set this globally.
+ * @param {number} [opts.timeout] - Allow a timeout, default: 0. Allows user to
+ *    avoid nasty lag due to TOML resolve issue. You can also use {@link Config}
+ *    class to set this globally.
  */
 export class FederationServer {
   /**
@@ -27,7 +34,7 @@ export class FederationServer {
    *
    * @memberof FederationServer
    */
-  private readonly serverURL: URI; // TODO: public or private? readonly?
+  private readonly serverURL: URL;
   /**
    * Domain this server represents.
    *
@@ -47,14 +54,20 @@ export class FederationServer {
    * A helper method for handling user inputs that contain `destination` value.
    * It accepts two types of values:
    *
-   * * For Stellar address (ex. `bob*stellar.org`) it splits Stellar address and then tries to find information about
-   * federation server in `stellar.toml` file for a given domain. It returns a `Promise` which resolves if federation
-   * server exists and user has been found and rejects in all other cases.
-   * * For Account ID (ex. `GB5XVAABEQMY63WTHDQ5RXADGYF345VWMNPTN2GFUDZT57D57ZQTJ7PS`) it returns a `Promise` which
-   * resolves if Account ID is valid and rejects in all other cases. Please note that this method does not check
-   * if the account actually exists in a ledger.
+   * * For Stellar address (ex. `bob*stellar.org`) it splits Stellar address and
+   *   then tries to find information about federation server in `stellar.toml`
+   *   file for a given domain. It returns a `Promise` which resolves if
+   *   federation server exists and user has been found and rejects in all other
+   *   cases.
+   *
+   * * For Account ID (ex.
+   *   `GB5XVAABEQMY63WTHDQ5RXADGYF345VWMNPTN2GFUDZT57D57ZQTJ7PS`) it returns a
+   *   `Promise` which resolves if Account ID is valid and rejects in all other
+   *   cases. Please note that this method does not check if the account
+   *   actually exists in a ledger.
    *
    * Example:
+   *
    * ```js
    * StellarSdk.FederationServer.resolve('bob*stellar.org')
    *  .then(federationRecord => {
@@ -66,16 +79,25 @@ export class FederationServer {
    *  });
    * ```
    *
-   * @see <a href="https://developers.stellar.org/docs/glossary/federation/" target="_blank">Federation doc</a>
-   * @see <a href="https://developers.stellar.org/docs/issuing-assets/publishing-asset-info/" target="_blank">Stellar.toml doc</a>
+   * @see <a href="https://developers.stellar.org/docs/glossary/federation/"
+   * target="_blank">Federation doc</a>
+   * @see <a
+   * href="https://developers.stellar.org/docs/issuing-assets/publishing-asset-info/"
+   * target="_blank">Stellar.toml doc</a>
+   *
    * @param {string} value Stellar Address (ex. `bob*stellar.org`)
    * @param {object} [opts] Options object
-   * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments!
-   * @param {number} [opts.timeout] - Allow a timeout, default: 0. Allows user to avoid nasty lag due to TOML resolve issue.
-   * @returns {Promise} `Promise` that resolves to a JSON object with this shape:
-   * * `account_id` - Account ID of the destination,
-   * * `memo_type` (optional) - Memo type that needs to be attached to a transaction,
-   * * `memo` (optional) - Memo value that needs to be attached to a transaction.
+   * @param {boolean} [opts.allowHttp] - Allow connecting to http servers,
+   *    default: `false`. This must be set to false in production deployments!
+   * @param {number} [opts.timeout] - Allow a timeout, default: 0. Allows user
+   *    to avoid nasty lag due to TOML resolve issue.
+   *
+   * @returns {Promise} resolves to a JSON object with this shape:
+   *    * `account_id` - account ID of the destination
+   *    * `memo_type` (optional) - memo type that needs to be attached to a
+   *      transaction
+   *    * `memo` (optional) - memo value that needs to be attached to a
+   *      transaction
    */
   public static async resolve(
     value: string,
@@ -109,6 +131,7 @@ export class FederationServer {
    *
    * If `stellar.toml` file does not exist for a given domain or it does not
    * contain information about a federation server Promise will reject.
+   *
    * ```js
    * StellarSdk.FederationServer.createForDomain('acme.com')
    *   .then(federationServer => {
@@ -118,11 +141,18 @@ export class FederationServer {
    *     // stellar.toml does not exist or it does not contain information about federation server.
    *   });
    * ```
-   * @see <a href="https://developers.stellar.org/docs/issuing-assets/publishing-asset-info/" target="_blank">Stellar.toml doc</a>
+   *
+   * @see <a
+   * href="https://developers.stellar.org/docs/issuing-assets/publishing-asset-info/"
+   * target="_blank">Stellar.toml doc</a>
+   *
    * @param {string} domain Domain to get federation server for
    * @param {object} [opts] Options object
-   * @param {boolean} [opts.allowHttp] - Allow connecting to http servers, default: `false`. This must be set to false in production deployments!
-   * @param {number} [opts.timeout] - Allow a timeout, default: 0. Allows user to avoid nasty lag due to TOML resolve issue.
+   * @param {boolean} [opts.allowHttp] - Allow connecting to http servers,
+   *    default: `false`. This must be set to false in production deployments!
+   * @param {number} [opts.timeout] - Allow a timeout, default: 0. Allows user
+   *    to avoid nasty lag due to TOML resolve issue.
+   *
    * @returns {Promise} `Promise` that resolves to a FederationServer object
    */
   public static async createForDomain(
@@ -144,7 +174,7 @@ export class FederationServer {
     opts: FederationServer.Options = {},
   ) {
     // TODO `domain` regexp
-    this.serverURL = URI(serverURL);
+    this.serverURL = new URL(serverURL);
     this.domain = domain;
 
     const allowHttp =
@@ -155,15 +185,21 @@ export class FederationServer {
     this.timeout =
       typeof opts.timeout === "undefined" ? Config.getTimeout() : opts.timeout;
 
-    if (this.serverURL.protocol() !== "https" && !allowHttp) {
+    if (this.serverURL.protocol !== "https" && !allowHttp) {
       throw new Error("Cannot connect to insecure federation server");
     }
   }
 
   /**
    * Get the federation record if the user was found for a given Stellar address
-   * @see <a href="https://developers.stellar.org/docs/glossary/federation/" target="_blank">Federation doc</a>
-   * @param {string} address Stellar address (ex. `bob*stellar.org`). If `FederationServer` was instantiated with `domain` param only username (ex. `bob`) can be passed.
+   *
+   * @see <a href="https://developers.stellar.org/docs/glossary/federation/"
+   * target="_blank">Federation doc</a>
+   *
+   * @param {string} address Stellar address (ex. `bob*stellar.org`). If
+   *    `FederationServer` was instantiated with `domain` param only username
+   *    (ex. `bob`) can be passed.
+   *
    * @returns {Promise} Promise that resolves to the federation record
    */
   public async resolveAddress(
@@ -180,8 +216,8 @@ export class FederationServer {
       }
       stellarAddress = `${address}*${this.domain}`;
     }
-    const url = this.serverURL.query({ type: "name", q: stellarAddress });
-    return this._sendRequest(url);
+
+    return this._sendRequest(query(this.serverURL, { type: "name", q: stellarAddress }));
   }
 
   /**
@@ -193,7 +229,7 @@ export class FederationServer {
   public async resolveAccountId(
     accountId: string,
   ): Promise<FederationServer.Record> {
-    const url = this.serverURL.query({ type: "id", q: accountId });
+    const url = query(this.serverURL, { type: "id", q: accountId });
     return this._sendRequest(url);
   }
 
@@ -206,11 +242,11 @@ export class FederationServer {
   public async resolveTransactionId(
     transactionId: string,
   ): Promise<FederationServer.Record> {
-    const url = this.serverURL.query({ type: "txid", q: transactionId });
+    const url = query(this.serverURL, { type: "txid", q: transactionId });
     return this._sendRequest(url);
   }
 
-  private async _sendRequest(url: URI) {
+  private async _sendRequest(url: URI | URL) {
     const timeout = this.timeout;
 
     return axios
@@ -260,4 +296,18 @@ export namespace FederationServer {
     allowHttp?: boolean;
     timeout?: number;
   }
+}
+
+/**
+ * Returns a new URL with the given parameters specified as a query.
+ *
+ * @param {URL} url the starting URL
+ * @param {Record<string, string>} params key-value pairs of query params to set
+ *
+ * @returns {URL} a new URL with the parameters set
+ */
+function query(url: URL, params: Record<string, string>): URL {
+  let clone = new URL(url);
+  clone.search = new URLSearchParams(params).toString();
+  return clone;
 }

--- a/src/federation_server.ts
+++ b/src/federation_server.ts
@@ -41,14 +41,14 @@ export class FederationServer {
    * @type {string}
    * @memberof FederationServer
    */
-  private readonly domain: string; // TODO: public or private? readonly?
+  private readonly domain: string;
   /**
    * Allow a timeout, default: 0. Allows user to avoid nasty lag due to TOML resolve issue.
    *
    * @type {number}
    * @memberof FederationServer
    */
-  private readonly timeout: number; // TODO: public or private? readonly?
+  private readonly timeout: number;
 
   /**
    * A helper method for handling user inputs that contain `destination` value.
@@ -177,15 +177,10 @@ export class FederationServer {
     this.serverURL = new URL(serverURL);
     this.domain = domain;
 
-    const allowHttp =
-      typeof opts.allowHttp === "undefined"
-        ? Config.isAllowHttp()
-        : opts.allowHttp;
+    const allowHttp = opts.allowHttp ?? Config.isAllowHttp();
+    this.timeout = opts.timeout ?? Config.getTimeout();
 
-    this.timeout =
-      typeof opts.timeout === "undefined" ? Config.getTimeout() : opts.timeout;
-
-    if (this.serverURL.protocol !== "https" && !allowHttp) {
+    if (this.serverURL.protocol !== "https:" && !allowHttp) {
       throw new Error("Cannot connect to insecure federation server");
     }
   }
@@ -308,6 +303,9 @@ export namespace FederationServer {
  */
 function query(url: URL, params: Record<string, string>): URL {
   let clone = new URL(url.toString());
-  clone.search = new URLSearchParams(params).toString();
+  Object.entries(params).forEach(([key, value]) => {
+    clone.searchParams.append(key, value);
+  });
+
   return clone;
 }

--- a/src/federation_server.ts
+++ b/src/federation_server.ts
@@ -307,7 +307,7 @@ export namespace FederationServer {
  * @returns {URL} a new URL with the parameters set
  */
 function query(url: URL, params: Record<string, string>): URL {
-  let clone = new URL(url);
+  let clone = new URL(url.toString());
   clone.search = new URLSearchParams(params).toString();
   return clone;
 }

--- a/src/federation_server.ts
+++ b/src/federation_server.ts
@@ -304,7 +304,7 @@ export namespace FederationServer {
 function query(url: URL, params: Record<string, string>): URL {
   let clone = new URL(url.toString());
   Object.entries(params).forEach(([key, value]) => {
-    clone.searchParams.append(key, value);
+    clone.searchParams.set(key, value);
   });
 
   return clone;

--- a/src/friendbot_builder.ts
+++ b/src/friendbot_builder.ts
@@ -1,7 +1,7 @@
 import { CallBuilder } from "./call_builder";
 
 export class FriendbotBuilder extends CallBuilder<any> {
-  constructor(serverUrl: URI, address: string) {
+  constructor(serverUrl: URL | string, address: string) {
     super(serverUrl);
     this.segment("friendbot");
     this.url.searchParams.set("addr", address);

--- a/src/friendbot_builder.ts
+++ b/src/friendbot_builder.ts
@@ -3,7 +3,7 @@ import { CallBuilder } from "./call_builder";
 export class FriendbotBuilder extends CallBuilder<any> {
   constructor(serverUrl: URI, address: string) {
     super(serverUrl);
-    this.url.segment("friendbot");
-    this.url.setQuery("addr", address);
+    this.segment("friendbot");
+    this.url.searchParams.set("addr", address);
   }
 }

--- a/src/horizon_axios_client.ts
+++ b/src/horizon_axios_client.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosResponse } from "axios";
-import URI from "urijs";
 
 /* tslint:disable-next-line:no-var-requires */
 const version = require("../package.json").version;
@@ -36,7 +35,7 @@ function _toSeconds(ms: number): number {
 
 HorizonAxiosClient.interceptors.response.use(
   function interceptorHorizonResponse(response: AxiosResponse) {
-    const hostname = URI(response.config.url!).hostname();
+    const hostname = new URL(response.config.url!).hostname;
     const serverTime = _toSeconds(Date.parse(response.headers.date));
     const localTimeRecorded = _toSeconds(new Date().getTime());
 

--- a/src/ledger_call_builder.ts
+++ b/src/ledger_call_builder.ts
@@ -16,7 +16,7 @@ export class LedgerCallBuilder extends CallBuilder<
 > {
   constructor(serverUrl: URI) {
     super(serverUrl);
-    this.url.segment("ledgers");
+    this.segment("ledgers");
   }
 
   /**

--- a/src/ledger_call_builder.ts
+++ b/src/ledger_call_builder.ts
@@ -9,12 +9,12 @@ import { ServerApi } from "./server_api";
  * @constructor
  * @class LedgerCallBuilder
  * @extends CallBuilder
- * @param {string} serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl Horizon server URL.
  */
 export class LedgerCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.LedgerRecord>
 > {
-  constructor(serverUrl: URI) {
+  constructor(serverUrl: URL | string) {
     super(serverUrl);
     this.segment("ledgers");
   }

--- a/src/liquidity_pool_call_builder.ts
+++ b/src/liquidity_pool_call_builder.ts
@@ -17,7 +17,7 @@ export class LiquidityPoolCallBuilder extends CallBuilder<
 > {
   constructor(serverUrl: URI) {
     super(serverUrl);
-    this.url.segment("liquidity_pools");
+    this.segment("liquidity_pools");
   }
 
   /**
@@ -31,7 +31,7 @@ export class LiquidityPoolCallBuilder extends CallBuilder<
     const assetList: string = assets
       .map((asset: Asset) => asset.toString())
       .join(",");
-    this.url.setQuery("reserves", assetList);
+    this.url.searchParams.set("reserves", assetList);
     return this;
   }
 
@@ -42,7 +42,7 @@ export class LiquidityPoolCallBuilder extends CallBuilder<
    * @returns {LiquidityPoolCallBuilder} current LiquidityPoolCallBuilder instance
    */
   public forAccount(id: string): this {
-    this.url.setQuery("account", id);
+    this.url.searchParams.set("account", id);
     return this;
   }
 
@@ -60,7 +60,7 @@ export class LiquidityPoolCallBuilder extends CallBuilder<
     }
 
     const builder = new CallBuilder<ServerApi.LiquidityPoolRecord>(
-      this.url.clone(),
+      this.clone(),
     );
     builder.filter.push([id.toLowerCase()]);
     return builder;

--- a/src/liquidity_pool_call_builder.ts
+++ b/src/liquidity_pool_call_builder.ts
@@ -10,12 +10,12 @@ import { ServerApi } from "./server_api";
  * @class LiquidityPoolCallBuilder
  * @extends CallBuilder
  * @constructor
- * @param {string} serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl Horizon server URL.
  */
 export class LiquidityPoolCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.LiquidityPoolRecord>
 > {
-  constructor(serverUrl: URI) {
+  constructor(serverUrl: URL | string) {
     super(serverUrl);
     this.segment("liquidity_pools");
   }

--- a/src/offer_call_builder.ts
+++ b/src/offer_call_builder.ts
@@ -10,12 +10,12 @@ import { ServerApi } from "./server_api";
  * @class OfferCallBuilder
  * @constructor
  * @extends CallBuilder
- * @param {string} serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl Horizon server URL.
  */
 export class OfferCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.OfferRecord>
 > {
-  constructor(serverUrl: URI) {
+  constructor(serverUrl: URL | string) {
     super(serverUrl, "offers");
     this.segment("offers");
   }

--- a/src/offer_call_builder.ts
+++ b/src/offer_call_builder.ts
@@ -17,7 +17,7 @@ export class OfferCallBuilder extends CallBuilder<
 > {
   constructor(serverUrl: URI) {
     super(serverUrl, "offers");
-    this.url.segment("offers");
+    this.segment("offers");
   }
 
   /**
@@ -28,7 +28,7 @@ export class OfferCallBuilder extends CallBuilder<
    * @returns {CallBuilder<ServerApi.OfferRecord>} CallBuilder<ServerApi.OfferRecord> OperationCallBuilder instance
    */
   public offer(offerId: string): CallBuilder<ServerApi.OfferRecord> {
-    const builder = new CallBuilder<ServerApi.OfferRecord>(this.url.clone());
+    const builder = new CallBuilder<ServerApi.OfferRecord>(this.clone());
     builder.filter.push([offerId]);
     return builder;
   }
@@ -53,11 +53,11 @@ export class OfferCallBuilder extends CallBuilder<
    */
   public buying(asset: Asset): this {
     if (!asset.isNative()) {
-      this.url.setQuery("buying_asset_type", asset.getAssetType());
-      this.url.setQuery("buying_asset_code", asset.getCode());
-      this.url.setQuery("buying_asset_issuer", asset.getIssuer());
+      this.url.searchParams.set("buying_asset_type", asset.getAssetType());
+      this.url.searchParams.set("buying_asset_code", asset.getCode());
+      this.url.searchParams.set("buying_asset_issuer", asset.getIssuer());
     } else {
-      this.url.setQuery("buying_asset_type", "native");
+      this.url.searchParams.set("buying_asset_type", "native");
     }
     return this;
   }
@@ -71,11 +71,11 @@ export class OfferCallBuilder extends CallBuilder<
    */
   public selling(asset: Asset): this {
     if (!asset.isNative()) {
-      this.url.setQuery("selling_asset_type", asset.getAssetType());
-      this.url.setQuery("selling_asset_code", asset.getCode());
-      this.url.setQuery("selling_asset_issuer", asset.getIssuer());
+      this.url.searchParams.set("selling_asset_type", asset.getAssetType());
+      this.url.searchParams.set("selling_asset_code", asset.getCode());
+      this.url.searchParams.set("selling_asset_issuer", asset.getIssuer());
     } else {
-      this.url.setQuery("selling_asset_type", "native");
+      this.url.searchParams.set("selling_asset_type", "native");
     }
     return this;
   }
@@ -87,7 +87,7 @@ export class OfferCallBuilder extends CallBuilder<
    * @returns {OfferCallBuilder} current OfferCallBuilder instance
    */
   public sponsor(id: string): this {
-    this.url.setQuery("sponsor", id);
+    this.url.searchParams.set("sponsor", id);
     return this;
   }
 
@@ -99,7 +99,7 @@ export class OfferCallBuilder extends CallBuilder<
    * @returns {OfferCallBuilder} current OfferCallBuilder instance
    */
   public seller(seller: string): this {
-    this.url.setQuery("seller", seller);
+    this.url.searchParams.set("seller", seller);
     return this;
   }
 }

--- a/src/operation_call_builder.ts
+++ b/src/operation_call_builder.ts
@@ -16,7 +16,7 @@ export class OperationCallBuilder extends CallBuilder<
 > {
   constructor(serverUrl: URI) {
     super(serverUrl, "operations");
-    this.url.segment("operations");
+    this.segment("operations");
   }
 
   /**
@@ -30,7 +30,7 @@ export class OperationCallBuilder extends CallBuilder<
     operationId: string,
   ): CallBuilder<ServerApi.OperationRecord> {
     const builder = new CallBuilder<ServerApi.OperationRecord>(
-      this.url.clone(),
+      this.clone(),
     );
     builder.filter.push([operationId]);
     return builder;
@@ -95,7 +95,7 @@ export class OperationCallBuilder extends CallBuilder<
    * @returns {OperationCallBuilder} this OperationCallBuilder instance
    */
   public includeFailed(value: boolean): this {
-    this.url.setQuery("include_failed", value.toString());
+    this.url.searchParams.set("include_failed", value.toString());
     return this;
   }
 }

--- a/src/operation_call_builder.ts
+++ b/src/operation_call_builder.ts
@@ -9,12 +9,12 @@ import { ServerApi } from "./server_api";
  * @class OperationCallBuilder
  * @constructor
  * @extends CallBuilder
- * @param {string} serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl Horizon server URL.
  */
 export class OperationCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.OperationRecord>
 > {
-  constructor(serverUrl: URI) {
+  constructor(serverUrl: URL | string) {
     super(serverUrl, "operations");
     this.segment("operations");
   }

--- a/src/orderbook_call_builder.ts
+++ b/src/orderbook_call_builder.ts
@@ -7,12 +7,12 @@ import { ServerApi } from "./server_api";
  *
  * Do not create this object directly, use {@link Server#orderbook}.
  * @see [Orderbook Details](https://developers.stellar.org/api/aggregations/order-books/)
- * @param {string} serverUrl serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl serverUrl Horizon server URL.
  * @param {Asset} selling Asset being sold
  * @param {Asset} buying Asset being bought
  */
 export class OrderbookCallBuilder extends CallBuilder<ServerApi.OrderbookRecord> {
-  constructor(serverUrl: URI, selling: Asset, buying: Asset) {
+  constructor(serverUrl: URL | string, selling: Asset, buying: Asset) {
     super(serverUrl);
     this.segment("order_book");
     if (!selling.isNative()) {

--- a/src/orderbook_call_builder.ts
+++ b/src/orderbook_call_builder.ts
@@ -14,20 +14,20 @@ import { ServerApi } from "./server_api";
 export class OrderbookCallBuilder extends CallBuilder<ServerApi.OrderbookRecord> {
   constructor(serverUrl: URI, selling: Asset, buying: Asset) {
     super(serverUrl);
-    this.url.segment("order_book");
+    this.segment("order_book");
     if (!selling.isNative()) {
-      this.url.setQuery("selling_asset_type", selling.getAssetType());
-      this.url.setQuery("selling_asset_code", selling.getCode());
-      this.url.setQuery("selling_asset_issuer", selling.getIssuer());
+      this.url.searchParams.set("selling_asset_type", selling.getAssetType());
+      this.url.searchParams.set("selling_asset_code", selling.getCode());
+      this.url.searchParams.set("selling_asset_issuer", selling.getIssuer());
     } else {
-      this.url.setQuery("selling_asset_type", "native");
+      this.url.searchParams.set("selling_asset_type", "native");
     }
     if (!buying.isNative()) {
-      this.url.setQuery("buying_asset_type", buying.getAssetType());
-      this.url.setQuery("buying_asset_code", buying.getCode());
-      this.url.setQuery("buying_asset_issuer", buying.getIssuer());
+      this.url.searchParams.set("buying_asset_type", buying.getAssetType());
+      this.url.searchParams.set("buying_asset_code", buying.getCode());
+      this.url.searchParams.set("buying_asset_issuer", buying.getIssuer());
     } else {
-      this.url.setQuery("buying_asset_type", "native");
+      this.url.searchParams.set("buying_asset_type", "native");
     }
   }
 }

--- a/src/path_call_builder.ts
+++ b/src/path_call_builder.ts
@@ -20,7 +20,7 @@ import { ServerApi } from "./server_api";
  * Do not create this object directly, use {@link Server#paths}.
  * @see [Find Payment Paths](https://developers.stellar.org/api/aggregations/paths/)
  * @extends CallBuilder
- * @param {string} serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl Horizon server URL.
  * @param {string} source The sender's account ID. Any returned path must use a source that the sender can hold.
  * @param {string} destination The destination account ID that any returned path should use.
  * @param {Asset} destinationAsset The destination asset.
@@ -30,7 +30,7 @@ export class PathCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.PaymentPathRecord>
 > {
   constructor(
-    serverUrl: URI,
+    serverUrl: URL | string,
     source: string,
     destination: string,
     destinationAsset: Asset,

--- a/src/path_call_builder.ts
+++ b/src/path_call_builder.ts
@@ -37,23 +37,23 @@ export class PathCallBuilder extends CallBuilder<
     destinationAmount: string
   ) {
     super(serverUrl);
-    this.url.segment("paths");
-    this.url.setQuery("destination_account", destination);
-    this.url.setQuery("source_account", source);
-    this.url.setQuery("destination_amount", destinationAmount);
+    this.segment("paths");
+    this.url.searchParams.set("destination_account", destination);
+    this.url.searchParams.set("source_account", source);
+    this.url.searchParams.set("destination_amount", destinationAmount);
 
     if (!destinationAsset.isNative()) {
-      this.url.setQuery(
+      this.url.searchParams.set(
         "destination_asset_type",
         destinationAsset.getAssetType()
       );
-      this.url.setQuery("destination_asset_code", destinationAsset.getCode());
-      this.url.setQuery(
+      this.url.searchParams.set("destination_asset_code", destinationAsset.getCode());
+      this.url.searchParams.set(
         "destination_asset_issuer",
         destinationAsset.getIssuer()
       );
     } else {
-      this.url.setQuery("destination_asset_type", "native");
+      this.url.searchParams.set("destination_asset_type", "native");
     }
   }
 }

--- a/src/payment_call_builder.ts
+++ b/src/payment_call_builder.ts
@@ -15,7 +15,7 @@ export class PaymentCallBuilder extends CallBuilder<
 > {
   constructor(serverUrl: URI) {
     super(serverUrl, "payments");
-    this.url.segment("payments");
+    this.segment("payments");
   }
 
   /**

--- a/src/payment_call_builder.ts
+++ b/src/payment_call_builder.ts
@@ -8,12 +8,12 @@ import { ServerApi } from "./server_api";
  * @see [All Payments](https://developers.stellar.org/api/resources/payments/)
  * @constructor
  * @extends CallBuilder
- * @param {string} serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl Horizon server URL.
  */
 export class PaymentCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.PaymentOperationRecord>
 > {
-  constructor(serverUrl: URI) {
+  constructor(serverUrl: URL | string) {
     super(serverUrl, "payments");
     this.segment("payments");
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -67,20 +67,14 @@ function _getAmountInLumens(amt: BigNumber) {
  */
 export class Server {
   /**
-   * serverURL Horizon Server URL (ex. `https://horizon-testnet.stellar.org`).
-   *
-   * TODO: Solve `URI(this.serverURL as any)`.
+   * Horizon Server URL (ex. `https://horizon-testnet.stellar.org`).
    */
   public readonly serverURL: URI;
 
-  constructor(serverURL: string, opts: Server.Options = {}) {
-    this.serverURL = URI(serverURL);
+  constructor(serverURL: string | URL, opts: Server.Options = {}) {
+    this.serverURL = URI(serverURL.toString());
 
-    const allowHttp =
-      typeof opts.allowHttp === "undefined"
-        ? Config.isAllowHttp()
-        : opts.allowHttp;
-
+    const allowHttp = opts.allowHttp ?? Config.isAllowHttp();
     const customHeaders: Record<string, string> = {};
 
     if (opts.appName) {
@@ -310,10 +304,11 @@ export class Server {
         .toString("base64"),
     );
 
-    return HorizonAxiosClient.post(
-      URI(this.serverURL as any)
-        .segment("transactions")
-        .toString(),
+    const url = new URL(this.serverURL.toString());
+    const prefix = url.pathname.endsWith("/") ? "" : "/";
+    url.pathname += prefix + "transactions";
+
+    return HorizonAxiosClient.post(url.toString(),
       `tx=${tx}`,
       { timeout: SUBMIT_TRANSACTION_TIMEOUT },
     )

--- a/src/stellar_toml_resolver.ts
+++ b/src/stellar_toml_resolver.ts
@@ -36,14 +36,8 @@ export class StellarTomlResolver {
     domain: string,
     opts: StellarTomlResolver.StellarTomlResolveOptions = {},
   ): Promise<StellarTomlResolver.StellarToml> {
-    const allowHttp =
-      typeof opts.allowHttp === "undefined"
-        ? Config.isAllowHttp()
-        : opts.allowHttp;
-
-    const timeout =
-      typeof opts.timeout === "undefined" ? Config.getTimeout() : opts.timeout;
-
+    const allowHttp = opts.allowHttp ?? Config.isAllowHttp();
+    const timeout = opts.timeout ?? Config.getTimeout()
     const protocol = allowHttp ? "http" : "https";
 
     return axios

--- a/src/strict_receive_path_call_builder.ts
+++ b/src/strict_receive_path_call_builder.ts
@@ -39,10 +39,10 @@ export class StrictReceivePathCallBuilder extends CallBuilder<
     destinationAmount: string
   ) {
     super(serverUrl);
-    this.url.segment("paths/strict-receive");
+    this.segment("paths", "strict-receive");
 
     if (typeof source === "string") {
-      this.url.setQuery("source_account", source);
+      this.url.searchParams.set("source_account", source);
     } else {
       const assets = source
         .map((asset) => {
@@ -53,23 +53,23 @@ export class StrictReceivePathCallBuilder extends CallBuilder<
           return `${asset.getCode()}:${asset.getIssuer()}`;
         })
         .join(",");
-      this.url.setQuery("source_assets", assets);
+      this.url.searchParams.set("source_assets", assets);
     }
 
-    this.url.setQuery("destination_amount", destinationAmount);
+    this.url.searchParams.set("destination_amount", destinationAmount);
 
     if (!destinationAsset.isNative()) {
-      this.url.setQuery(
+      this.url.searchParams.set(
         "destination_asset_type",
         destinationAsset.getAssetType()
       );
-      this.url.setQuery("destination_asset_code", destinationAsset.getCode());
-      this.url.setQuery(
+      this.url.searchParams.set("destination_asset_code", destinationAsset.getCode());
+      this.url.searchParams.set(
         "destination_asset_issuer",
         destinationAsset.getIssuer()
       );
     } else {
-      this.url.setQuery("destination_asset_type", "native");
+      this.url.searchParams.set("destination_asset_type", "native");
     }
   }
 }

--- a/src/strict_receive_path_call_builder.ts
+++ b/src/strict_receive_path_call_builder.ts
@@ -24,7 +24,7 @@ import { ServerApi } from "./server_api";
  * Do not create this object directly, use {@link Server#strictReceivePaths}.
  * @see [Find Payment Paths](https://developers.stellar.org/api/aggregations/paths/)
  * @extends CallBuilder
- * @param {string} serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl Horizon server URL.
  * @param {string|Asset[]} source The sender's account ID or a list of Assets. Any returned path must use a source that the sender can hold.
  * @param {Asset} destinationAsset The destination asset.
  * @param {string} destinationAmount The amount, denominated in the destination asset, that any returned path should be able to satisfy.
@@ -33,7 +33,7 @@ export class StrictReceivePathCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.PaymentPathRecord>
 > {
   constructor(
-    serverUrl: URI,
+    serverUrl: URL | string,
     source: string | Asset[],
     destinationAsset: Asset,
     destinationAmount: string

--- a/src/strict_send_path_call_builder.ts
+++ b/src/strict_send_path_call_builder.ts
@@ -39,21 +39,20 @@ export class StrictSendPathCallBuilder extends CallBuilder<
     destination: string | Asset[]
   ) {
     super(serverUrl);
-
-    this.url.segment("paths/strict-send");
+    this.segment("paths", "strict-send");
 
     if (sourceAsset.isNative()) {
-      this.url.setQuery("source_asset_type", "native");
+      this.url.searchParams.set("source_asset_type", "native");
     } else {
-      this.url.setQuery("source_asset_type", sourceAsset.getAssetType());
-      this.url.setQuery("source_asset_code", sourceAsset.getCode());
-      this.url.setQuery("source_asset_issuer", sourceAsset.getIssuer());
+      this.url.searchParams.set("source_asset_type", sourceAsset.getAssetType());
+      this.url.searchParams.set("source_asset_code", sourceAsset.getCode());
+      this.url.searchParams.set("source_asset_issuer", sourceAsset.getIssuer());
     }
 
-    this.url.setQuery("source_amount", sourceAmount);
+    this.url.searchParams.set("source_amount", sourceAmount);
 
     if (typeof destination === "string") {
-      this.url.setQuery("destination_account", destination);
+      this.url.searchParams.set("destination_account", destination);
     } else {
       const assets = destination
         .map((asset) => {
@@ -65,7 +64,7 @@ export class StrictSendPathCallBuilder extends CallBuilder<
         })
         .join(",");
 
-      this.url.setQuery("destination_assets", assets);
+      this.url.searchParams.set("destination_assets", assets);
     }
   }
 }

--- a/src/strict_send_path_call_builder.ts
+++ b/src/strict_send_path_call_builder.ts
@@ -23,7 +23,7 @@ import { ServerApi } from "./server_api";
  * Do not create this object directly, use {@link Server#strictSendPaths}.
  * @see [Find Payment Paths](https://developers.stellar.org/api/aggregations/paths/)
  * @extends CallBuilder
- * @param {string} serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl Horizon server URL.
  * @param {Asset} sourceAsset The asset to be sent.
  * @param {string} sourceAmount The amount, denominated in the source asset, that any returned path should be able to satisfy.
  * @param {string|Asset[]} destination The destination account or the destination assets.
@@ -33,7 +33,7 @@ export class StrictSendPathCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.PaymentPathRecord>
 > {
   constructor(
-    serverUrl: URI,
+    serverUrl: URL | string,
     sourceAsset: Asset,
     sourceAmount: string,
     destination: string | Asset[]

--- a/src/trade_aggregation_call_builder.ts
+++ b/src/trade_aggregation_call_builder.ts
@@ -43,36 +43,36 @@ export class TradeAggregationCallBuilder extends CallBuilder<
   ) {
     super(serverUrl);
 
-    this.url.segment("trade_aggregations");
+    this.segment("trade_aggregations");
     if (!base.isNative()) {
-      this.url.setQuery("base_asset_type", base.getAssetType());
-      this.url.setQuery("base_asset_code", base.getCode());
-      this.url.setQuery("base_asset_issuer", base.getIssuer());
+      this.url.searchParams.set("base_asset_type", base.getAssetType());
+      this.url.searchParams.set("base_asset_code", base.getCode());
+      this.url.searchParams.set("base_asset_issuer", base.getIssuer());
     } else {
-      this.url.setQuery("base_asset_type", "native");
+      this.url.searchParams.set("base_asset_type", "native");
     }
     if (!counter.isNative()) {
-      this.url.setQuery("counter_asset_type", counter.getAssetType());
-      this.url.setQuery("counter_asset_code", counter.getCode());
-      this.url.setQuery("counter_asset_issuer", counter.getIssuer());
+      this.url.searchParams.set("counter_asset_type", counter.getAssetType());
+      this.url.searchParams.set("counter_asset_code", counter.getCode());
+      this.url.searchParams.set("counter_asset_issuer", counter.getIssuer());
     } else {
-      this.url.setQuery("counter_asset_type", "native");
+      this.url.searchParams.set("counter_asset_type", "native");
     }
     if (typeof start_time !== "number" || typeof end_time !== "number") {
       throw new BadRequestError("Invalid time bounds", [start_time, end_time]);
     } else {
-      this.url.setQuery("start_time", start_time.toString());
-      this.url.setQuery("end_time", end_time.toString());
+      this.url.searchParams.set("start_time", start_time.toString());
+      this.url.searchParams.set("end_time", end_time.toString());
     }
     if (!this.isValidResolution(resolution)) {
       throw new BadRequestError("Invalid resolution", resolution);
     } else {
-      this.url.setQuery("resolution", resolution.toString());
+      this.url.searchParams.set("resolution", resolution.toString());
     }
     if (!this.isValidOffset(offset, resolution)) {
       throw new BadRequestError("Invalid offset", offset);
     } else {
-      this.url.setQuery("offset", offset.toString());
+      this.url.searchParams.set("offset", offset.toString());
     }
   }
 

--- a/src/trade_aggregation_call_builder.ts
+++ b/src/trade_aggregation_call_builder.ts
@@ -21,7 +21,7 @@ const allowedResolutions = [
  * @class TradeAggregationCallBuilder
  * @extends CallBuilder
  * @constructor
- * @param {string} serverUrl serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl serverUrl Horizon server URL.
  * @param {Asset} base base asset
  * @param {Asset} counter counter asset
  * @param {long} start_time lower time boundary represented as millis since epoch
@@ -33,7 +33,7 @@ export class TradeAggregationCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<TradeAggregationRecord>
 > {
   constructor(
-    serverUrl: URI,
+    serverUrl: URL | string,
     base: Asset,
     counter: Asset,
     start_time: number,

--- a/src/trades_call_builder.ts
+++ b/src/trades_call_builder.ts
@@ -15,7 +15,7 @@ import { ServerApi } from "./server_api";
 export class TradesCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.TradeRecord>
 > {
-  constructor(serverUrl: URI) {
+  constructor(serverUrl: URL | string) {
     super(serverUrl, "trades");
     this.segment("trades");
   }

--- a/src/trades_call_builder.ts
+++ b/src/trades_call_builder.ts
@@ -17,7 +17,7 @@ export class TradesCallBuilder extends CallBuilder<
 > {
   constructor(serverUrl: URI) {
     super(serverUrl, "trades");
-    this.url.segment("trades");
+    this.segment("trades");
   }
 
   /**
@@ -28,18 +28,18 @@ export class TradesCallBuilder extends CallBuilder<
    */
   public forAssetPair(base: Asset, counter: Asset): this {
     if (!base.isNative()) {
-      this.url.setQuery("base_asset_type", base.getAssetType());
-      this.url.setQuery("base_asset_code", base.getCode());
-      this.url.setQuery("base_asset_issuer", base.getIssuer());
+      this.url.searchParams.set("base_asset_type", base.getAssetType());
+      this.url.searchParams.set("base_asset_code", base.getCode());
+      this.url.searchParams.set("base_asset_issuer", base.getIssuer());
     } else {
-      this.url.setQuery("base_asset_type", "native");
+      this.url.searchParams.set("base_asset_type", "native");
     }
     if (!counter.isNative()) {
-      this.url.setQuery("counter_asset_type", counter.getAssetType());
-      this.url.setQuery("counter_asset_code", counter.getCode());
-      this.url.setQuery("counter_asset_issuer", counter.getIssuer());
+      this.url.searchParams.set("counter_asset_type", counter.getAssetType());
+      this.url.searchParams.set("counter_asset_code", counter.getCode());
+      this.url.searchParams.set("counter_asset_issuer", counter.getIssuer());
     } else {
-      this.url.setQuery("counter_asset_type", "native");
+      this.url.searchParams.set("counter_asset_type", "native");
     }
     return this;
   }
@@ -50,7 +50,7 @@ export class TradesCallBuilder extends CallBuilder<
    * @returns {TradesCallBuilder} current TradesCallBuilder instance
    */
   public forOffer(offerId: string): this {
-    this.url.setQuery("offer_id", offerId);
+    this.url.searchParams.set("offer_id", offerId);
     return this;
   }
 
@@ -60,7 +60,7 @@ export class TradesCallBuilder extends CallBuilder<
    * @returns {TradesCallBuilder} current TradesCallBuilder instance.
    */
   public forType(tradeType: ServerApi.TradeType): this {
-    this.url.setQuery("trade_type", tradeType);
+    this.url.searchParams.set("trade_type", tradeType);
     return this;
   }
 

--- a/src/transaction_call_builder.ts
+++ b/src/transaction_call_builder.ts
@@ -9,12 +9,12 @@ import { ServerApi } from "./server_api";
  * @extends CallBuilder
  * @see [All Transactions](https://developers.stellar.org/api/resources/transactions/)
  * @constructor
- * @param {string} serverUrl Horizon server URL.
+ * @param {string|URL} serverUrl Horizon server URL.
  */
 export class TransactionCallBuilder extends CallBuilder<
   ServerApi.CollectionPage<ServerApi.TransactionRecord>
 > {
-  constructor(serverUrl: URI) {
+  constructor(serverUrl: URL | string) {
     super(serverUrl, "transactions");
     this.segment("transactions");
   }

--- a/src/transaction_call_builder.ts
+++ b/src/transaction_call_builder.ts
@@ -16,7 +16,7 @@ export class TransactionCallBuilder extends CallBuilder<
 > {
   constructor(serverUrl: URI) {
     super(serverUrl, "transactions");
-    this.url.segment("transactions");
+    this.segment("transactions");
   }
 
   /**
@@ -29,7 +29,7 @@ export class TransactionCallBuilder extends CallBuilder<
     transactionId: string,
   ): CallBuilder<ServerApi.TransactionRecord> {
     const builder = new CallBuilder<ServerApi.TransactionRecord>(
-      this.url.clone(),
+      this.clone(),
     );
     builder.filter.push([transactionId]);
     return builder;
@@ -82,7 +82,7 @@ export class TransactionCallBuilder extends CallBuilder<
    * @returns {TransactionCallBuilder} current TransactionCallBuilder instance
    */
   public includeFailed(value: boolean): this {
-    this.url.setQuery("include_failed", value.toString());
+    this.url.searchParams.set("include_failed", value.toString());
     return this;
   }
 }

--- a/test/unit/call_builders_test.js
+++ b/test/unit/call_builders_test.js
@@ -1,9 +1,8 @@
-const URI = require("urijs");
 const CallBuilder = require("../../lib/call_builder").CallBuilder;
 
 describe("CallBuilder functions", function () {
   it("doesn't mutate the constructor passed url argument (it clones it instead)", function () {
-    let arg = URI("https://onedom.ain/");
+    let arg = new URL("https://onedom.ain/");
     const builder = new CallBuilder(arg);
     builder.url.segment("one_segment");
     builder.checkFilter();

--- a/test/unit/call_builders_test.js
+++ b/test/unit/call_builders_test.js
@@ -4,7 +4,7 @@ describe("CallBuilder functions", function () {
   it("doesn't mutate the constructor passed url argument (it clones it instead)", function () {
     let arg = new URL("https://onedom.ain/");
     const builder = new CallBuilder(arg);
-    builder.url.segment("one_segment");
+    builder.segment("one_segment");
     builder.checkFilter();
 
     expect(arg.toString()).not.to.be.equal("https://onedom.ain/one_segment"); // https://onedom.ain/

--- a/test/unit/federation_server_test.js
+++ b/test/unit/federation_server_test.js
@@ -195,9 +195,7 @@ FEDERATION_SERVER="https://api.stellar.org/federation"
       StellarSdk.FederationServer.createForDomain("acme.com").then(
         (federationServer) => {
           expect(federationServer.serverURL.protocol).equals("https:");
-          expect(federationServer.serverURL.hostname).equals(
-            "api.stellar.org"
-          );
+          expect(federationServer.serverURL.hostname).equals("api.stellar.org");
           expect(federationServer.serverURL.pathname).equals("/federation");
           expect(federationServer.domain).equals("acme.com");
           done();

--- a/test/unit/federation_server_test.js
+++ b/test/unit/federation_server_test.js
@@ -56,7 +56,7 @@ describe("federation-server.js tests", function () {
         .expects("get")
         .withArgs(
           sinon.match(
-            "https://acme.com:1337/federation?type=name&q=bob%2Astellar.org"
+            /https:\/\/acme.com:1337\/federation\?type=name&q=bob(%2A|\*)stellar\.org/
           )
         )
         .returns(
@@ -194,11 +194,11 @@ FEDERATION_SERVER="https://api.stellar.org/federation"
 
       StellarSdk.FederationServer.createForDomain("acme.com").then(
         (federationServer) => {
-          expect(federationServer.serverURL.protocol()).equals("https");
-          expect(federationServer.serverURL.hostname()).equals(
+          expect(federationServer.serverURL.protocol).equals("https:");
+          expect(federationServer.serverURL.hostname).equals(
             "api.stellar.org"
           );
-          expect(federationServer.serverURL.path()).equals("/federation");
+          expect(federationServer.serverURL.pathname).equals("/federation");
           expect(federationServer.domain).equals("acme.com");
           done();
         }
@@ -259,7 +259,7 @@ FEDERATION_SERVER="https://api.stellar.org/federation"
         .expects("get")
         .withArgs(
           sinon.match(
-            "https://api.stellar.org/federation?type=name&q=bob%2Astellar.org"
+            /https:\/\/api\.stellar\.org\/federation\?type=name&q=bob(%2A|\*)stellar\.org/
           )
         )
         .returns(
@@ -296,7 +296,7 @@ FEDERATION_SERVER="https://api.stellar.org/federation"
         .expects("get")
         .withArgs(
           sinon.match(
-            "https://acme.com:1337/federation?type=name&q=bob%2Astellar.org"
+            /https:\/\/acme.com:1337\/federation\?type=name&q=bob(%2A|\*)stellar\.org/
           )
         )
         .returns(

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -477,8 +477,6 @@ describe("server.js non-transaction tests", function () {
             .order("asc")
             .call()
             .then(function (page) {
-              console.log("page:", page)
-
               page.next().then(function (response) {
                 expect(response.records).to.be.deep.equal(
                   ledgersResponse._embedded.records

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -358,7 +358,7 @@ describe("server.js non-transaction tests", function () {
     });
   });
 
-  describe("Server._sendResourceRequest", function () {
+  describe("Server._sendNormalRequest", function () {
     describe("requests all ledgers", function () {
       let ledgersResponse = {
         _embedded: {
@@ -477,6 +477,8 @@ describe("server.js non-transaction tests", function () {
             .order("asc")
             .call()
             .then(function (page) {
+              console.log("page:", page)
+
               page.next().then(function (response) {
                 expect(response.records).to.be.deep.equal(
                   ledgersResponse._embedded.records

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,7 +26,7 @@
     "@nicolo-ribaudo/chokidar-2" "2.1.8-no-fsevents.3"
     chokidar "^3.4.0"
 
-"@babel/code-frame@^7.18.6", "@babel/code-frame@^7.21.4":
+"@babel/code-frame@^7.21.4":
   version "7.21.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.21.4.tgz#d0fa9e4413aca81f2b23b9442797bda1826edb39"
   integrity sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==
@@ -34,9 +34,9 @@
     "@babel/highlight" "^7.18.6"
 
 "@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.5", "@babel/compat-data@^7.21.5":
-  version "7.21.7"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.21.7.tgz#61caffb60776e49a57ba61a88f02bedd8714f6bc"
-  integrity sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==
+  version "7.21.9"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.21.9.tgz#10a2e7fda4e51742c907938ac3b7229426515514"
+  integrity sha512-FUGed8kfhyWvbYug/Un/VPJD41rDIgoVVcR+FuzhzOYyRz5uED+Gd3SLZml0Uw2l2aHFb7ZgdW5mGA3G2cCCnQ==
 
 "@babel/core@^7.12.0", "@babel/core@^7.12.3", "@babel/core@^7.7.5":
   version "7.21.8"
@@ -76,9 +76,9 @@
     eslint-rule-composer "^0.3.0"
 
 "@babel/generator@^7.21.5":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.21.5.tgz#c0c0e5449504c7b7de8236d99338c3e2a340745f"
-  integrity sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==
+  version "7.21.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.21.9.tgz#3a1b706e07d836e204aee0650e8ee878d3aaa241"
+  integrity sha512-F3fZga2uv09wFdEjEQIJxXALXfz0+JaOb7SabvVMmjHxeVTuGW8wgE8Vp1Hd7O+zMTYtcfEISGRzPkeiaPPsvg==
   dependencies:
     "@babel/types" "^7.21.5"
     "@jridgewell/gen-mapping" "^0.3.2"
@@ -292,10 +292,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.14.7", "@babel/parser@^7.20.15", "@babel/parser@^7.20.7", "@babel/parser@^7.21.5", "@babel/parser@^7.21.8":
-  version "7.21.8"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.8.tgz#642af7d0333eab9c0ad70b14ac5e76dbde7bfdf8"
-  integrity sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==
+"@babel/parser@^7.14.7", "@babel/parser@^7.20.15", "@babel/parser@^7.21.5", "@babel/parser@^7.21.8", "@babel/parser@^7.21.9":
+  version "7.21.9"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.9.tgz#ab18ea3b85b4bc33ba98a8d4c2032c557d23cf14"
+  integrity sha512-q5PNg/Bi1OpGgx5jYlvWZwAorZepEudDMCLtj967aeS7WMont7dUZI46M2XwcIQqvUlMxWfdLFu4S/qSxeUu5g==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -957,13 +957,13 @@
     regenerator-runtime "^0.13.11"
 
 "@babel/template@^7.18.10", "@babel/template@^7.20.7":
-  version "7.20.7"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
-  integrity sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==
+  version "7.21.9"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.21.9.tgz#bf8dad2859130ae46088a99c1f265394877446fb"
+  integrity sha512-MK0X5k8NKOuWRamiEfc3KEJiHMTkGZNUjzMipqCGDDc6ijRl/B7RGSKVGncu4Ro/HdyzzY6cmoXuKI2Gffk7vQ==
   dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/parser" "^7.20.7"
-    "@babel/types" "^7.20.7"
+    "@babel/code-frame" "^7.21.4"
+    "@babel/parser" "^7.21.9"
+    "@babel/types" "^7.21.5"
 
 "@babel/traverse@^7.20.5", "@babel/traverse@^7.21.5":
   version "7.21.5"
@@ -981,7 +981,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.20.0", "@babel/types@^7.20.5", "@babel/types@^7.20.7", "@babel/types@^7.21.0", "@babel/types@^7.21.4", "@babel/types@^7.21.5", "@babel/types@^7.4.4":
+"@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.20.0", "@babel/types@^7.20.5", "@babel/types@^7.21.0", "@babel/types@^7.21.4", "@babel/types@^7.21.5", "@babel/types@^7.4.4":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.5.tgz#18dfbd47c39d3904d5db3d3dc2cc80bedb60e5b6"
   integrity sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==
@@ -1094,11 +1094,6 @@
     js-yaml "^4.1.0"
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
-
-"@eslint/js@8.40.0":
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.40.0.tgz#3ba73359e11f5a7bd3e407f70b3528abfae69cec"
-  integrity sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==
 
 "@eslint/js@8.41.0":
   version "8.41.0"
@@ -1387,9 +1382,9 @@
     "@types/estree" "*"
 
 "@types/eslint@*", "@types/eslint@^8.37.0":
-  version "8.37.0"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.37.0.tgz#29cebc6c2a3ac7fea7113207bf5a828fdf4d7ef1"
-  integrity sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==
+  version "8.40.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.40.0.tgz#ae73dc9ec5237f2794c4f79efd6a4c73b13daf23"
+  integrity sha512-nbq2mvc/tBrK9zQQuItvjJl++GTN5j06DaPtp3hZCpngmG6Q3xoyEmd0TwZI0gAy/G1X0zhGBbr2imsGFdFV0g==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
@@ -1424,9 +1419,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
-  version "7.0.11"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
-  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+  version "7.0.12"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
+  integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -1439,9 +1434,9 @@
   integrity sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==
 
 "@types/lodash@^4.14.192":
-  version "4.14.194"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
-  integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
+  version "4.14.195"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
+  integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
 
 "@types/markdown-it@^12.2.3":
   version "12.2.3"
@@ -1456,20 +1451,15 @@
   resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
   integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
 
-"@types/node@*", "@types/node@>=10.0.0":
-  version "20.2.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.1.tgz#de559d4b33be9a808fd43372ccee822c70f39704"
-  integrity sha512-DqJociPbZP1lbZ5SQPk4oag6W7AyaGMO6gSfRwq3PWl4PXTwJpRQJhDq4W0kzrg3w6tJ1SwlvGZ5uKFHY13LIg==
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@^20.2.3":
+  version "20.2.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.4.tgz#e6c3345f7ed9c6df41fdc288a94e2633167bc15d"
+  integrity sha512-ni5f8Xlf4PwnT/Z3f0HURc3ZSw8UyrqMqmM3L5ysa7VjHu8c3FOmIo1nKCcLrV/OAmtf3N4kFna/aJqxsfEtnA==
 
 "@types/node@^14.14.35":
-  version "14.18.47"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.47.tgz#89a56b05804d136cb99bf2f823bb00814a889aae"
-  integrity sha512-OuJi8bIng4wYHHA3YpKauL58dZrPxro3d0tabPHyiNF8rKfGKuVfr83oFlPLmKri1cX+Z3cJP39GXmnqkP11Gw==
-
-"@types/node@^20.2.3":
-  version "20.2.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.2.3.tgz#b31eb300610c3835ac008d690de6f87e28f9b878"
-  integrity sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==
+  version "14.18.48"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.48.tgz#ee5c7ac6e38fd2a9e6885f15c003464cf2da343c"
+  integrity sha512-iL0PIMwejpmuVHgfibHpfDwOdsbmB50wr21X71VnF5d7SsBF7WK+ZvP/SCcFm7Iwb9iiYSap9rlrdhToNAWdxg==
 
 "@types/parsimmon@^1.10.1":
   version "1.10.6"
@@ -1514,14 +1504,14 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^5.55.0":
-  version "5.59.6"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.6.tgz#a350faef1baa1e961698240f922d8de1761a9e2b"
-  integrity sha512-sXtOgJNEuRU5RLwPUb1jxtToZbgvq3M6FPpY4QENxoOggK+UpTxUBpj6tD8+Qh2g46Pi9We87E+eHnUw8YcGsw==
+  version "5.59.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.7.tgz#e470af414f05ecfdc05a23e9ce6ec8f91db56fe2"
+  integrity sha512-BL+jYxUFIbuYwy+4fF86k5vdT9lT0CNJ6HtwrIvGh0PhH8s0yy5rjaKH2fDCrz5ITHy07WCzVGNvAmjJh4IJFA==
   dependencies:
     "@eslint-community/regexpp" "^4.4.0"
-    "@typescript-eslint/scope-manager" "5.59.6"
-    "@typescript-eslint/type-utils" "5.59.6"
-    "@typescript-eslint/utils" "5.59.6"
+    "@typescript-eslint/scope-manager" "5.59.7"
+    "@typescript-eslint/type-utils" "5.59.7"
+    "@typescript-eslint/utils" "5.59.7"
     debug "^4.3.4"
     grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
@@ -1529,17 +1519,7 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/parser@^5.55.0":
-  version "5.59.6"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.6.tgz#bd36f71f5a529f828e20b627078d3ed6738dbb40"
-  integrity sha512-7pCa6al03Pv1yf/dUg/s1pXz/yGMUBAw5EeWqNTFiSueKvRNonze3hma3lhdsOrQcaOXhbk5gKu2Fludiho9VA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "5.59.6"
-    "@typescript-eslint/types" "5.59.6"
-    "@typescript-eslint/typescript-estree" "5.59.6"
-    debug "^4.3.4"
-
-"@typescript-eslint/parser@^5.59.7":
+"@typescript-eslint/parser@^5.55.0", "@typescript-eslint/parser@^5.59.7":
   version "5.59.7"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.7.tgz#02682554d7c1028b89aa44a48bf598db33048caa"
   integrity sha512-VhpsIEuq/8i5SF+mPg9jSdIwgMBBp0z9XqjiEay+81PYLJuroN+ET1hM5IhkiYMJd9MkTz8iJLt7aaGAgzWUbQ==
@@ -1549,14 +1529,6 @@
     "@typescript-eslint/typescript-estree" "5.59.7"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.59.6":
-  version "5.59.6"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.6.tgz#d43a3687aa4433868527cfe797eb267c6be35f19"
-  integrity sha512-gLbY3Le9Dxcb8KdpF0+SJr6EQ+hFGYFl6tVY8VxLPFDfUZC7BHFw+Vq7bM5lE9DwWPfx4vMWWTLGXgpc0mAYyQ==
-  dependencies:
-    "@typescript-eslint/types" "5.59.6"
-    "@typescript-eslint/visitor-keys" "5.59.6"
-
 "@typescript-eslint/scope-manager@5.59.7":
   version "5.59.7"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.7.tgz#0243f41f9066f3339d2f06d7f72d6c16a16769e2"
@@ -1565,40 +1537,22 @@
     "@typescript-eslint/types" "5.59.7"
     "@typescript-eslint/visitor-keys" "5.59.7"
 
-"@typescript-eslint/type-utils@5.59.6":
-  version "5.59.6"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.6.tgz#37c51d2ae36127d8b81f32a0a4d2efae19277c48"
-  integrity sha512-A4tms2Mp5yNvLDlySF+kAThV9VTBPCvGf0Rp8nl/eoDX9Okun8byTKoj3fJ52IJitjWOk0fKPNQhXEB++eNozQ==
+"@typescript-eslint/type-utils@5.59.7":
+  version "5.59.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.7.tgz#89c97291371b59eb18a68039857c829776f1426d"
+  integrity sha512-ozuz/GILuYG7osdY5O5yg0QxXUAEoI4Go3Do5xeu+ERH9PorHBPSdvD3Tjp2NN2bNLh1NJQSsQu2TPu/Ly+HaQ==
   dependencies:
-    "@typescript-eslint/typescript-estree" "5.59.6"
-    "@typescript-eslint/utils" "5.59.6"
+    "@typescript-eslint/typescript-estree" "5.59.7"
+    "@typescript-eslint/utils" "5.59.7"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
-"@typescript-eslint/types@5.59.6", "@typescript-eslint/types@^5.56.0":
-  version "5.59.6"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.6.tgz#5a6557a772af044afe890d77c6a07e8c23c2460b"
-  integrity sha512-tH5lBXZI7T2MOUgOWFdVNUILsI02shyQvfzG9EJkoONWugCG77NDDa1EeDGw7oJ5IvsTAAGVV8I3Tk2PNu9QfA==
-
-"@typescript-eslint/types@5.59.7":
+"@typescript-eslint/types@5.59.7", "@typescript-eslint/types@^5.56.0":
   version "5.59.7"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.7.tgz#6f4857203fceee91d0034ccc30512d2939000742"
   integrity sha512-UnVS2MRRg6p7xOSATscWkKjlf/NDKuqo5TdbWck6rIRZbmKpVNTLALzNvcjIfHBE7736kZOFc/4Z3VcZwuOM/A==
 
-"@typescript-eslint/typescript-estree@5.59.6", "@typescript-eslint/typescript-estree@^5.55.0":
-  version "5.59.6"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.6.tgz#2fb80522687bd3825504925ea7e1b8de7bb6251b"
-  integrity sha512-vW6JP3lMAs/Tq4KjdI/RiHaaJSO7IUsbkz17it/Rl9Q+WkQ77EOuOnlbaU8kKfVIOJxMhnRiBG+olE7f3M16DA==
-  dependencies:
-    "@typescript-eslint/types" "5.59.6"
-    "@typescript-eslint/visitor-keys" "5.59.6"
-    debug "^4.3.4"
-    globby "^11.1.0"
-    is-glob "^4.0.3"
-    semver "^7.3.7"
-    tsutils "^3.21.0"
-
-"@typescript-eslint/typescript-estree@5.59.7":
+"@typescript-eslint/typescript-estree@5.59.7", "@typescript-eslint/typescript-estree@^5.55.0":
   version "5.59.7"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.7.tgz#b887acbd4b58e654829c94860dbff4ac55c5cff8"
   integrity sha512-4A1NtZ1I3wMN2UGDkU9HMBL+TIQfbrh4uS0WDMMpf3xMRursDbqEf1ahh6vAAe3mObt8k3ZATnezwG4pdtWuUQ==
@@ -1611,27 +1565,19 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.59.6", "@typescript-eslint/utils@^5.55.0":
-  version "5.59.6"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.6.tgz#82960fe23788113fc3b1f9d4663d6773b7907839"
-  integrity sha512-vzaaD6EXbTS29cVH0JjXBdzMt6VBlv+hE31XktDRMX1j3462wZCJa7VzO2AxXEXcIl8GQqZPcOPuW/Z1tZVogg==
+"@typescript-eslint/utils@5.59.7", "@typescript-eslint/utils@^5.55.0":
+  version "5.59.7"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.7.tgz#7adf068b136deae54abd9a66ba5a8780d2d0f898"
+  integrity sha512-yCX9WpdQKaLufz5luG4aJbOpdXf/fjwGMcLFXZVPUz3QqLirG5QcwwnIHNf8cjLjxK4qtzTO8udUtMQSAToQnQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@types/json-schema" "^7.0.9"
     "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.59.6"
-    "@typescript-eslint/types" "5.59.6"
-    "@typescript-eslint/typescript-estree" "5.59.6"
+    "@typescript-eslint/scope-manager" "5.59.7"
+    "@typescript-eslint/types" "5.59.7"
+    "@typescript-eslint/typescript-estree" "5.59.7"
     eslint-scope "^5.1.1"
     semver "^7.3.7"
-
-"@typescript-eslint/visitor-keys@5.59.6":
-  version "5.59.6"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.6.tgz#673fccabf28943847d0c8e9e8d008e3ada7be6bb"
-  integrity sha512-zEfbFLzB9ETcEJ4HZEEsCR9HHeNku5/Qw1jSS5McYJv5BR+ftYXwFFAH5Al+xkGaZEqowMwl7uoJjQb1YSPF8Q==
-  dependencies:
-    "@typescript-eslint/types" "5.59.6"
-    eslint-visitor-keys "^3.3.0"
 
 "@typescript-eslint/visitor-keys@5.59.7":
   version "5.59.7"
@@ -1802,7 +1748,7 @@ accepts@~1.3.4:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-acorn-import-assertions@^1.7.6:
+acorn-import-assertions@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
   integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
@@ -2407,9 +2353,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001449:
-  version "1.0.30001488"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz#d19d7b6e913afae3e98f023db97c19e9ddc5e91f"
-  integrity sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==
+  version "1.0.30001489"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz#ca82ee2d4e4dbf2bd2589c9360d3fcc2c7ba3bd8"
+  integrity sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -3043,9 +2989,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.284:
-  version "1.4.399"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.399.tgz#df8a63d1f572124ad8b5d846e38b0532ad7d9d54"
-  integrity sha512-+V1aNvVgoWNWYIbMOiQ1n5fRIaY4SlQ/uRlrsCjLrUwr/3OvQgiX2f5vdav4oArVT9TnttJKcPCqjwPNyZqw/A==
+  version "1.4.408"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.408.tgz#73e657a24bd0b7481d68c943dded0d097b0d0a52"
+  integrity sha512-vjeaj0u/UYnzA/CIdGXzzcxRLCqRwREYc9YfaWInjIEr7/XPttZ6ShpyqapchEy0S2r6LpLjDBTnNj7ZxnxJKg==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -3083,9 +3029,9 @@ end-of-stream@^1.4.1:
     once "^1.4.0"
 
 engine.io-parser@~5.0.3:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.6.tgz#7811244af173e157295dec9b2718dfe42a64ef45"
-  integrity sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.7.tgz#ed5eae76c71f398284c578ab6deafd3ba7e4e4f6"
+  integrity sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==
 
 engine.io@~6.4.1:
   version "6.4.2"
@@ -3103,10 +3049,10 @@ engine.io@~6.4.1:
     engine.io-parser "~5.0.3"
     ws "~8.11.0"
 
-enhanced-resolve@^5.14.0:
-  version "5.14.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.14.0.tgz#0b6c676c8a3266c99fa281e4433a706f5c0c61c4"
-  integrity sha512-+DCows0XNwLDcUhbFJPdlQEVnT2zXlCv7hPxemTz86/O+B/hCQ+mb7ydkPKiflpVraqLPCAfu7lDy+hBXueojw==
+enhanced-resolve@^5.14.1:
+  version "5.14.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.14.1.tgz#de684b6803724477a4af5d74ccae5de52c25f6b3"
+  integrity sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -3369,53 +3315,7 @@ eslint-webpack-plugin@^4.0.1:
     normalize-path "^3.0.0"
     schema-utils "^4.0.0"
 
-eslint@^8.17.0:
-  version "8.40.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.40.0.tgz#a564cd0099f38542c4e9a2f630fa45bf33bc42a4"
-  integrity sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==
-  dependencies:
-    "@eslint-community/eslint-utils" "^4.2.0"
-    "@eslint-community/regexpp" "^4.4.0"
-    "@eslint/eslintrc" "^2.0.3"
-    "@eslint/js" "8.40.0"
-    "@humanwhocodes/config-array" "^0.11.8"
-    "@humanwhocodes/module-importer" "^1.0.1"
-    "@nodelib/fs.walk" "^1.2.8"
-    ajv "^6.10.0"
-    chalk "^4.0.0"
-    cross-spawn "^7.0.2"
-    debug "^4.3.2"
-    doctrine "^3.0.0"
-    escape-string-regexp "^4.0.0"
-    eslint-scope "^7.2.0"
-    eslint-visitor-keys "^3.4.1"
-    espree "^9.5.2"
-    esquery "^1.4.2"
-    esutils "^2.0.2"
-    fast-deep-equal "^3.1.3"
-    file-entry-cache "^6.0.1"
-    find-up "^5.0.0"
-    glob-parent "^6.0.2"
-    globals "^13.19.0"
-    grapheme-splitter "^1.0.4"
-    ignore "^5.2.0"
-    import-fresh "^3.0.0"
-    imurmurhash "^0.1.4"
-    is-glob "^4.0.0"
-    is-path-inside "^3.0.3"
-    js-sdsl "^4.1.4"
-    js-yaml "^4.1.0"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.4.1"
-    lodash.merge "^4.6.2"
-    minimatch "^3.1.2"
-    natural-compare "^1.4.0"
-    optionator "^0.9.1"
-    strip-ansi "^6.0.1"
-    strip-json-comments "^3.1.0"
-    text-table "^0.2.0"
-
-eslint@^8.41.0:
+eslint@^8.17.0, eslint@^8.41.0:
   version "8.41.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.41.0.tgz#3062ca73363b4714b16dbc1e60f035e6134b6f1c"
   integrity sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==
@@ -3567,9 +3467,9 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
+  integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
 fast-glob@^3.2.9:
   version "3.2.12"
@@ -4622,11 +4522,6 @@ jest-worker@^29.5.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-js-sdsl@^4.1.4:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.4.0.tgz#8b437dbe642daa95760400b602378ed8ffea8430"
-  integrity sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==
-
 js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -5315,7 +5210,7 @@ nise@^5.1.4:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
-node-gyp-build@^4.3.0:
+node-gyp-build@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.6.0.tgz#0c52e4cbf54bbd28b709820ef7b6a3c2d6209055"
   integrity sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==
@@ -5359,9 +5254,9 @@ node-preload@^0.2.1:
     process-on-spawn "^1.0.0"
 
 node-releases@^2.0.8:
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.10.tgz#c311ebae3b6a148c89b1813fd7c4d3c024ef537f"
-  integrity sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.12.tgz#35627cc224a23bfb06fb3380f2b3afaaa7eb1039"
+  integrity sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==
 
 "normalize-package-data@~1.0.1 || ^2.0.0 || ^3.0.0":
   version "3.0.3"
@@ -6363,11 +6258,11 @@ socket.io@^4.4.1:
     socket.io-parser "~4.2.1"
 
 sodium-native@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-4.0.1.tgz#773201b0d7872da294b9b12cd90d4a913dc9a2dd"
-  integrity sha512-OQTaxrVLtMvrnfcwZVsOTHe58MfDApJiHJNoOwcmmrhwvlYkfaUt2WuzRio8PgEMOd96R5aDHY49DCtock1zsA==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-4.0.3.tgz#b47e3f1024c71db76ef0141343e1e7611df3d4e0"
+  integrity sha512-0zOjNag+0gIRe56O1TkTfltT+b+JhOpGV6u69MVoKy+BTH95viPPJ0exHHnmgRliWKDGyYsyNeyBamfcU7ZlgQ==
   dependencies:
-    node-gyp-build "^4.3.0"
+    node-gyp-build "^4.6.0"
 
 source-map-support@^0.5.16, source-map-support@~0.5.20:
   version "0.5.21"
@@ -6721,9 +6616,9 @@ terser-webpack-plugin@^5.3.7, terser-webpack-plugin@^5.3.9:
     terser "^5.16.8"
 
 terser@^5.16.8:
-  version "5.17.4"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.17.4.tgz#b0c2d94897dfeba43213ed5f90ed117270a2c696"
-  integrity sha512-jcEKZw6UPrgugz/0Tuk/PVyLAPfMBJf5clnGueo45wTweoV8yh7Q7PEkhkJ5uuUbC7zAxEcG3tqNr1bstkQ8nw==
+  version "5.17.6"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.17.6.tgz#d810e75e1bb3350c799cd90ebefe19c9412c12de"
+  integrity sha512-V8QHcs8YuyLkLHsJO5ucyff1ykrLVsR4dNnS//L5Y3NiSXpbK1J+WMVUs67eI0KTxs9JtHhgEQpXQVHlHI92DQ==
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"
@@ -6828,9 +6723,9 @@ tslib@^1.8.0, tslib@^1.8.1:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.1.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.1.tgz#f2ad78c367857d54e49a0ef9def68737e1a67b21"
-  integrity sha512-KaI6gPil5m9vF7DKaoXxx1ia9fxS4qG5YveErRRVknPDXXriu5M8h48YRjB6h5ZUOKuAKlSJYb0GaDe8I39fRw==
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.2.tgz#1b6f07185c881557b0ffa84b111a0106989e8338"
+  integrity sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==
 
 tslint@5.14.0:
   version "5.14.0"
@@ -7154,9 +7049,9 @@ webpack-merge@^4.1.5:
     lodash "^4.17.15"
 
 webpack-merge@^5.7.3:
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.8.0.tgz#2b39dbf22af87776ad744c390223731d30a68f61"
-  integrity sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.9.0.tgz#dc160a1c4cf512ceca515cc231669e9ddb133826"
+  integrity sha512-6NbRQw4+Sy50vYNTw7EyOn41OZItPiXB8GNv3INSoe3PSFaHJEz3SHTrYVaRm2LilNGnFUzh0FAwqPEmU/CwDg==
   dependencies:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
@@ -7167,9 +7062,9 @@ webpack-sources@^3.2.3:
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@^5.83.1:
-  version "5.83.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.83.1.tgz#fcb69864a0669ac3539a471081952c45b15d1c40"
-  integrity sha512-TNsG9jDScbNuB+Lb/3+vYolPplCS3bbEaJf+Bj0Gw4DhP3ioAflBb1flcRt9zsWITyvOhM96wMQNRWlSX52DgA==
+  version "5.84.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.84.1.tgz#d4493acdeca46b26ffc99d86d784cabfeb925a15"
+  integrity sha512-ZP4qaZ7vVn/K8WN/p990SGATmrL1qg4heP/MrVneczYtpDGJWlrgZv55vxaV2ul885Kz+25MP2kSXkPe3LZfmg==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^1.0.0"
@@ -7177,10 +7072,10 @@ webpack@^5.83.1:
     "@webassemblyjs/wasm-edit" "^1.11.5"
     "@webassemblyjs/wasm-parser" "^1.11.5"
     acorn "^8.7.1"
-    acorn-import-assertions "^1.7.6"
+    acorn-import-assertions "^1.9.0"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.14.0"
+    enhanced-resolve "^5.14.1"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"
@@ -7329,9 +7224,9 @@ yallist@^4.0.0:
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
-  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.0.tgz#47ebe58ee718f772ce65862beb1db816210589a0"
+  integrity sha512-8/1wgzdKc7bc9E6my5wZjmdavHLvO/QOmLG1FBugblEvY4IXrLjlViIOmL24HthU042lWTDRO90Fz1Yp66UnMw==
 
 yargs-parser@20.2.4:
   version "20.2.4"


### PR DESCRIPTION
### What
Replaces usage of `URI` (from [`urijs`](http://medialize.github.io/URI.js/docs.html)) with native [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL).

There is still a reliance on `urijs`'s [`URITemplate`](https://medialize.github.io/URI.js/uri-template.html) API for building URLs from Horizon's `_links` responses, but this should still lower bundle size as its an explicit, standalone import.

### Why
Reducing bundle size, see #824.

```
Assets: 
  stellar-sdk.js (1.83 MiB)
  stellar-sdk.min.js (685 KiB)
```

### Known Limitations
Is this worth it? Tests pass, but this might break in subtle ways.