### PR TITLE
Broaden library compatibility by transpiling Stellar dependencies

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,24 +1,20 @@
 {
-    "comments": false,
+    "comments": true, // for debugging & jsdocs
     "presets": [
         "@babel/preset-env",
         "@babel/typescript"
     ],
     "targets": {
-        "node": 14,
-        "browsers": [ "> 2%" ]
+        "browsers": [ "> 2%" ]          // target modern browsers and ES6
     },
     "env": {
         "development": {
-            "comments": true,           // for debugging
             "plugins": [ "istanbul" ]   // for code coverage
         },
-        "docs": {
-            "comments": true            // for jsdocs
-        },
         "production": {
-            // stricter target for final browser bundle
+            "comments": false,
             "targets": {
+                "node": 14,
                 "browsers": [
                     "> 2%",
                     "ie 11",

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "@stellar/tsconfig",
   "compilerOptions": {
     "declaration": true,
+    "emitDeclarationOnly": true,
     "declarationDir": "../lib",
+    "removeComments": false,
+    "lib": ["ES6"],
     "moduleResolution": "node",
     "rootDir": "../src",
     "outDir": "../lib",

--- a/config/webpack.config.browser.js
+++ b/config/webpack.config.browser.js
@@ -32,7 +32,7 @@ const config = {
     rules: [
       {
         test: /\.m?(ts|js)$/,
-        exclude: /node_modules/,
+        exclude: /node_modules\/(?!(stellar-base|js-xdr))/,
         use: {
           loader: 'babel-loader',
           options: {


### PR DESCRIPTION
In line with stellar/js-soroban-client#88, stellar/js-soroban-client#75, and stellar/js-soroban-client#76, the modernization of the build pipeline has some unpleasant downstream impacts. This changeset should minimize that:

 * Babel will transpile our modern dependencies
 * TypeScript will only drop declaration files and keep comments