### PR TITLE
Improvement on buildChallengeTx without webAuthDomain

### DIFF
--- a/src/webauth/utils.ts
+++ b/src/webauth/utils.ts
@@ -99,13 +99,16 @@ export function buildChallengeTx(
         source: clientAccountID,
       }),
     )
-    .addOperation(
+
+  if (webAuthDomain) {
+    builder.addOperation(
       Operation.manageData({
         name: "web_auth_domain",
         value: webAuthDomain,
         source: account.accountId(),
       }),
     );
+  }
 
   if (clientDomain) {
     if (!clientSigningKey) {


### PR DESCRIPTION
**What**
This omits webAuthDomain when create a challenge without this field
  **Consideration** this field `webAuthDomain` is optional in `buildChallengeTx` function

**Why**
If we create an Challenge with `web_auth_domain=null`, so this element is when is used to authenticate, throw a follow Error:
`InvalidChallengeError: 'web_auth_domain' operation value should not be null`
