### PR TITLE
Add support for new `sendTransaction` response field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Added
+* Support for the new, optional `diagnosticEventsXdr` field on the `SorobanRpc.Server.sendTransaction` method. The raw field will be present when using the `_sendTransaction` method, while the normal method will have an already-parsed `diagnosticEvents: xdr.DiagnosticEvent[]` field, instead ([]()).
+* A new exported interface `SorobanRpc.Api.EventResponse` so that developers can type-check individual events ([#904](https://github.com/stellar/js-stellar-sdk/pull/904)).
+
 
 ## [v11.1.0](https://github.com/stellar/js-stellar-sdk/compare/v11.0.1...v11.1.0)
 

--- a/src/soroban/api.ts
+++ b/src/soroban/api.ts
@@ -186,6 +186,7 @@ export namespace Api {
 
   export interface SendTransactionResponse extends BaseSendTransactionResponse {
     errorResult?: xdr.TransactionResult;
+    diagnosticEvents?: xdr.DiagnosticEvent[];
   }
 
   export interface RawSendTransactionResponse

--- a/src/soroban/api.ts
+++ b/src/soroban/api.ts
@@ -197,6 +197,12 @@ export namespace Api {
      * It contains details on why the network rejected the transaction.
      */
     errorResultXdr?: string;
+    /**
+     * This is a base64-encoded instance of an array of
+     * {@link xdr.DiagnosticEvent}s, set only when `status` is `"ERROR"` and
+     * diagnostic events are enabled on the server.
+     */
+    diagnosticEventsXdr?: string[];
   }
 
   export interface BaseSendTransactionResponse {

--- a/src/soroban/parsers.ts
+++ b/src/soroban/parsers.ts
@@ -4,21 +4,22 @@ import { Api } from './api';
 export function parseRawSendTransaction(
   r: Api.RawSendTransactionResponse
 ): Api.SendTransactionResponse {
-  const errResult = r.errorResultXdr;
+  const { errorResultXdr, diagnosticEventsXdr } = r;
   delete r.errorResultXdr;
-
-  const diagEvents = r.diagnosticEventsXdr;
   delete r.diagnosticEventsXdr;
 
-  if (!!errResult) {
+  if (!!errorResultXdr) {
     return {
       ...r,
-      ...(diagEvents !== undefined && diagEvents.length > 0 && {
-        diagnosticEvents: diagEvents.map(
-          evt => xdr.DiagnosticEvent.fromXDR(evt, 'base64')
-        )
-      }),
-      errorResult: xdr.TransactionResult.fromXDR(errResult, 'base64'),
+      ...(
+        diagnosticEventsXdr !== undefined &&
+        diagnosticEventsXdr.length > 0 && {
+          diagnosticEvents: diagnosticEventsXdr.map(
+            evt => xdr.DiagnosticEvent.fromXDR(evt, 'base64')
+          )
+        }
+      ),
+      errorResult: xdr.TransactionResult.fromXDR(errorResultXdr, 'base64'),
     };
   }
 

--- a/src/soroban/parsers.ts
+++ b/src/soroban/parsers.ts
@@ -7,10 +7,18 @@ export function parseRawSendTransaction(
   const errResult = r.errorResultXdr;
   delete r.errorResultXdr;
 
+  const diagEvents = r.diagnosticEventsXdr;
+  delete r.diagnosticEventsXdr;
+
   if (!!errResult) {
     return {
       ...r,
-      errorResult: xdr.TransactionResult.fromXDR(errResult, 'base64')
+      ...(diagEvents !== undefined && diagEvents.length > 0 && {
+        diagnosticEvents: diagEvents.map(
+          evt => xdr.DiagnosticEvent.fromXDR(evt, 'base64')
+        )
+      }),
+      errorResult: xdr.TransactionResult.fromXDR(errResult, 'base64'),
     };
   }
 

--- a/test/unit/server/soroban/send_transaction_test.js
+++ b/test/unit/server/soroban/send_transaction_test.js
@@ -96,7 +96,7 @@ describe("Server#sendTransaction", function () {
         }),
       );
 
-      this.server
+    this.server
       .sendTransaction(this.transaction)
       .then(function (r) {
         expect(r.errorResult).to.be.instanceOf(xdr.TransactionResult);

--- a/test/unit/server/soroban/send_transaction_test.js
+++ b/test/unit/server/soroban/send_transaction_test.js
@@ -52,7 +52,12 @@ describe("Server#sendTransaction", function () {
 
     this.server
       .sendTransaction(this.transaction)
-      .then(function () {
+      .then(function (r) {
+        expect(r.status).to.eql("PENDING");
+        expect(r.errorResult).to.be.undefined;
+        expect(r.errorResultXdr).to.be.undefined;
+        expect(r.diagnosticEvents).to.be.undefined;
+        expect(r.diagnosticEventsXdr).to.be.undefined;
         done();
       })
       .catch(function (err) {

--- a/test/unit/server/soroban/send_transaction_test.js
+++ b/test/unit/server/soroban/send_transaction_test.js
@@ -83,17 +83,23 @@ describe("Server#sendTransaction", function () {
               id: this.hash,
               status: "ERROR",
               errorResultXdr: txResult.toXDR("base64"),
+              diagnosticEventsXdr: [
+                "AAAAAQAAAAAAAAAAAAAAAgAAAAAAAAADAAAADwAAAAdmbl9jYWxsAAAAAA0AAAAgr/p6gt6h8MrmSw+WNJnu3+sCP9dHXx7jR8IH0sG6Cy0AAAAPAAAABWhlbGxvAAAAAAAADwAAAAVBbG9oYQAAAA==",
+              ],
             },
           },
         }),
       );
 
-    this.server
+      this.server
       .sendTransaction(this.transaction)
       .then(function (r) {
         expect(r.errorResult).to.be.instanceOf(xdr.TransactionResult);
         expect(r.errorResult).to.eql(txResult);
         expect(r.errorResultXdr).to.be.undefined;
+        expect(r.diagnosticEventsXdr).to.be.undefined;
+        expect(r.diagnosticEvents).to.have.lengthOf(1);
+        expect(r.diagnosticEvents[0]).to.be.instanceOf(xdr.DiagnosticEvent);
 
         done();
       })


### PR DESCRIPTION
Related:
 * https://github.com/stellar/soroban-tools/pull/1152
 * https://gist.github.com/Shaptic/d7181cf634b4495d750ed6065b67d38c

Closes #903. 