### PR TITLE
Make Node 16 the minimum version.

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -18,10 +18,10 @@ jobs:
           repository: stellar/js-stellar-base
           path: js-stellar-base
 
-      - name: Install Node (14.x)
+      - name: Install Node (16.x)
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 16
 
       - name: Install Dependencies
         run: yarn install

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: 16
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Depencencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [16, 18]
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        node-version: [16, 18]
+        node-version: [16, 18, 20]
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -134,16 +134,16 @@ cd js-stellar-sdk
 npm install
 ```
 
-3. Install Node 14
+3. Install Node 16
 
-Because we support the oldest maintenance version of Node, please install and develop on Node 14 so you don't get surprised when your code works locally but breaks in CI.
+Because we support the oldest maintenance version of Node, please install and develop on Node 16 so you don't get surprised when your code works locally but breaks in CI.
 
 Here's how to install `nvm` if you haven't: https://github.com/creationix/nvm
 
 ```shell
 nvm install
 
-# if you've never installed 14 before you'll want to re-install yarn
+# if you've never installed 16 before you'll want to re-install yarn
 npm install -g yarn
 ```
 

--- a/babel.config.json
+++ b/babel.config.json
@@ -14,7 +14,7 @@
         "production": {
             "comments": false,
             "targets": {
-                "node": 14,
+                "node": 16,
                 "browsers": [
                     "> 2%",
                     "ie 11",


### PR DESCRIPTION
Node 16 is the [oldest active version](https://nodejs.dev/en/about/releases/).

This change is required for #846 as `eslint` now requires Node 16.