### PR TITLE
Drop all usage of array-based passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Fixed
+* `SorobanRpc`: remove all instances of array-based parsing to conform to future breaking changes in Soroban RPC ([#924](https://github.com/stellar/js-stellar-sdk/pull/924)).
+
 
 ## [v11.2.2](https://github.com/stellar/js-stellar-sdk/compare/v11.2.1...v11.2.2)
 

--- a/src/soroban/jsonrpc.ts
+++ b/src/soroban/jsonrpc.ts
@@ -26,38 +26,11 @@ export interface Error<E = any> {
   data?: E;
 }
 
-/**
- * Sends the jsonrpc 'params' as an array.
- */
-export async function post<T>(
-  url: string,
-  method: string,
-  ...params: any
-): Promise<T> {
-  if (params && params.length < 1) {
-    params = null;
-  }
-  const response = await axios.post<Response<T>>(url, {
-    jsonrpc: "2.0",
-    // TODO: Generate a unique request id
-    id: 1,
-    method,
-    params,
-  });
-  if (hasOwnProperty(response.data, "error")) {
-    throw response.data.error;
-  } else {
-    return response.data?.result;
-  }
-}
-
-/**
- * Sends the jsonrpc 'params' as the single 'param' obj, no array wrapper is applied.
- */
+/** Sends the jsonrpc 'params' as a single 'param' object (no array support). */
 export async function postObject<T>(
   url: string,
   method: string,
-  param: any,
+  param: any = null,
 ): Promise<T> {
   const response = await axios.post<Response<T>>(url, {
     jsonrpc: "2.0",

--- a/src/soroban/server.ts
+++ b/src/soroban/server.ts
@@ -141,7 +141,7 @@ export class Server {
    * });
    */
   public async getHealth(): Promise<Api.GetHealthResponse> {
-    return jsonrpc.post<Api.GetHealthResponse>(
+    return jsonrpc.postObject<Api.GetHealthResponse>(
       this.serverURL.toString(),
       'getHealth'
     );
@@ -276,10 +276,11 @@ export class Server {
 
   public async _getLedgerEntries(...keys: xdr.LedgerKey[]) {
     return jsonrpc
-      .post<Api.RawGetLedgerEntriesResponse>(
+      .postObject<Api.RawGetLedgerEntriesResponse>(
         this.serverURL.toString(),
-        'getLedgerEntries',
-        keys.map((k) => k.toXDR('base64'))
+        'getLedgerEntries', {
+          keys: keys.map((k) => k.toXDR('base64'))
+        }
       );
   }
 
@@ -350,7 +351,7 @@ export class Server {
   public async _getTransaction(
     hash: string
   ): Promise<Api.RawGetTransactionResponse> {
-    return jsonrpc.post(this.serverURL.toString(), 'getTransaction', hash);
+    return jsonrpc.postObject(this.serverURL.toString(), 'getTransaction', {hash});
   }
 
   /**
@@ -427,7 +428,7 @@ export class Server {
    * });
    */
   public async getNetwork(): Promise<Api.GetNetworkResponse> {
-    return await jsonrpc.post(this.serverURL.toString(), 'getNetwork');
+    return await jsonrpc.postObject(this.serverURL.toString(), 'getNetwork');
   }
 
   /**
@@ -446,7 +447,7 @@ export class Server {
    * });
    */
   public async getLatestLedger(): Promise<Api.GetLatestLedgerResponse> {
-    return jsonrpc.post(this.serverURL.toString(), 'getLatestLedger');
+    return jsonrpc.postObject(this.serverURL.toString(), 'getLatestLedger');
   }
 
   /**
@@ -647,10 +648,10 @@ export class Server {
   public async _sendTransaction(
     transaction: Transaction | FeeBumpTransaction
   ): Promise<Api.RawSendTransactionResponse> {
-    return jsonrpc.post(
+    return jsonrpc.postObject(
       this.serverURL.toString(),
       'sendTransaction',
-      transaction.toXDR()
+      { transaction: transaction.toXDR() }
     );
   }
 

--- a/test/unit/server/soroban/get_account_test.js
+++ b/test/unit/server/soroban/get_account_test.js
@@ -25,7 +25,7 @@ describe("Server#getAccount", function () {
         jsonrpc: "2.0",
         id: 1,
         method: "getLedgerEntries",
-        params: [[key.toXDR("base64")]],
+        params: { keys: [ key.toXDR("base64") ] },
       })
       .returns(
         Promise.resolve({
@@ -62,7 +62,7 @@ describe("Server#getAccount", function () {
         jsonrpc: "2.0",
         id: 1,
         method: "getLedgerEntries",
-        params: [[key.toXDR("base64")]],
+        params: { keys: [ key.toXDR("base64") ] },
       })
       .returns(
         Promise.resolve({

--- a/test/unit/server/soroban/get_contract_data_test.js
+++ b/test/unit/server/soroban/get_contract_data_test.js
@@ -55,7 +55,7 @@ describe("Server#getContractData", function () {
         jsonrpc: "2.0",
         id: 1,
         method: "getLedgerEntries",
-        params: [[ledgerKey.toXDR("base64")]],
+        params: { keys: [ledgerKey.toXDR("base64")] },
       })
       .returns(
         Promise.resolve({
@@ -99,7 +99,7 @@ describe("Server#getContractData", function () {
         jsonrpc: "2.0",
         id: 1,
         method: "getLedgerEntries",
-        params: [[ledgerKeyDupe.toXDR("base64")]],
+        params: { keys: [ledgerKeyDupe.toXDR("base64")] },
       })
       .returns(Promise.resolve({ data: { result: { entries: [] } } }));
 

--- a/test/unit/server/soroban/get_ledger_entries_test.js
+++ b/test/unit/server/soroban/get_ledger_entries_test.js
@@ -44,7 +44,7 @@ describe("Server#getLedgerEntries", function () {
         jsonrpc: "2.0",
         id: 1,
         method: "getLedgerEntries",
-        params: [requests],
+        params: {keys: requests},
       })
       .returns(
         Promise.resolve({

--- a/test/unit/server/soroban/get_transaction_test.js
+++ b/test/unit/server/soroban/get_transaction_test.js
@@ -42,7 +42,7 @@ describe("Server#getTransaction", function () {
           jsonrpc: "2.0",
           id: 1,
           method: "getTransaction",
-          params: [this.hash],
+          params: { hash: this.hash },
         })
         .returns(Promise.resolve({ data: { id: 1, result } }));
     };

--- a/test/unit/server/soroban/request_airdrop_test.js
+++ b/test/unit/server/soroban/request_airdrop_test.js
@@ -126,7 +126,7 @@ describe("Server#requestAirdrop", function () {
         jsonrpc: "2.0",
         id: 1,
         method: "getLedgerEntries",
-        params: [[accountKey.toXDR("base64")]],
+        params: { keys: [accountKey.toXDR("base64")] },
       })
       .returns(
         Promise.resolve({

--- a/test/unit/server/soroban/send_transaction_test.js
+++ b/test/unit/server/soroban/send_transaction_test.js
@@ -42,7 +42,7 @@ describe("Server#sendTransaction", function () {
         jsonrpc: "2.0",
         id: 1,
         method: "sendTransaction",
-        params: [this.blob],
+        params: { transaction: this.blob },
       })
       .returns(
         Promise.resolve({
@@ -78,7 +78,7 @@ describe("Server#sendTransaction", function () {
         jsonrpc: "2.0",
         id: 1,
         method: "sendTransaction",
-        params: [this.blob],
+        params: { transaction: this.blob },
       })
       .returns(
         Promise.resolve({


### PR DESCRIPTION
Per #923, array-based parsing will be removed in order to support optional parameters in the future within Soroban RPC.