### PR TITLE
Ensure that event streaming tests write a valid stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Fixed
+* Event streaming tests now pass on Node 20, which seems to have tighter conformance to the spec ([#917](https://github.com/stellar/js-stellar-sdk/pull/917)).
+
 
 ## [v11.2.1](https://github.com/stellar/js-stellar-sdk/compare/v11.2.0...v11.2.1)
 

--- a/test/integration/client_headers_test.js
+++ b/test/integration/client_headers_test.js
@@ -44,7 +44,14 @@ describe("integration tests: client headers", function (done) {
       let query = url.parse(request.url, true).query;
       expect(query["X-Client-Name"]).to.be.equal("js-stellar-sdk");
       expect(query["X-Client-Version"]).to.match(versionPattern);
+
+      // write a valid event stream so that we don't error prematurely
+      response.writeHead(200, {
+        "Content-Type": "text/event-stream",
+      });
+      response.write("retry: 10\nevent: close\ndata: byebye\n\n");
       response.end();
+
       server.close(() => {
         closeStream();
         done();
@@ -62,11 +69,7 @@ describe("integration tests: client headers", function (done) {
         allowHttp: true,
       })
         .operations()
-        .stream({
-          onerror: (err) => {
-            done(err);
-          },
-        });
+        .stream({ onerror: (err) => done(err) });
     });
   });
 });


### PR DESCRIPTION
Tests now pass on Node 20, which seems to have tighter conformance to the SSE spec.

Closes #902.