### PR TITLE
Fix TypeScript Issue by Eliminating 'utility-types' Dependency from stellar-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "terser-webpack-plugin": "^5.3.10",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3",
-    "utility-types": "^3.7.0",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.0.1"
   },

--- a/src/horizon/server_api.ts
+++ b/src/horizon/server_api.ts
@@ -1,5 +1,4 @@
 import { Asset } from "@stellar/stellar-base";
-import { Omit } from "utility-types";
 import { HorizonApi } from "./horizon_api";
 
 // more types

--- a/yarn.lock
+++ b/yarn.lock
@@ -7000,6 +7000,7 @@ typedarray@^0.0.6:
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 "typescript-5.3@npm:typescript@~5.3.0-0", typescript@^5.3.3:
+  name typescript-5.3
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
@@ -7115,11 +7116,6 @@ util@^0.12.5:
     is-generator-function "^1.0.7"
     is-typed-array "^1.1.3"
     which-typed-array "^1.1.2"
-
-utility-types@^3.7.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
-  integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
 
 utils-merge@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Removed 'utility-types' dependency and usage

This update removes the 'utility-types' dependency from the stellar-sdk codebase. Initially moved to devDependencies, 'utility-types' was implicated in a TypeScript bug affecting the `TransactionRecord` interface on `src/horizon/server_api.ts`, where certain properties were not recognized in TypeScript projects. To resolve this, the 'utility-types' package has been completely eliminated. Changes include removing its references and imports, and updating package.json and yarn.lock files. This simplification not only resolves the TypeScript issue but also streamlines the dependency graph, potentially decreasing installation times and package size.