### PR TITLE
Handle events without contract IDs correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Fixed
-* The `SorobanRpc.Server.getEvents` method now correctly parses responses without a `contractId` field set. The `events[i].contractId` field on an event is now optional, omitted if there was no ID for the event (e.g. system events;  ([#TODO](https://github.com/stellar/js-stellar-sdk/pull/TODO))).
+* The `SorobanRpc.Server.getEvents` method now correctly parses responses without a `contractId` field set. The `events[i].contractId` field on an event is now optional, omitted if there was no ID for the event (e.g. system events;  ([#883](https://github.com/stellar/js-stellar-sdk/pull/883))).
 
 
 ## [v11.0.0-beta.6](https://github.com/stellar/js-stellar-sdk/compare/v11.0.0-beta.5...v11.0.0-beta.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Fixed
+* The `SorobanRpc.Server.getEvents` method now correctly parses responses without a `contractId` field set. The `events[i].contractId` field on an event is now optional, omitted if there was no ID for the event (e.g. system events;  ([#TODO](https://github.com/stellar/js-stellar-sdk/pull/TODO))).
+
 
 ## [v11.0.0-beta.6](https://github.com/stellar/js-stellar-sdk/compare/v11.0.0-beta.5...v11.0.0-beta.6)
 

--- a/src/soroban/api.ts
+++ b/src/soroban/api.ts
@@ -152,7 +152,7 @@ export namespace Api {
   }
 
   interface EventResponse extends BaseEventResponse {
-    contractId: Contract;
+    contractId?: Contract;
     topic: xdr.ScVal[];
     value: xdr.ScVal;
   }
@@ -171,7 +171,7 @@ export namespace Api {
     inSuccessfulContractCall: boolean;
   }
 
-  interface RawEventResponse extends BaseEventResponse {
+  export interface RawEventResponse extends BaseEventResponse {
     contractId: string;
     topic: string[];
     value: {

--- a/src/soroban/parsers.ts
+++ b/src/soroban/parsers.ts
@@ -23,17 +23,16 @@ export function parseRawEvents(
   return {
     latestLedger: r.latestLedger,
     events: (r.events ?? []).map((evt) => {
+      const clone: Omit<Api.RawEventResponse, 'contractId'> = { ...evt };
+      delete (clone as any).contractId; // `as any` hack because contractId field isn't optional
+
       // the contractId may be empty so we omit the field in that case
-      const cid = evt.contractId;
-      delete (evt as any).contractId;
-      const rv = {
-        ...evt as Omit<Api.RawEventResponse, 'contractId'>,
-        ...(cid !== '' && { contractId: new Contract(cid) }),
+      return {
+        ...clone,
+        ...(evt.contractId !== '' && { contractId: new Contract(evt.contractId) }),
         topic: evt.topic.map((topic) => xdr.ScVal.fromXDR(topic, 'base64')),
         value: xdr.ScVal.fromXDR(evt.value.xdr, 'base64')
       };
-      evt.contractId = cid; // put value back after parsing
-      return rv;
     })
   };
 }

--- a/src/soroban/parsers.ts
+++ b/src/soroban/parsers.ts
@@ -23,12 +23,17 @@ export function parseRawEvents(
   return {
     latestLedger: r.latestLedger,
     events: (r.events ?? []).map((evt) => {
-      return {
-        ...evt,
-        contractId: new Contract(evt.contractId),
+      // the contractId may be empty so we omit the field in that case
+      const cid = evt.contractId;
+      delete (evt as any).contractId;
+      const rv = {
+        ...evt as Omit<Api.RawEventResponse, 'contractId'>,
+        ...(cid !== '' && { contractId: new Contract(cid) }),
         topic: evt.topic.map((topic) => xdr.ScVal.fromXDR(topic, 'base64')),
         value: xdr.ScVal.fromXDR(evt.value.xdr, 'base64')
       };
+      evt.contractId = cid; // put value back after parsing
+      return rv;
     })
   };
 }

--- a/test/unit/contract_spec.js
+++ b/test/unit/contract_spec.js
@@ -6,239 +6,251 @@ const publicKey = "GCBVOLOM32I7OD5TWZQCIXCXML3TK56MDY7ZMTAILIBQHHKPCVU42XYW";
 const addr = Address.fromString(publicKey);
 let SPEC;
 before(() => {
-    SPEC = new ContractSpec(spec);
+  SPEC = new ContractSpec(spec);
 });
 it("throws if no entries", () => {
-    expect(() => new ContractSpec([])).to.throw(/Contract spec must have at least one entry/i);
+  expect(() => new ContractSpec([])).to.throw(
+    /Contract spec must have at least one entry/i,
+  );
 });
 describe("Can round trip custom types", function () {
-    function getResultType(funcName) {
-        let fn = SPEC.findEntry(funcName).value();
-        if (!(fn instanceof xdr.ScSpecFunctionV0)) {
-            throw new Error("Not a function");
-        }
-        if (fn.outputs().length === 0) {
-            return xdr.ScSpecTypeDef.scSpecTypeVoid();
-        }
-        return fn.outputs()[0];
+  function getResultType(funcName) {
+    let fn = SPEC.findEntry(funcName).value();
+    if (!(fn instanceof xdr.ScSpecFunctionV0)) {
+      throw new Error("Not a function");
     }
-    function roundtrip(funcName, input, typeName) {
-        let type = getResultType(funcName);
-        let ty = typeName ?? funcName;
-        let obj = {};
-        obj[ty] = input;
-        let scVal = SPEC.funcArgsToScVals(funcName, obj)[0];
-        let result = SPEC.scValToNative(scVal, type);
-        expect(result).deep.equal(input);
+    if (fn.outputs().length === 0) {
+      return xdr.ScSpecTypeDef.scSpecTypeVoid();
     }
-    it("u32", () => {
-        roundtrip("u32_", 1);
+    return fn.outputs()[0];
+  }
+  function roundtrip(funcName, input, typeName) {
+    let type = getResultType(funcName);
+    let ty = typeName ?? funcName;
+    let obj = {};
+    obj[ty] = input;
+    let scVal = SPEC.funcArgsToScVals(funcName, obj)[0];
+    let result = SPEC.scValToNative(scVal, type);
+    expect(result).deep.equal(input);
+  }
+  it("u32", () => {
+    roundtrip("u32_", 1);
+  });
+  it("i32", () => {
+    roundtrip("i32_", -1);
+  });
+  it("i64", () => {
+    roundtrip("i64_", 1n);
+  });
+  it("strukt", () => {
+    roundtrip("strukt", { a: 0, b: true, c: "hello" });
+  });
+  describe("simple", () => {
+    it("first", () => {
+      const simple = { tag: "First", values: undefined };
+      roundtrip("simple", simple);
     });
-    it("i32", () => {
-        roundtrip("i32_", -1);
+    it("simple second", () => {
+      const simple = { tag: "Second", values: undefined };
+      roundtrip("simple", simple);
     });
-    it("i64", () => {
-        roundtrip("i64_", 1n);
+    it("simple third", () => {
+      const simple = { tag: "Third", values: undefined };
+      roundtrip("simple", simple);
     });
-    it("strukt", () => {
-        roundtrip("strukt", { a: 0, b: true, c: "hello" });
-    });
-    describe("simple", () => {
-        it("first", () => {
-            const simple = { tag: "First", values: undefined };
-            roundtrip("simple", simple);
-        });
-        it("simple second", () => {
-            const simple = { tag: "Second", values: undefined };
-            roundtrip("simple", simple);
-        });
-        it("simple third", () => {
-            const simple = { tag: "Third", values: undefined };
-            roundtrip("simple", simple);
-        });
-    });
-    describe("complex", () => {
-        it("struct", () => {
-            const complex = {
-                tag: "Struct",
-                values: [{ a: 0, b: true, c: "hello" }],
-            };
-            roundtrip("complex", complex);
-        });
-        it("tuple", () => {
-            const complex = {
-                tag: "Tuple",
-                values: [
-                    [
-                        { a: 0, b: true, c: "hello" },
-                        { tag: "First", values: undefined },
-                    ],
-                ],
-            };
-            roundtrip("complex", complex);
-        });
-        it("enum", () => {
-            const complex = {
-                tag: "Enum",
-                values: [{ tag: "First", values: undefined }],
-            };
-            roundtrip("complex", complex);
-        });
-        it("asset", () => {
-            const complex = { tag: "Asset", values: [addr, 1n] };
-            roundtrip("complex", complex);
-        });
-        it("void", () => {
-            const complex = { tag: "Void", values: undefined };
-            roundtrip("complex", complex);
-        });
-    });
-    it("addresse", () => {
-        roundtrip("addresse", addr);
-    });
-    it("bytes", () => {
-        const bytes = Buffer.from("hello");
-        roundtrip("bytes", bytes);
-    });
-    it("bytes_n", () => {
-        const bytes_n = Buffer.from("123456789"); // what's the correct way to construct bytes_n?
-        roundtrip("bytes_n", bytes_n);
-    });
-    it("card", () => {
-        const card = 11;
-        roundtrip("card", card);
-    });
-    it("boolean", () => {
-        roundtrip("boolean", true);
-    });
-    it("not", () => {
-        roundtrip("boolean", false);
-    });
-    it("i128", () => {
-        roundtrip("i128", -1n);
-    });
-    it("u128", () => {
-        roundtrip("u128", 1n);
-    });
-    it("map", () => {
-        const map = new Map();
-        map.set(1, true);
-        map.set(2, false);
-        roundtrip("map", map);
-        map.set(3, "hahaha");
-        expect(() => roundtrip("map", map)).to.throw(/invalid type scSpecTypeBool specified for string value/i);
-    });
-    it("vec", () => {
-        const vec = [1, 2, 3];
-        roundtrip("vec", vec);
+  });
+  describe("complex", () => {
+    it("struct", () => {
+      const complex = {
+        tag: "Struct",
+        values: [{ a: 0, b: true, c: "hello" }],
+      };
+      roundtrip("complex", complex);
     });
     it("tuple", () => {
-        const tuple = ["hello", 1];
-        roundtrip("tuple", tuple);
-    });
-    it("option", () => {
-        roundtrip("option", 1);
-        roundtrip("option", undefined);
-    });
-    it("u256", () => {
-        roundtrip("u256", 1n);
-        expect(() => roundtrip("u256", -1n)).to.throw(/expected a positive value, got: -1/i);
-    });
-    it("i256", () => {
-        roundtrip("i256", -1n);
-    });
-    it("string", () => {
-        roundtrip("string", "hello");
-    });
-    it("tuple_strukt", () => {
-        const arg = [
+      const complex = {
+        tag: "Tuple",
+        values: [
+          [
             { a: 0, b: true, c: "hello" },
             { tag: "First", values: undefined },
-        ];
-        roundtrip("tuple_strukt", arg);
+          ],
+        ],
+      };
+      roundtrip("complex", complex);
     });
+    it("enum", () => {
+      const complex = {
+        tag: "Enum",
+        values: [{ tag: "First", values: undefined }],
+      };
+      roundtrip("complex", complex);
+    });
+    it("asset", () => {
+      const complex = { tag: "Asset", values: [addr, 1n] };
+      roundtrip("complex", complex);
+    });
+    it("void", () => {
+      const complex = { tag: "Void", values: undefined };
+      roundtrip("complex", complex);
+    });
+  });
+  it("addresse", () => {
+    roundtrip("addresse", addr);
+  });
+  it("bytes", () => {
+    const bytes = Buffer.from("hello");
+    roundtrip("bytes", bytes);
+  });
+  it("bytes_n", () => {
+    const bytes_n = Buffer.from("123456789"); // what's the correct way to construct bytes_n?
+    roundtrip("bytes_n", bytes_n);
+  });
+  it("card", () => {
+    const card = 11;
+    roundtrip("card", card);
+  });
+  it("boolean", () => {
+    roundtrip("boolean", true);
+  });
+  it("not", () => {
+    roundtrip("boolean", false);
+  });
+  it("i128", () => {
+    roundtrip("i128", -1n);
+  });
+  it("u128", () => {
+    roundtrip("u128", 1n);
+  });
+  it("map", () => {
+    const map = new Map();
+    map.set(1, true);
+    map.set(2, false);
+    roundtrip("map", map);
+    map.set(3, "hahaha");
+    expect(() => roundtrip("map", map)).to.throw(
+      /invalid type scSpecTypeBool specified for string value/i,
+    );
+  });
+  it("vec", () => {
+    const vec = [1, 2, 3];
+    roundtrip("vec", vec);
+  });
+  it("tuple", () => {
+    const tuple = ["hello", 1];
+    roundtrip("tuple", tuple);
+  });
+  it("option", () => {
+    roundtrip("option", 1);
+    roundtrip("option", undefined);
+  });
+  it("u256", () => {
+    roundtrip("u256", 1n);
+    expect(() => roundtrip("u256", -1n)).to.throw(
+      /expected a positive value, got: -1/i,
+    );
+  });
+  it("i256", () => {
+    roundtrip("i256", -1n);
+  });
+  it("string", () => {
+    roundtrip("string", "hello");
+  });
+  it("tuple_strukt", () => {
+    const arg = [
+      { a: 0, b: true, c: "hello" },
+      { tag: "First", values: undefined },
+    ];
+    roundtrip("tuple_strukt", arg);
+  });
 });
 describe("parsing and building ScVals", function () {
-    it("Can parse entries", function () {
-        let spec = new ContractSpec([GIGA_MAP, func]);
-        let fn = spec.findEntry("giga_map");
-        let gigaMap = spec.findEntry("GigaMap");
-        expect(gigaMap).deep.equal(GIGA_MAP);
-        expect(fn).deep.equal(func);
-    });
+  it("Can parse entries", function () {
+    let spec = new ContractSpec([GIGA_MAP, func]);
+    let fn = spec.findEntry("giga_map");
+    let gigaMap = spec.findEntry("GigaMap");
+    expect(gigaMap).deep.equal(GIGA_MAP);
+    expect(fn).deep.equal(func);
+  });
 });
-export const GIGA_MAP = xdr.ScSpecEntry.scSpecEntryUdtStructV0(new xdr.ScSpecUdtStructV0({
+export const GIGA_MAP = xdr.ScSpecEntry.scSpecEntryUdtStructV0(
+  new xdr.ScSpecUdtStructV0({
     doc: "This is a kitchen sink of all the types",
     lib: "",
     name: "GigaMap",
     fields: [
-        new xdr.ScSpecUdtStructFieldV0({
-            doc: "",
-            name: "bool",
-            type: xdr.ScSpecTypeDef.scSpecTypeBool(),
-        }),
-        new xdr.ScSpecUdtStructFieldV0({
-            doc: "",
-            name: "i128",
-            type: xdr.ScSpecTypeDef.scSpecTypeI128(),
-        }),
-        new xdr.ScSpecUdtStructFieldV0({
-            doc: "",
-            name: "u128",
-            type: xdr.ScSpecTypeDef.scSpecTypeU128(),
-        }),
-        new xdr.ScSpecUdtStructFieldV0({
-            doc: "",
-            name: "i256",
-            type: xdr.ScSpecTypeDef.scSpecTypeI256(),
-        }),
-        new xdr.ScSpecUdtStructFieldV0({
-            doc: "",
-            name: "u256",
-            type: xdr.ScSpecTypeDef.scSpecTypeU256(),
-        }),
-        new xdr.ScSpecUdtStructFieldV0({
-            doc: "",
-            name: "i32",
-            type: xdr.ScSpecTypeDef.scSpecTypeI32(),
-        }),
-        new xdr.ScSpecUdtStructFieldV0({
-            doc: "",
-            name: "u32",
-            type: xdr.ScSpecTypeDef.scSpecTypeU32(),
-        }),
-        new xdr.ScSpecUdtStructFieldV0({
-            doc: "",
-            name: "i64",
-            type: xdr.ScSpecTypeDef.scSpecTypeI64(),
-        }),
-        new xdr.ScSpecUdtStructFieldV0({
-            doc: "",
-            name: "u64",
-            type: xdr.ScSpecTypeDef.scSpecTypeU64(),
-        }),
-        new xdr.ScSpecUdtStructFieldV0({
-            doc: "",
-            name: "symbol",
-            type: xdr.ScSpecTypeDef.scSpecTypeSymbol(),
-        }),
-        new xdr.ScSpecUdtStructFieldV0({
-            doc: "",
-            name: "string",
-            type: xdr.ScSpecTypeDef.scSpecTypeString(),
-        }),
+      new xdr.ScSpecUdtStructFieldV0({
+        doc: "",
+        name: "bool",
+        type: xdr.ScSpecTypeDef.scSpecTypeBool(),
+      }),
+      new xdr.ScSpecUdtStructFieldV0({
+        doc: "",
+        name: "i128",
+        type: xdr.ScSpecTypeDef.scSpecTypeI128(),
+      }),
+      new xdr.ScSpecUdtStructFieldV0({
+        doc: "",
+        name: "u128",
+        type: xdr.ScSpecTypeDef.scSpecTypeU128(),
+      }),
+      new xdr.ScSpecUdtStructFieldV0({
+        doc: "",
+        name: "i256",
+        type: xdr.ScSpecTypeDef.scSpecTypeI256(),
+      }),
+      new xdr.ScSpecUdtStructFieldV0({
+        doc: "",
+        name: "u256",
+        type: xdr.ScSpecTypeDef.scSpecTypeU256(),
+      }),
+      new xdr.ScSpecUdtStructFieldV0({
+        doc: "",
+        name: "i32",
+        type: xdr.ScSpecTypeDef.scSpecTypeI32(),
+      }),
+      new xdr.ScSpecUdtStructFieldV0({
+        doc: "",
+        name: "u32",
+        type: xdr.ScSpecTypeDef.scSpecTypeU32(),
+      }),
+      new xdr.ScSpecUdtStructFieldV0({
+        doc: "",
+        name: "i64",
+        type: xdr.ScSpecTypeDef.scSpecTypeI64(),
+      }),
+      new xdr.ScSpecUdtStructFieldV0({
+        doc: "",
+        name: "u64",
+        type: xdr.ScSpecTypeDef.scSpecTypeU64(),
+      }),
+      new xdr.ScSpecUdtStructFieldV0({
+        doc: "",
+        name: "symbol",
+        type: xdr.ScSpecTypeDef.scSpecTypeSymbol(),
+      }),
+      new xdr.ScSpecUdtStructFieldV0({
+        doc: "",
+        name: "string",
+        type: xdr.ScSpecTypeDef.scSpecTypeString(),
+      }),
     ],
-}));
-const GIGA_MAP_TYPE = xdr.ScSpecTypeDef.scSpecTypeUdt(new xdr.ScSpecTypeUdt({ name: "GigaMap" }));
-let func = xdr.ScSpecEntry.scSpecEntryFunctionV0(new xdr.ScSpecFunctionV0({
+  }),
+);
+const GIGA_MAP_TYPE = xdr.ScSpecTypeDef.scSpecTypeUdt(
+  new xdr.ScSpecTypeUdt({ name: "GigaMap" }),
+);
+let func = xdr.ScSpecEntry.scSpecEntryFunctionV0(
+  new xdr.ScSpecFunctionV0({
     doc: "Kitchen Sink",
     name: "giga_map",
     inputs: [
-        new xdr.ScSpecFunctionInputV0({
-            doc: "",
-            name: "giga_map",
-            type: GIGA_MAP_TYPE,
-        }),
+      new xdr.ScSpecFunctionInputV0({
+        doc: "",
+        name: "giga_map",
+        type: GIGA_MAP_TYPE,
+      }),
     ],
     outputs: [GIGA_MAP_TYPE],
-}));
+  }),
+);

--- a/test/unit/server/soroban/get_events_test.js
+++ b/test/unit/server/soroban/get_events_test.js
@@ -239,7 +239,7 @@ let getEventsResponseFixture = [
     type: "system",
     ledger: "1",
     ledgerClosedAt: "2022-11-16T16:10:41Z",
-    contractId,
+    contractId: '',
     id: "0164090849041387521-0000000003",
     pagingToken: "164090849041387521-3",
     inSuccessfulContractCall: true,

--- a/test/unit/server/soroban/get_events_test.js
+++ b/test/unit/server/soroban/get_events_test.js
@@ -67,6 +67,7 @@ describe("Server#getEvents", function () {
       })
       .then(function (response) {
         expect(response).to.be.deep.equal(parseEvents(result));
+        expect(response.events[0].contractId).to.be.undefined;
         done();
       })
       .catch(done);
@@ -239,7 +240,7 @@ let getEventsResponseFixture = [
     type: "system",
     ledger: "1",
     ledgerClosedAt: "2022-11-16T16:10:41Z",
-    contractId: '',
+    contractId: "",
     id: "0164090849041387521-0000000003",
     pagingToken: "164090849041387521-3",
     inSuccessfulContractCall: true,


### PR DESCRIPTION
As reported [on Discord](https://discord.com/channels/897514728459468821/966788672164855829/1178514050204848239) and confirmed by an example in the [docs](https://soroban.stellar.org/api/methods/getEvents), the `SorobanRpc.Server.getEvents` method will fail when the event response contains an empty contract ID. There was an implicit assumption in the code that it would always be present and valid, but in fact it can sometimes be empty.

This modifies the `parseRawEvents` code to omit the `contractId` field from the parsed response.