### PR TITLE
Export the individual event response instance

### DIFF
--- a/src/soroban/api.ts
+++ b/src/soroban/api.ts
@@ -148,7 +148,7 @@ export namespace Api {
     events: EventResponse[];
   }
 
-  interface EventResponse extends BaseEventResponse {
+  export interface EventResponse extends BaseEventResponse {
     contractId?: Contract;
     topic: xdr.ScVal[];
     value: xdr.ScVal;


### PR DESCRIPTION
So that devs can use the type reliably in their code.