### PR TITLE
Release beta.3 hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 
+## [v11.0.0-beta.3](https://github.com/stellar/js-stellar-sdk/compare/v11.0.0-beta.2...v11.0.0-beta.3)
+
+### Fixed
+- Fix a webpack error preventing correct exports of the SDK for browsers ([TODO]()).
+
+
 ## [v11.0.0-beta.2](https://github.com/stellar/js-stellar-sdk/compare/v11.0.0-beta.1...v11.0.0-beta.2)
 
 ### Breaking Changes

--- a/config/webpack.config.browser.js
+++ b/config/webpack.config.browser.js
@@ -22,8 +22,11 @@ const config = {
   },
   output: {
     clean: true,
-    library: 'StellarSdk',
-    compareBeforeEmit: true,
+    library: {
+      name: 'StellarSdk',
+      type: 'umd',
+      umdNamedDefine: true
+    },
     path: path.resolve(__dirname, '../dist')
   },
   mode: process.env.NODE_ENV ?? 'development',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-sdk",
-  "version": "11.0.0-beta.2",
+  "version": "11.0.0-beta.3",
   "description": "A library for working with the Stellar Horizon server.",
   "keywords": [
     "stellar"


### PR DESCRIPTION
This should fix the library export for browsers, mimicking the [same config in soroban-client](https://github.com/stellar/js-soroban-client/blob/main/webpack.config.browser.js#L25-L29).