### PR TITLE
Drop the unnecessary `networkPassphrase` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ A breaking change will get clearly marked in this log.
 
 ### Breaking Changes
 * The `soroban-client` library ([stellar/js-soroban-client](https://github.com/stellar/js-soroban-client)) has been merged into this package, causing significant breaking changes in the module structure ([#860](https://github.com/stellar/js-stellar-sdk/pull/860)):
-
   - The namespaces have changed to move each server-dependent component into its own module. Shared components (e.g. `TransactionBuilder`) are still in the top level, Horizon-specific interactions are in the `Horizon` namespace (i.e. `Server` is now `Horizon.Server`), and new Soroban RPC interactions are in the `SorobanRpc` namespace.
   - There is a [detailed migration guide](https://gist.github.com/Shaptic/5ce4f16d9cce7118f391fbde398c2f30) available to outline both the literal (i.e. necessary code changes) and philosophical (i.e. how to find certain functionality) changes needed to adapt to this merge.
+* The `SorobanRpc.Server.prepareTransaction` and `SorobanRpc.assembleTransaction` methods no longer need an optional `networkPassphrase` parameter, because it is implicitly part of the transaction already ([#870](https://github.com/stellar/js-stellar-sdk/pull/870)).
 
 
 ## [v11.0.0-beta.4](https://github.com/stellar/js-stellar-sdk/compare/v11.0.0-beta.3...v11.0.0-beta.4)

--- a/src/horizon/server.ts
+++ b/src/horizon/server.ts
@@ -322,9 +322,7 @@ export class Server {
           return response.data;
         }
 
-        // TODO: fix stellar-base types.
-        const responseXDR: xdr.TransactionResult = (xdr.TransactionResult
-          .fromXDR as any)(response.data.result_xdr, "base64");
+        const responseXDR = xdr.TransactionResult.fromXDR(response.data.result_xdr, "base64");
 
         // TODO: fix stellar-base types.
         const results = (responseXDR as any).result().value();

--- a/src/soroban/transaction.ts
+++ b/src/soroban/transaction.ts
@@ -11,9 +11,7 @@ import { parseRawSimulation } from './parsers';
 /**
  * Combines the given raw transaction alongside the simulation results.
  *
- * @param raw   the initial transaction, w/o simulation applied
- * @param networkPassphrase  the network this simulation applies to (see
- *    {@link Networks} for options)
+ * @param raw         the initial transaction, w/o simulation applied
  * @param simulation  the Soroban RPC simulation result (see
  *    {@link Server.simulateTransaction})
  *

--- a/src/soroban/transaction.ts
+++ b/src/soroban/transaction.ts
@@ -29,7 +29,6 @@ import { parseRawSimulation } from './parsers';
  */
 export function assembleTransaction(
   raw: Transaction | FeeBumpTransaction,
-  networkPassphrase: string,
   simulation:
     | Api.SimulateTransactionResponse
     | Api.RawSimulateTransactionResponse
@@ -38,7 +37,6 @@ export function assembleTransaction(
     // TODO: Handle feebump transactions
     return assembleTransaction(
       raw.innerTransaction,
-      networkPassphrase,
       simulation
     );
   }
@@ -70,7 +68,7 @@ export function assembleTransaction(
     fee: (classicFeeNum + minResourceFeeNum).toString(),
     // apply the pre-built Soroban Tx Data from simulation onto the Tx
     sorobanData: success.transactionData.build(),
-    networkPassphrase
+    networkPassphrase: raw.networkPassphrase
   });
 
   switch (raw.operations[0].type) {

--- a/test/unit/transaction_test.js
+++ b/test/unit/transaction_test.js
@@ -61,7 +61,7 @@ describe("assembleTransaction", () => {
 
     function singleContractFnTransaction(auth) {
       return new StellarSdk.TransactionBuilder(source, { fee: 100 })
-        .setNetworkPassphrase("Test")
+        .setNetworkPassphrase(networkPassphrase)
         .setTimeout(StellarSdk.TimeoutInfinite)
         .addOperation(
           StellarSdk.Operation.invokeHostFunction({
@@ -82,7 +82,6 @@ describe("assembleTransaction", () => {
       const txn = singleContractFnTransaction();
       const result = SorobanRpc.assembleTransaction(
         txn,
-        networkPassphrase,
         simulationResponse,
       ).build();
 
@@ -100,7 +99,6 @@ describe("assembleTransaction", () => {
       const txn = singleContractFnTransaction();
       const result = SorobanRpc.assembleTransaction(
         txn,
-        networkPassphrase,
         simulationResponse,
       ).build();
 
@@ -143,11 +141,7 @@ describe("assembleTransaction", () => {
       const txn = singleContractFnTransaction();
       let simulateResp = JSON.parse(JSON.stringify(simulationResponse));
       simulateResp.results[0].auth = null;
-      const result = SorobanRpc.assembleTransaction(
-        txn,
-        networkPassphrase,
-        simulateResp,
-      ).build();
+      const result = SorobanRpc.assembleTransaction(txn, simulateResp).build();
 
       expect(
         result
@@ -176,7 +170,7 @@ describe("assembleTransaction", () => {
         .build();
 
       expect(() => {
-        SorobanRpc.assembleTransaction(txn, networkPassphrase, {
+        SorobanRpc.assembleTransaction(txn, {
           transactionData: {},
           events: [],
           minResourceFee: "0",
@@ -208,7 +202,6 @@ describe("assembleTransaction", () => {
 
         const tx = SorobanRpc.assembleTransaction(
           txn,
-          networkPassphrase,
           simulationResponse,
         ).build();
         expect(tx.operations[0].type).to.equal(op.body().switch().name);
@@ -219,7 +212,6 @@ describe("assembleTransaction", () => {
       const txn = singleContractFnTransaction([fnAuth, fnAuth, fnAuth]);
       const tx = SorobanRpc.assembleTransaction(
         txn,
-        networkPassphrase,
         simulationResponse,
       ).build();
 


### PR DESCRIPTION
The network passphrase is part of the transaction object we've been passing around, so there's no need for an explicit `networkPassphrase` parameter and/or unnecessary `getNetwork` call.