### PR TITLE
Extend `.payments()` call builder to encompass add'l non-payment types

### DIFF
--- a/src/horizon/payment_call_builder.ts
+++ b/src/horizon/payment_call_builder.ts
@@ -5,13 +5,19 @@ import { ServerApi } from "./server_api";
  * Creates a new {@link PaymentCallBuilder} pointed to server defined by serverUrl.
  *
  * Do not create this object directly, use {@link Server#payments}.
- * @see [All Payments](https://developers.stellar.org/api/resources/payments/)
+ * @see [All Payments](https://developers.stellar.org/api/horizon/resources/list-all-payments/)
  * @constructor
  * @extends CallBuilder
  * @param {string} serverUrl Horizon server URL.
  */
 export class PaymentCallBuilder extends CallBuilder<
-  ServerApi.CollectionPage<ServerApi.PaymentOperationRecord>
+  ServerApi.CollectionPage<
+    | ServerApi.PaymentOperationRecord
+    | ServerApi.CreateAccountOperationRecord
+    | ServerApi.AccountMergeOperationRecord
+    | ServerApi.PathPaymentOperationRecord
+    | ServerApi.PathPaymentStrictSendOperationRecord
+  >
 > {
   constructor(serverUrl: URI) {
     super(serverUrl, "payments");
@@ -20,7 +26,7 @@ export class PaymentCallBuilder extends CallBuilder<
 
   /**
    * This endpoint responds with a collection of Payment operations where the given account was either the sender or receiver.
-   * @see [Payments for Account](https://developers.stellar.org/api/resources/accounts/payments/)
+   * @see [Payments for Account](https://developers.stellar.org/api/horizon/resources/get-payments-by-account-id)
    * @param {string} accountId For example: `GDGQVOKHW4VEJRU2TETD6DBRKEO5ERCNF353LW5WBFW3JJWQ2BRQ6KDD`
    * @returns {PaymentCallBuilder} this PaymentCallBuilder instance
    */
@@ -30,7 +36,7 @@ export class PaymentCallBuilder extends CallBuilder<
 
   /**
    * This endpoint represents all payment operations that are part of a valid transactions in a given ledger.
-   * @see [Payments for Ledger](https://developers.stellar.org/api/resources/ledgers/payments/)
+   * @see [Payments for Ledger](https://developers.stellar.org/api/horizon/resources/retrieve-a-ledgers-payments)
    * @param {number|string} sequence Ledger sequence
    * @returns {PaymentCallBuilder} this PaymentCallBuilder instance
    */


### PR DESCRIPTION
As described by the [docs](https://developers.stellar.org/api/horizon/resources/list-all-payments), the `/payments` endpoint returns a _collection_ of operations rather than, specifically, the Payment Operation:

> Operations that can be returned by this endpoint include: create_account, payment, path_payment_strict_recieve, path_payment_strict_send, and account_merge.

This PR expands the types to the `PaymentCallBuilder` accordingly.

Note that **this is a breaking change**, because anyone using this call builder will now need to either cast the returned records or handle all of the variations.