### PR TITLE
fix GetEventsRequest property type

### DIFF
--- a/src/soroban/server.ts
+++ b/src/soroban/server.ts
@@ -35,7 +35,7 @@ export namespace Server {
   /** Describes the complex filter combinations available for event queries. */
   export interface GetEventsRequest {
     filters: Api.EventFilter[];
-    startLedger?: number; // either this or cursor
+    startLedger?: string; // either this or cursor
     cursor?: string; // either this or startLedger
     limit?: number;
   }


### PR DESCRIPTION
Fix issue reported in https://github.com/stellar/js-stellar-sdk/issues/893

**WHAT:**
RPC calls to getEvents fail with:

```
[UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason 
"#<Object>".] {
  code: 'ERR_UNHANDLED_REJECTION'
}
```

**WHY:**
Testing further we could find the root cause for the issue.

https://github.com/stellar/js-stellar-sdk/blob/dc07e03b7ec06b9443999a9e55e76354c35b8c31/src/soroban/server.ts#L38

The parameter `startLedger`  under `GetEventsRequest ` is set as a number, while the getEvents expects it to be stringified. See [this doc](https://soroban.stellar.org/api/methods/getEvents) for reference.

Forcing the parameter as a string, fixes the issue and returns the correct output from the RPC server.

=============

Update: Refer to issue, this change is not relevant as the switch to number was a deliberate modification due to the newer RPC build
