### PR TITLE
Support resource leeway parameter when simulating Soroban transactions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 A breaking change will get clearly marked in this log.
 
 
+## Unreleased
+
+### Added
+* `SorobanRpc.Server.simulateTransaction` now supports an optional `addlResources` parameter to allow users to specify additional resources that they want to include in a simulation ([TODO]()).
+
+
 ## [v11.0.1](https://github.com/stellar/js-stellar-sdk/compare/v10.2.1...v11.0.0)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Added
-* `SorobanRpc.Server.simulateTransaction` now supports an optional `addlResources` parameter to allow users to specify additional resources that they want to include in a simulation ([TODO]()).
+* `SorobanRpc.Server.simulateTransaction` now supports an optional `addlResources` parameter to allow users to specify additional resources that they want to include in a simulation ([#896](https://github.com/stellar/js-stellar-sdk/pull/896)).
 
 
 ## [v11.0.1](https://github.com/stellar/js-stellar-sdk/compare/v10.2.1...v11.0.0)

--- a/src/soroban/server.ts
+++ b/src/soroban/server.ts
@@ -40,15 +40,16 @@ export namespace Server {
     limit?: number;
   }
 
+  /** Describes additional resource leeways for transaction simulation. */
+  export interface SimulationResources {
+    cpuInstructions: number;
+  }
+
   export interface Options {
     allowHttp?: boolean;
     timeout?: number;
     headers?: Record<string, string>;
   }
-}
-
-export interface SimulationResources {
-  cpuInstructions: number;
 }
 
 /**
@@ -492,7 +493,7 @@ export class Server {
    */
   public async simulateTransaction(
     tx: Transaction | FeeBumpTransaction,
-    addlResources?: SimulationResources
+    addlResources?: Server.SimulationResources
   ): Promise<Api.SimulateTransactionResponse> {
     return this._simulateTransaction(tx, addlResources)
       .then(parseRawSimulation);
@@ -500,7 +501,7 @@ export class Server {
 
   public async _simulateTransaction(
     transaction: Transaction | FeeBumpTransaction,
-    addlResources?: SimulationResources
+    addlResources?: Server.SimulationResources
   ): Promise<Api.RawSimulateTransactionResponse> {
     return jsonrpc.postObject(
       this.serverURL.toString(),

--- a/src/soroban/server.ts
+++ b/src/soroban/server.ts
@@ -41,7 +41,7 @@ export namespace Server {
   }
 
   /** Describes additional resource leeways for transaction simulation. */
-  export interface SimulationResources {
+  export interface ResourceLeeway {
     cpuInstructions: number;
   }
 
@@ -493,7 +493,7 @@ export class Server {
    */
   public async simulateTransaction(
     tx: Transaction | FeeBumpTransaction,
-    addlResources?: Server.SimulationResources
+    addlResources?: Server.ResourceLeeway
   ): Promise<Api.SimulateTransactionResponse> {
     return this._simulateTransaction(tx, addlResources)
       .then(parseRawSimulation);
@@ -501,7 +501,7 @@ export class Server {
 
   public async _simulateTransaction(
     transaction: Transaction | FeeBumpTransaction,
-    addlResources?: Server.SimulationResources
+    addlResources?: Server.ResourceLeeway
   ): Promise<Api.RawSimulateTransactionResponse> {
     return jsonrpc.postObject(
       this.serverURL.toString(),

--- a/test/unit/server/soroban/simulate_transaction_test.js
+++ b/test/unit/server/soroban/simulate_transaction_test.js
@@ -81,7 +81,9 @@ describe("Server#simulateTransaction", async function (done) {
         jsonrpc: "2.0",
         id: 1,
         method: "simulateTransaction",
-        params: [this.blob],
+        params: {
+          transaction: this.blob
+        }
       })
       .returns(
         Promise.resolve({ data: { id: 1, result: simulationResponse } }),
@@ -89,6 +91,33 @@ describe("Server#simulateTransaction", async function (done) {
 
     this.server
       .simulateTransaction(this.transaction)
+      .then(function (response) {
+        expect(response).to.be.deep.equal(parsedSimulationResponse);
+        done();
+      })
+      .catch(function (err) {
+        done(err);
+      });
+  });
+
+  it("simulates a transaction with add'l resource usage", function (done) {
+    this.axiosMock
+      .expects("post")
+      .withArgs(serverUrl, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "simulateTransaction",
+        params: {
+          transaction: this.blob,
+          resourceConfig: { instructionLeeway: 100 }
+        }
+      })
+      .returns(
+        Promise.resolve({ data: { id: 1, result: simulationResponse } }),
+      );
+
+    this.server
+      .simulateTransaction(this.transaction, { cpuInstructions: 100 })
       .then(function (response) {
         expect(response).to.be.deep.equal(parsedSimulationResponse);
         done();


### PR DESCRIPTION
### What
This adds an optional `addlResources` parameter to the Soroban RPC's `simulateTransaction` method which lets users specify an additional leeway for CPU instruction usage in their transaction simulation:

```typescript
interface SimulationResources {
  cpuInstructions: number;
}
```

### Why
The Soroban RPC server introduced this optional feature as part of the (pending) v20.1.0 (see https://github.com/stellar/soroban-tools/pull/1131).

This additionally fixes https://github.com/stellar/js-stellar-sdk/issues/895.