### PR TITLE
Release beta.6 with various bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+
+## [v11.0.0-beta.6](https://github.com/stellar/js-stellar-sdk/compare/v11.0.0-beta.4...v11.0.0-beta.6)
+
 ### Fixed
+* The `stellar-base` library has been upgraded to `beta.4` which contains a bugfix for large sequence numbers ([TODO]()).
 * The `SorobanRpc.Server.getTransaction()` method will now return the full response when encountering a `FAILED` transaction result ([#872](https://github.com/stellar/js-stellar-sdk/pull/872)).
 * The `SorobanRpc.Server.getEvents()` method will correctly parse the event value (which is an `xdr.ScVal` rather than an `xdr.DiagnosticEvent`, see the modified `SorobanRpc.Api.EventResponse.value`; [#876](https://github.com/stellar/js-stellar-sdk/pull/876)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 
-## [v11.0.0-beta.6](https://github.com/stellar/js-stellar-sdk/compare/v11.0.0-beta.4...v11.0.0-beta.6)
+## [v11.0.0-beta.6](https://github.com/stellar/js-stellar-sdk/compare/v11.0.0-beta.5...v11.0.0-beta.6)
 
 ### Fixed
-* The `stellar-base` library has been upgraded to `beta.4` which contains a bugfix for large sequence numbers ([TODO]()).
+* The `stellar-base` library has been upgraded to `beta.4` which contains a bugfix for large sequence numbers ([#877](https://github.com/stellar/js-stellar-sdk/pull/877)).
 * The `SorobanRpc.Server.getTransaction()` method will now return the full response when encountering a `FAILED` transaction result ([#872](https://github.com/stellar/js-stellar-sdk/pull/872)).
 * The `SorobanRpc.Server.getEvents()` method will correctly parse the event value (which is an `xdr.ScVal` rather than an `xdr.DiagnosticEvent`, see the modified `SorobanRpc.Api.EventResponse.value`; [#876](https://github.com/stellar/js-stellar-sdk/pull/876)).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-sdk",
-  "version": "11.0.0-beta.5",
+  "version": "11.0.0-beta.6",
   "description": "A library for working with the Stellar network, including communication with the Horizon and Soroban RPC servers.",
   "keywords": [
     "stellar"
@@ -83,7 +83,7 @@
     "@babel/preset-env": "^7.22.20",
     "@babel/preset-typescript": "^7.23.0",
     "@babel/register": "^7.22.15",
-    "@definitelytyped/dtslint": "^0.0.184",
+    "@definitelytyped/dtslint": "^0.0.189",
     "@istanbuljs/nyc-config-babel": "3.0.0",
     "@stellar/tsconfig": "^1.0.2",
     "@types/chai": "^4.3.6",
@@ -91,11 +91,11 @@
     "@types/eventsource": "^1.1.12",
     "@types/lodash": "^4.14.199",
     "@types/mocha": "^10.0.2",
-    "@types/node": "^20.8.8",
+    "@types/node": "^20.8.10",
     "@types/randombytes": "^2.0.1",
     "@types/sinon": "^10.0.19",
     "@types/urijs": "^1.19.20",
-    "@typescript-eslint/parser": "^6.7.4",
+    "@typescript-eslint/parser": "^6.9.1",
     "axios-mock-adapter": "^1.22.0",
     "babel-loader": "^9.1.3",
     "babel-plugin-istanbul": "^6.1.1",
@@ -142,11 +142,11 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
-    "axios": "^1.5.1",
+    "axios": "^1.6.0",
     "bignumber.js": "^9.1.2",
     "eventsource": "^2.0.2",
     "randombytes": "^2.1.0",
-    "stellar-base": "10.0.0-beta.3",
+    "stellar-base": "10.0.0-beta.4",
     "toml": "^3.0.0",
     "urijs": "^1.19.1"
   }

--- a/test/unit/contract_spec.js
+++ b/test/unit/contract_spec.js
@@ -6,251 +6,239 @@ const publicKey = "GCBVOLOM32I7OD5TWZQCIXCXML3TK56MDY7ZMTAILIBQHHKPCVU42XYW";
 const addr = Address.fromString(publicKey);
 let SPEC;
 before(() => {
-  SPEC = new ContractSpec(spec);
+    SPEC = new ContractSpec(spec);
 });
 it("throws if no entries", () => {
-  expect(() => new ContractSpec([])).to.throw(
-    /Contract spec must have at least one entry/i,
-  );
+    expect(() => new ContractSpec([])).to.throw(/Contract spec must have at least one entry/i);
 });
 describe("Can round trip custom types", function () {
-  function getResultType(funcName) {
-    let fn = SPEC.findEntry(funcName).value();
-    if (!(fn instanceof xdr.ScSpecFunctionV0)) {
-      throw new Error("Not a function");
+    function getResultType(funcName) {
+        let fn = SPEC.findEntry(funcName).value();
+        if (!(fn instanceof xdr.ScSpecFunctionV0)) {
+            throw new Error("Not a function");
+        }
+        if (fn.outputs().length === 0) {
+            return xdr.ScSpecTypeDef.scSpecTypeVoid();
+        }
+        return fn.outputs()[0];
     }
-    if (fn.outputs().length === 0) {
-      return xdr.ScSpecTypeDef.scSpecTypeVoid();
+    function roundtrip(funcName, input, typeName) {
+        let type = getResultType(funcName);
+        let ty = typeName ?? funcName;
+        let obj = {};
+        obj[ty] = input;
+        let scVal = SPEC.funcArgsToScVals(funcName, obj)[0];
+        let result = SPEC.scValToNative(scVal, type);
+        expect(result).deep.equal(input);
     }
-    return fn.outputs()[0];
-  }
-  function roundtrip(funcName, input, typeName) {
-    let type = getResultType(funcName);
-    let ty = typeName ?? funcName;
-    let obj = {};
-    obj[ty] = input;
-    let scVal = SPEC.funcArgsToScVals(funcName, obj)[0];
-    let result = SPEC.scValToNative(scVal, type);
-    expect(result).deep.equal(input);
-  }
-  it("u32", () => {
-    roundtrip("u32_", 1);
-  });
-  it("i32", () => {
-    roundtrip("i32_", -1);
-  });
-  it("i64", () => {
-    roundtrip("i64_", 1n);
-  });
-  it("strukt", () => {
-    roundtrip("strukt", { a: 0, b: true, c: "hello" });
-  });
-  describe("simple", () => {
-    it("first", () => {
-      const simple = { tag: "First", values: undefined };
-      roundtrip("simple", simple);
+    it("u32", () => {
+        roundtrip("u32_", 1);
     });
-    it("simple second", () => {
-      const simple = { tag: "Second", values: undefined };
-      roundtrip("simple", simple);
+    it("i32", () => {
+        roundtrip("i32_", -1);
     });
-    it("simple third", () => {
-      const simple = { tag: "Third", values: undefined };
-      roundtrip("simple", simple);
+    it("i64", () => {
+        roundtrip("i64_", 1n);
     });
-  });
-  describe("complex", () => {
-    it("struct", () => {
-      const complex = {
-        tag: "Struct",
-        values: [{ a: 0, b: true, c: "hello" }],
-      };
-      roundtrip("complex", complex);
+    it("strukt", () => {
+        roundtrip("strukt", { a: 0, b: true, c: "hello" });
+    });
+    describe("simple", () => {
+        it("first", () => {
+            const simple = { tag: "First", values: undefined };
+            roundtrip("simple", simple);
+        });
+        it("simple second", () => {
+            const simple = { tag: "Second", values: undefined };
+            roundtrip("simple", simple);
+        });
+        it("simple third", () => {
+            const simple = { tag: "Third", values: undefined };
+            roundtrip("simple", simple);
+        });
+    });
+    describe("complex", () => {
+        it("struct", () => {
+            const complex = {
+                tag: "Struct",
+                values: [{ a: 0, b: true, c: "hello" }],
+            };
+            roundtrip("complex", complex);
+        });
+        it("tuple", () => {
+            const complex = {
+                tag: "Tuple",
+                values: [
+                    [
+                        { a: 0, b: true, c: "hello" },
+                        { tag: "First", values: undefined },
+                    ],
+                ],
+            };
+            roundtrip("complex", complex);
+        });
+        it("enum", () => {
+            const complex = {
+                tag: "Enum",
+                values: [{ tag: "First", values: undefined }],
+            };
+            roundtrip("complex", complex);
+        });
+        it("asset", () => {
+            const complex = { tag: "Asset", values: [addr, 1n] };
+            roundtrip("complex", complex);
+        });
+        it("void", () => {
+            const complex = { tag: "Void", values: undefined };
+            roundtrip("complex", complex);
+        });
+    });
+    it("addresse", () => {
+        roundtrip("addresse", addr);
+    });
+    it("bytes", () => {
+        const bytes = Buffer.from("hello");
+        roundtrip("bytes", bytes);
+    });
+    it("bytes_n", () => {
+        const bytes_n = Buffer.from("123456789"); // what's the correct way to construct bytes_n?
+        roundtrip("bytes_n", bytes_n);
+    });
+    it("card", () => {
+        const card = 11;
+        roundtrip("card", card);
+    });
+    it("boolean", () => {
+        roundtrip("boolean", true);
+    });
+    it("not", () => {
+        roundtrip("boolean", false);
+    });
+    it("i128", () => {
+        roundtrip("i128", -1n);
+    });
+    it("u128", () => {
+        roundtrip("u128", 1n);
+    });
+    it("map", () => {
+        const map = new Map();
+        map.set(1, true);
+        map.set(2, false);
+        roundtrip("map", map);
+        map.set(3, "hahaha");
+        expect(() => roundtrip("map", map)).to.throw(/invalid type scSpecTypeBool specified for string value/i);
+    });
+    it("vec", () => {
+        const vec = [1, 2, 3];
+        roundtrip("vec", vec);
     });
     it("tuple", () => {
-      const complex = {
-        tag: "Tuple",
-        values: [
-          [
+        const tuple = ["hello", 1];
+        roundtrip("tuple", tuple);
+    });
+    it("option", () => {
+        roundtrip("option", 1);
+        roundtrip("option", undefined);
+    });
+    it("u256", () => {
+        roundtrip("u256", 1n);
+        expect(() => roundtrip("u256", -1n)).to.throw(/expected a positive value, got: -1/i);
+    });
+    it("i256", () => {
+        roundtrip("i256", -1n);
+    });
+    it("string", () => {
+        roundtrip("string", "hello");
+    });
+    it("tuple_strukt", () => {
+        const arg = [
             { a: 0, b: true, c: "hello" },
             { tag: "First", values: undefined },
-          ],
-        ],
-      };
-      roundtrip("complex", complex);
+        ];
+        roundtrip("tuple_strukt", arg);
     });
-    it("enum", () => {
-      const complex = {
-        tag: "Enum",
-        values: [{ tag: "First", values: undefined }],
-      };
-      roundtrip("complex", complex);
-    });
-    it("asset", () => {
-      const complex = { tag: "Asset", values: [addr, 1n] };
-      roundtrip("complex", complex);
-    });
-    it("void", () => {
-      const complex = { tag: "Void", values: undefined };
-      roundtrip("complex", complex);
-    });
-  });
-  it("addresse", () => {
-    roundtrip("addresse", addr);
-  });
-  it("bytes", () => {
-    const bytes = Buffer.from("hello");
-    roundtrip("bytes", bytes);
-  });
-  it("bytes_n", () => {
-    const bytes_n = Buffer.from("123456789"); // what's the correct way to construct bytes_n?
-    roundtrip("bytes_n", bytes_n);
-  });
-  it("card", () => {
-    const card = 11;
-    roundtrip("card", card);
-  });
-  it("boolean", () => {
-    roundtrip("boolean", true);
-  });
-  it("not", () => {
-    roundtrip("boolean", false);
-  });
-  it("i128", () => {
-    roundtrip("i128", -1n);
-  });
-  it("u128", () => {
-    roundtrip("u128", 1n);
-  });
-  it("map", () => {
-    const map = new Map();
-    map.set(1, true);
-    map.set(2, false);
-    roundtrip("map", map);
-    map.set(3, "hahaha");
-    expect(() => roundtrip("map", map)).to.throw(
-      /invalid type scSpecTypeBool specified for string value/i,
-    );
-  });
-  it("vec", () => {
-    const vec = [1, 2, 3];
-    roundtrip("vec", vec);
-  });
-  it("tuple", () => {
-    const tuple = ["hello", 1];
-    roundtrip("tuple", tuple);
-  });
-  it("option", () => {
-    roundtrip("option", 1);
-    roundtrip("option", undefined);
-  });
-  it("u256", () => {
-    roundtrip("u256", 1n);
-    expect(() => roundtrip("u256", -1n)).to.throw(
-      /expected a positive value, got: -1/i,
-    );
-  });
-  it("i256", () => {
-    roundtrip("i256", -1n);
-  });
-  it("string", () => {
-    roundtrip("string", "hello");
-  });
-  it("tuple_strukt", () => {
-    const arg = [
-      { a: 0, b: true, c: "hello" },
-      { tag: "First", values: undefined },
-    ];
-    roundtrip("tuple_strukt", arg);
-  });
 });
 describe("parsing and building ScVals", function () {
-  it("Can parse entries", function () {
-    let spec = new ContractSpec([GIGA_MAP, func]);
-    let fn = spec.findEntry("giga_map");
-    let gigaMap = spec.findEntry("GigaMap");
-    expect(gigaMap).deep.equal(GIGA_MAP);
-    expect(fn).deep.equal(func);
-  });
+    it("Can parse entries", function () {
+        let spec = new ContractSpec([GIGA_MAP, func]);
+        let fn = spec.findEntry("giga_map");
+        let gigaMap = spec.findEntry("GigaMap");
+        expect(gigaMap).deep.equal(GIGA_MAP);
+        expect(fn).deep.equal(func);
+    });
 });
-export const GIGA_MAP = xdr.ScSpecEntry.scSpecEntryUdtStructV0(
-  new xdr.ScSpecUdtStructV0({
+export const GIGA_MAP = xdr.ScSpecEntry.scSpecEntryUdtStructV0(new xdr.ScSpecUdtStructV0({
     doc: "This is a kitchen sink of all the types",
     lib: "",
     name: "GigaMap",
     fields: [
-      new xdr.ScSpecUdtStructFieldV0({
-        doc: "",
-        name: "bool",
-        type: xdr.ScSpecTypeDef.scSpecTypeBool(),
-      }),
-      new xdr.ScSpecUdtStructFieldV0({
-        doc: "",
-        name: "i128",
-        type: xdr.ScSpecTypeDef.scSpecTypeI128(),
-      }),
-      new xdr.ScSpecUdtStructFieldV0({
-        doc: "",
-        name: "u128",
-        type: xdr.ScSpecTypeDef.scSpecTypeU128(),
-      }),
-      new xdr.ScSpecUdtStructFieldV0({
-        doc: "",
-        name: "i256",
-        type: xdr.ScSpecTypeDef.scSpecTypeI256(),
-      }),
-      new xdr.ScSpecUdtStructFieldV0({
-        doc: "",
-        name: "u256",
-        type: xdr.ScSpecTypeDef.scSpecTypeU256(),
-      }),
-      new xdr.ScSpecUdtStructFieldV0({
-        doc: "",
-        name: "i32",
-        type: xdr.ScSpecTypeDef.scSpecTypeI32(),
-      }),
-      new xdr.ScSpecUdtStructFieldV0({
-        doc: "",
-        name: "u32",
-        type: xdr.ScSpecTypeDef.scSpecTypeU32(),
-      }),
-      new xdr.ScSpecUdtStructFieldV0({
-        doc: "",
-        name: "i64",
-        type: xdr.ScSpecTypeDef.scSpecTypeI64(),
-      }),
-      new xdr.ScSpecUdtStructFieldV0({
-        doc: "",
-        name: "u64",
-        type: xdr.ScSpecTypeDef.scSpecTypeU64(),
-      }),
-      new xdr.ScSpecUdtStructFieldV0({
-        doc: "",
-        name: "symbol",
-        type: xdr.ScSpecTypeDef.scSpecTypeSymbol(),
-      }),
-      new xdr.ScSpecUdtStructFieldV0({
-        doc: "",
-        name: "string",
-        type: xdr.ScSpecTypeDef.scSpecTypeString(),
-      }),
+        new xdr.ScSpecUdtStructFieldV0({
+            doc: "",
+            name: "bool",
+            type: xdr.ScSpecTypeDef.scSpecTypeBool(),
+        }),
+        new xdr.ScSpecUdtStructFieldV0({
+            doc: "",
+            name: "i128",
+            type: xdr.ScSpecTypeDef.scSpecTypeI128(),
+        }),
+        new xdr.ScSpecUdtStructFieldV0({
+            doc: "",
+            name: "u128",
+            type: xdr.ScSpecTypeDef.scSpecTypeU128(),
+        }),
+        new xdr.ScSpecUdtStructFieldV0({
+            doc: "",
+            name: "i256",
+            type: xdr.ScSpecTypeDef.scSpecTypeI256(),
+        }),
+        new xdr.ScSpecUdtStructFieldV0({
+            doc: "",
+            name: "u256",
+            type: xdr.ScSpecTypeDef.scSpecTypeU256(),
+        }),
+        new xdr.ScSpecUdtStructFieldV0({
+            doc: "",
+            name: "i32",
+            type: xdr.ScSpecTypeDef.scSpecTypeI32(),
+        }),
+        new xdr.ScSpecUdtStructFieldV0({
+            doc: "",
+            name: "u32",
+            type: xdr.ScSpecTypeDef.scSpecTypeU32(),
+        }),
+        new xdr.ScSpecUdtStructFieldV0({
+            doc: "",
+            name: "i64",
+            type: xdr.ScSpecTypeDef.scSpecTypeI64(),
+        }),
+        new xdr.ScSpecUdtStructFieldV0({
+            doc: "",
+            name: "u64",
+            type: xdr.ScSpecTypeDef.scSpecTypeU64(),
+        }),
+        new xdr.ScSpecUdtStructFieldV0({
+            doc: "",
+            name: "symbol",
+            type: xdr.ScSpecTypeDef.scSpecTypeSymbol(),
+        }),
+        new xdr.ScSpecUdtStructFieldV0({
+            doc: "",
+            name: "string",
+            type: xdr.ScSpecTypeDef.scSpecTypeString(),
+        }),
     ],
-  }),
-);
-const GIGA_MAP_TYPE = xdr.ScSpecTypeDef.scSpecTypeUdt(
-  new xdr.ScSpecTypeUdt({ name: "GigaMap" }),
-);
-let func = xdr.ScSpecEntry.scSpecEntryFunctionV0(
-  new xdr.ScSpecFunctionV0({
+}));
+const GIGA_MAP_TYPE = xdr.ScSpecTypeDef.scSpecTypeUdt(new xdr.ScSpecTypeUdt({ name: "GigaMap" }));
+let func = xdr.ScSpecEntry.scSpecEntryFunctionV0(new xdr.ScSpecFunctionV0({
     doc: "Kitchen Sink",
     name: "giga_map",
     inputs: [
-      new xdr.ScSpecFunctionInputV0({
-        doc: "",
-        name: "giga_map",
-        type: GIGA_MAP_TYPE,
-      }),
+        new xdr.ScSpecFunctionInputV0({
+            doc: "",
+            name: "giga_map",
+            type: GIGA_MAP_TYPE,
+        }),
     ],
     outputs: [GIGA_MAP_TYPE],
-  }),
-);
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,27 +1029,27 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@definitelytyped/dts-critic@0.0.180":
-  version "0.0.180"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/dts-critic/-/dts-critic-0.0.180.tgz#8107fc254f9a9b8565625393f07b1f52d4202350"
-  integrity sha512-ggHGzu9LLW+fV/cat8GCPNiAtODMVBJ5Bga9FtrCrVRQQqWqp6KYMBMc5tON9zMfPteCCTN8WEl8rQ351Hu53Q==
+"@definitelytyped/dts-critic@0.0.185":
+  version "0.0.185"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/dts-critic/-/dts-critic-0.0.185.tgz#d8ab9c20ef07e9a9d0b9e56327777789d8862a74"
+  integrity sha512-VQ1Y9tq90cLtF5i6g/iPwi6QJKNs3G0H1y52mZ/6yD0iiRBqrcwxTA+X7JSNg57ZG+mwm8NZdXN4VWblnk5/Dg==
   dependencies:
-    "@definitelytyped/header-parser" "0.0.180"
+    "@definitelytyped/header-parser" "0.0.184"
     command-exists "^1.2.8"
     rimraf "^3.0.2"
     semver "^7.5.2"
     tmp "^0.2.1"
     yargs "^15.3.1"
 
-"@definitelytyped/dtslint@^0.0.184":
-  version "0.0.184"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/dtslint/-/dtslint-0.0.184.tgz#96a7bc9e7a52aac18fc356cdf79f1f1e806282a8"
-  integrity sha512-A0yI5jaulbcOfuSDugRgpZSRoMDHA0VaQ1FWQn/juGCOvPJfRad2/B6zndJFsOFzJCM0MwL0JqaAa9fSmxqQHA==
+"@definitelytyped/dtslint@^0.0.189":
+  version "0.0.189"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/dtslint/-/dtslint-0.0.189.tgz#4effeb4115c094f2e35285bc5c111a54726b5820"
+  integrity sha512-NyQ1DHxMmgBImQeefA3xCnlskHbalMYuaE3lsMzIijRUQjbF2beZmQRHnl7xYCnHsC+q8L92h3DW2HWwSd5uBQ==
   dependencies:
-    "@definitelytyped/dts-critic" "0.0.180"
-    "@definitelytyped/header-parser" "0.0.180"
+    "@definitelytyped/dts-critic" "0.0.185"
+    "@definitelytyped/header-parser" "0.0.184"
     "@definitelytyped/typescript-versions" "0.0.179"
-    "@definitelytyped/utils" "0.0.179"
+    "@definitelytyped/utils" "0.0.182"
     "@typescript-eslint/eslint-plugin" "^5.55.0"
     "@typescript-eslint/parser" "^5.55.0"
     "@typescript-eslint/types" "^5.56.0"
@@ -1063,13 +1063,13 @@
     tslint "5.14.0"
     yargs "^15.1.0"
 
-"@definitelytyped/header-parser@0.0.180":
-  version "0.0.180"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/header-parser/-/header-parser-0.0.180.tgz#eb232f021b24c9a89ff3b3b1ee1b47234688f320"
-  integrity sha512-fCTevUtPRjolPR8SjTOsThoEHKXT0LndD4rCZQV+PWTxJc6YjkSUVCyr2iD8Btb8nOcJdSHt2JMF8xf1OEBZKA==
+"@definitelytyped/header-parser@0.0.184":
+  version "0.0.184"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/header-parser/-/header-parser-0.0.184.tgz#93864e715c7a6c09d9aaeb21d5dfe5d24e03d5cf"
+  integrity sha512-e5aTiMFYzrNu/xC9LqzVNXbkyF/e/EU88tJVsEyxKaWr8RjX7Y2ONsXmCJjsKbiQEUjKJobtSgk21XwhoSa3KQ==
   dependencies:
     "@definitelytyped/typescript-versions" "0.0.179"
-    "@definitelytyped/utils" "0.0.179"
+    "@definitelytyped/utils" "0.0.182"
     semver "^7.3.7"
 
 "@definitelytyped/typescript-versions@0.0.179":
@@ -1077,17 +1077,16 @@
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.179.tgz#62cd6e114b56322ea1aef7a4f3492f1b8ad50fc2"
   integrity sha512-E0VjIZkVtOt2ozagGlmWULKJYvFZwMjS6A335QJX8dmn21idRP/0RodxRpjtMU2//ChtvCZZUuKrPZQ2D/owww==
 
-"@definitelytyped/utils@0.0.179":
-  version "0.0.179"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/utils/-/utils-0.0.179.tgz#8d3e736ddb8fbe069269ecd811f00b04720cd4d5"
-  integrity sha512-aUNyshFuHT+tDRlLH5pUd9acIzTim5CMiuOZmVHvjlIi7BzMxRBbG7MtzYkpwA5TxHQo2gwumLN2u9UfEklrkQ==
+"@definitelytyped/utils@0.0.182":
+  version "0.0.182"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/utils/-/utils-0.0.182.tgz#42a655bd74314b6252f7f0c5fd9d8b99908878b8"
+  integrity sha512-ANeeI+ixK9FYgljDlVtlBqcaPi1Fi9R55MkhtGbNNUY/g4u1S1QXoBY/87oYF92VjQPpbxC0ZuiP8MnVuHqh6w==
   dependencies:
     "@definitelytyped/typescript-versions" "0.0.179"
     "@qiwi/npm-registry-client" "^8.9.1"
     "@types/node" "^14.14.35"
     charm "^1.0.2"
     fs-extra "^8.1.0"
-    fstream "^1.0.12"
     tar "^6.1.11"
     tar-stream "^2.1.4"
 
@@ -1104,9 +1103,9 @@
     eslint-visitor-keys "^3.3.0"
 
 "@eslint-community/regexpp@^4.4.0", "@eslint-community/regexpp@^4.6.1":
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.9.1.tgz#449dfa81a57a1d755b09aa58d826c1262e4283b4"
-  integrity sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.10.0.tgz#548f6de556857c8bb73bbee70c35dc82a2e74d63"
+  integrity sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==
 
 "@eslint/eslintrc@^2.1.2":
   version "2.1.2"
@@ -1420,9 +1419,9 @@
     "@types/json-schema" "*"
 
 "@types/estree@*", "@types/estree@^1.0.0":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.3.tgz#2be19e759a3dd18c79f9f436bd7363556c1a73dd"
-  integrity sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.4.tgz#d9748f5742171b26218516cf1828b8eafaf8a9fa"
+  integrity sha512-2JwWnHK9H+wUZNorf2Zr6ves96WHoWDJIftkcxPKsS7Djta6Zu519LarhRNljPXkpsZR2ZMwNCPeW7omW07BJw==
 
 "@types/eventsource@^1.1.12":
   version "1.1.14"
@@ -1486,12 +1485,12 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.3.tgz#4804fe9cd39da26eb62fa65c15ea77615a187812"
   integrity sha512-RsOPImTriV/OE4A9qKjMtk2MnXiuLLbcO3nCXK+kvq4nr0iMfFgpjaX3MPLb6f7+EL1FGSelYvuJMV6REH+ZPQ==
 
-"@types/node@*", "@types/node@>=10.0.0", "@types/node@^20.8.8":
-  version "20.8.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.8.tgz#adee050b422061ad5255fc38ff71b2bb96ea2a0e"
-  integrity sha512-YRsdVxq6OaLfmR9Hy816IMp33xOBjfyOgUd77ehqg96CFywxAPbDbXvAsuN2KVg2HOT8Eh6uAfU+l4WffwPVrQ==
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@^20.8.10":
+  version "20.8.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.10.tgz#a5448b895c753ae929c26ce85cab557c6d4a365e"
+  integrity sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==
   dependencies:
-    undici-types "~5.25.1"
+    undici-types "~5.26.4"
 
 "@types/node@^14.14.35":
   version "14.18.63"
@@ -1573,15 +1572,15 @@
     "@typescript-eslint/typescript-estree" "5.62.0"
     debug "^4.3.4"
 
-"@typescript-eslint/parser@^6.7.4":
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-6.9.0.tgz#2b402cadeadd3f211c25820e5433413347b27391"
-  integrity sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==
+"@typescript-eslint/parser@^6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-6.9.1.tgz#4f685f672f8b9580beb38d5fb99d52fc3e34f7a3"
+  integrity sha512-C7AK2wn43GSaCUZ9do6Ksgi2g3mwFkMO3Cis96kzmgudoVaKyt62yNzJOktP0HDLb/iO2O0n2lBOzJgr6Q/cyg==
   dependencies:
-    "@typescript-eslint/scope-manager" "6.9.0"
-    "@typescript-eslint/types" "6.9.0"
-    "@typescript-eslint/typescript-estree" "6.9.0"
-    "@typescript-eslint/visitor-keys" "6.9.0"
+    "@typescript-eslint/scope-manager" "6.9.1"
+    "@typescript-eslint/types" "6.9.1"
+    "@typescript-eslint/typescript-estree" "6.9.1"
+    "@typescript-eslint/visitor-keys" "6.9.1"
     debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@5.62.0":
@@ -1592,13 +1591,13 @@
     "@typescript-eslint/types" "5.62.0"
     "@typescript-eslint/visitor-keys" "5.62.0"
 
-"@typescript-eslint/scope-manager@6.9.0":
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.9.0.tgz#2626e9a7fe0e004c3e25f3b986c75f584431134e"
-  integrity sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==
+"@typescript-eslint/scope-manager@6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-6.9.1.tgz#e96afeb9a68ad1cd816dba233351f61e13956b75"
+  integrity sha512-38IxvKB6NAne3g/+MyXMs2Cda/Sz+CEpmm+KLGEM8hx/CvnSRuw51i8ukfwB/B/sESdeTGet1NH1Wj7I0YXswg==
   dependencies:
-    "@typescript-eslint/types" "6.9.0"
-    "@typescript-eslint/visitor-keys" "6.9.0"
+    "@typescript-eslint/types" "6.9.1"
+    "@typescript-eslint/visitor-keys" "6.9.1"
 
 "@typescript-eslint/type-utils@5.62.0":
   version "5.62.0"
@@ -1615,10 +1614,10 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz#258607e60effa309f067608931c3df6fed41fd2f"
   integrity sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==
 
-"@typescript-eslint/types@6.9.0":
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.9.0.tgz#86a0cbe7ac46c0761429f928467ff3d92f841098"
-  integrity sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==
+"@typescript-eslint/types@6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.9.1.tgz#a6cfc20db0fcedcb2f397ea728ef583e0ee72459"
+  integrity sha512-BUGslGOb14zUHOUmDB2FfT6SI1CcZEJYfF3qFwBeUrU6srJfzANonwRYHDpLBuzbq3HaoF2XL2hcr01c8f8OaQ==
 
 "@typescript-eslint/typescript-estree@5.62.0", "@typescript-eslint/typescript-estree@^5.55.0":
   version "5.62.0"
@@ -1633,13 +1632,13 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@6.9.0":
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.0.tgz#d0601b245be873d8fe49f3737f93f8662c8693d4"
-  integrity sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==
+"@typescript-eslint/typescript-estree@6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.1.tgz#8c77910a49a04f0607ba94d78772da07dab275ad"
+  integrity sha512-U+mUylTHfcqeO7mLWVQ5W/tMLXqVpRv61wm9ZtfE5egz7gtnmqVIw9ryh0mgIlkKk9rZLY3UHygsBSdB9/ftyw==
   dependencies:
-    "@typescript-eslint/types" "6.9.0"
-    "@typescript-eslint/visitor-keys" "6.9.0"
+    "@typescript-eslint/types" "6.9.1"
+    "@typescript-eslint/visitor-keys" "6.9.1"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -1668,12 +1667,12 @@
     "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
-"@typescript-eslint/visitor-keys@6.9.0":
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.0.tgz#cc69421c10c4ac997ed34f453027245988164e80"
-  integrity sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==
+"@typescript-eslint/visitor-keys@6.9.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.1.tgz#6753a9225a0ba00459b15d6456b9c2780b66707d"
+  integrity sha512-MUaPUe/QRLEffARsmNfmpghuQkW436DvESW+h+M52w0coICHRfD6Np9/K6PdACwnrq1HmuLl+cSPZaJmeVPkSw==
   dependencies:
-    "@typescript-eslint/types" "6.9.0"
+    "@typescript-eslint/types" "6.9.1"
     eslint-visitor-keys "^3.4.1"
 
 "@ungap/structured-clone@^1.2.0":
@@ -1853,14 +1852,14 @@ acorn-jsx@^5.3.2:
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn-walk@^8.1.1:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
-  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.0.tgz#2097665af50fd0cf7a2dfccd2b9368964e66540f"
+  integrity sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==
 
 acorn@^8.4.1, acorn@^8.7.1, acorn@^8.8.2, acorn@^8.9.0:
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
-  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
+  version "8.11.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
+  integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -2149,10 +2148,10 @@ axios-mock-adapter@^1.22.0:
     fast-deep-equal "^3.1.3"
     is-buffer "^2.0.5"
 
-axios@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.5.1.tgz#11fbaa11fc35f431193a9564109c88c1f27b585f"
-  integrity sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==
+axios@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.0.tgz#f1e5292f26b2fd5c2e66876adc5b06cdbd7d2102"
+  integrity sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==
   dependencies:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"
@@ -2492,9 +2491,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001541:
-  version "1.0.30001553"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001553.tgz#e64e7dc8fd4885cd246bb476471420beb5e474b5"
-  integrity sha512-N0ttd6TrFfuqKNi+pMgWJTb9qrdJu4JSpgPFLe/lrD19ugC6fZgF0pUewRowDwzdDnb9V41mFcdlYgl/PyKf4A==
+  version "1.0.30001559"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001559.tgz#95a982440d3d314c471db68d02664fb7536c5a30"
+  integrity sha512-cPiMKZgqgkg5LY3/ntGeLFUpi6tzddBNS58A4tnTgQw1zON7u2sZMU7SzOeVH4tj20++9ggL+V6FDOFMTaFFYA==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2848,9 +2847,9 @@ cookiejar@^2.1.4:
   integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
 core-js-compat@^3.31.0, core-js-compat@^3.33.1:
-  version "3.33.1"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.33.1.tgz#debe80464107d75419e00c2ee29f35982118ff84"
-  integrity sha512-6pYKNOgD/j/bkC5xS5IIg6bncid3rfrI42oBH1SQJbsmYPKF7rhzcFzYCcxYMmNQQ0rCEB8WqpW7QHndOggaeQ==
+  version "3.33.2"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.33.2.tgz#3ea4563bfd015ad4e4b52442865b02c62aba5085"
+  integrity sha512-axfo+wxFVxnqf8RvxTzoAlzW4gRoacrHeoFlc9n0x50+7BEyZL/Rt3hicaED1/CEd7I6tPCPVUYcJwCMO5XUYw==
   dependencies:
     browserslist "^4.22.1"
 
@@ -3151,9 +3150,9 @@ dom-serialize@^2.2.1:
     void-elements "^2.0.0"
 
 domain-browser@^4.22.0:
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-4.22.0.tgz#6ddd34220ec281f9a65d3386d267ddd35c491f9f"
-  integrity sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==
+  version "4.23.0"
+  resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-4.23.0.tgz#427ebb91efcb070f05cffdfb8a4e9a6c25f8c94b"
+  integrity sha512-ArzcM/II1wCCujdCNyQjXrAFwS4mrLh4C7DZWlaI8mdh7h3BfKdNd3bKXITfl2PT9FtfQqaGvhi1vPRQPimjGA==
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -3174,9 +3173,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.535:
-  version "1.4.566"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.566.tgz#5c5ba1d2dc895f4887043f0cc7e61798c7e5919a"
-  integrity sha512-mv+fAy27uOmTVlUULy15U3DVJ+jg+8iyKH1bpwboCRhtDC69GKf1PPTZvEIhCyDr81RFqfxZJYrbgp933a1vtg==
+  version "1.4.576"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.576.tgz#0c6940fdc0d60f7e34bd742b29d8fa847c9294d1"
+  integrity sha512-yXsZyXJfAqzWk1WKryr0Wl0MN2D47xodPvEEwlVePBnhU5E7raevLQR+E6b9JAD3GfL/7MbAL9ZtWQQPcLx7wA==
 
 elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.4"
@@ -3253,9 +3252,9 @@ entities@~2.1.0:
   integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
 envinfo@^7.7.3:
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.10.0.tgz#55146e3909cc5fe63c22da63fb15b05aeac35b13"
-  integrity sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.11.0.tgz#c3793f44284a55ff8c82faf1ffd91bc6478ea01f"
+  integrity sha512-G9/6xF1FPbIw0TtalAMaVPpiq2aDEuKLXM314jPVAO9r2fo2a4BLqMNkmRS7O/xPPZ+COAhGIz3ETvHEV3eUcg==
 
 es-abstract@^1.22.1:
   version "1.22.3"
@@ -3935,16 +3934,6 @@ fsevents@~2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
-fstream@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
-  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
-  dependencies:
-    graceful-fs "^4.1.2"
-    inherits "~2.0.0"
-    mkdirp ">=0.5 0"
-    rimraf "2"
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
@@ -4364,7 +4353,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.3, inherits@~2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5380,7 +5369,7 @@ minizlib@^2.1.1:
     minipass "^3.0.0"
     yallist "^4.0.0"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@^0.5.5:
+mkdirp@^0.5.1, mkdirp@^0.5.5:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
@@ -6031,9 +6020,9 @@ punycode@^1.4.1:
   integrity sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==
 
 punycode@^2.1.0, punycode@^2.1.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
-  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 qjobs@^1.2.0:
   version "1.2.0"
@@ -6311,13 +6300,6 @@ rfdc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
-
-rimraf@2:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
-  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
 
 rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
@@ -6680,10 +6662,10 @@ statuses@~1.5.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
-stellar-base@10.0.0-beta.3:
-  version "10.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-10.0.0-beta.3.tgz#c90e261945c58e2176b0a50b9a7b96003ecb0768"
-  integrity sha512-+B1fOdsDWJEnYSYkKSAVHVngzaqDtD8wdDMT/FC+11MrohP3uGY1OmrEeVn34jiBmUlpYZVudDnpDMSXD4RqDA==
+stellar-base@10.0.0-beta.4:
+  version "10.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-10.0.0-beta.4.tgz#818d3b5dd702a7d18f1db47a72837cec80616716"
+  integrity sha512-3EXDFHSahVDMTHrHiFOO8kFf5KN+AL4x5kd5rxjElElPG+385cyWDbO83GrNmDGU/u9/XiVL+riJjz5gQTv6RQ==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^9.1.2"
@@ -6945,9 +6927,9 @@ terser-webpack-plugin@^5.3.7, terser-webpack-plugin@^5.3.9:
     terser "^5.16.8"
 
 terser@^5.16.8:
-  version "5.22.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.22.0.tgz#4f18103f84c5c9437aafb7a14918273310a8a49d"
-  integrity sha512-hHZVLgRA2z4NWcN6aS5rQDc+7Dcy58HOf2zbYwmFcQ+ua3h6eEFf5lIDKTzbWwlazPyOZsFQO8V80/IjVNExEw==
+  version "5.24.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.24.0.tgz#4ae50302977bca4831ccc7b4fef63a3c04228364"
+  integrity sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
     acorn "^8.8.2"
@@ -7213,9 +7195,9 @@ typescript@^5.2.2:
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 ua-parser-js@^0.7.30:
-  version "0.7.36"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.36.tgz#382c5d6fc09141b6541be2cae446ecfcec284db2"
-  integrity sha512-CPPLoCts2p7D8VbybttE3P2ylv0OBZEAy7a12DsulIEcAiMtWJy+PBgMXgWDI80D5UwqE8oQPHYnk13tm38M2Q==
+  version "0.7.37"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.37.tgz#e464e66dac2d33a7a1251d7d7a99d6157ec27832"
+  integrity sha512-xV8kqRKM+jhMvcHWUKthV9fNebIzrNy//2O9ZwWcfiBFR5f25XVZPLlEajk/sf3Ra15V92isyQqnIEXRDaZWEA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -7237,10 +7219,10 @@ underscore@~1.13.2:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
-undici-types@~5.25.1:
-  version "5.25.3"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.25.3.tgz#e044115914c85f0bcbb229f346ab739f064998c3"
-  integrity sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Fixed
* The `stellar-base` library has been upgraded to `beta.4` which contains a bugfix for large sequence numbers ([#877](https://github.com/stellar/js-stellar-sdk/pull/877)).
* The `SorobanRpc.Server.getTransaction()` method will now return the full response when encountering a `FAILED` transaction result ([#872](https://github.com/stellar/js-stellar-sdk/pull/872)).
* The `SorobanRpc.Server.getEvents()` method will correctly parse the event value (which is an `xdr.ScVal` rather than an `xdr.DiagnosticEvent`, see the modified `SorobanRpc.Api.EventResponse.value`; [#876](https://github.com/stellar/js-stellar-sdk/pull/876)).