### PR TITLE
build: move TypeScript to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "taffydb": "^2.7.3",
     "terser-webpack-plugin": "^5.3.10",
     "ts-node": "^10.9.2",
+    "typescript": "^5.3.3",
     "webpack": "^5.90.1",
     "webpack-cli": "^5.0.1"
   },
@@ -148,7 +149,6 @@
     "eventsource": "^2.0.2",
     "randombytes": "^2.1.0",
     "toml": "^3.0.0",
-    "typescript": "^5.3.3",
     "urijs": "^1.19.1"
   }
 }


### PR DESCRIPTION
No reason to have TypeScript in main `dependencies` rather than `devDependencies`, is there?

Reduces bundle size by >85%. Bundle size before this change, as measured by [bundle-phobia-cli](https://github.com/AdrieanKhisbe/bundle-phobia-cli):

```
$ bundle-phobia -p ./package.json
ℹ @stellar/stellar-base (11.0.0) has 7 dependencies for a weight of 351.57KB (81.82KB gzipped)
ℹ axios (1.6.7) has 3 dependencies for a weight of 30.48KB (11.66KB gzipped)
ℹ bignumber.js (9.1.2) has 0 dependencies for a weight of 18.19KB (8.15KB gzipped)
ℹ eventsource (2.0.2) has 0 dependencies for a weight of 5.21KB (2.08KB gzipped)
ℹ randombytes (2.1.0) has 1 dependencies for a weight of 1.57KB (720B gzipped)
ℹ toml (3.0.0) has 0 dependencies for a weight of 27.47KB (5.97KB gzipped)
ℹ typescript (5.3.3) has 0 dependencies for a weight of 3.15MB (890.61KB gzipped)
ℹ urijs (1.19.11) has 0 dependencies for a weight of 41.75KB (13.21KB gzipped)

ℹ total (8 packages) has 11 dependencies for a weight of 3.62MB (1014.21KB gzipped)
```



After:

```
$ bundle-phobia -p ./package.json
ℹ @stellar/stellar-base (11.0.0) has 7 dependencies for a weight of 351.57KB (81.82KB gzipped)
ℹ axios (1.6.7) has 3 dependencies for a weight of 30.48KB (11.66KB gzipped)
ℹ bignumber.js (9.1.2) has 0 dependencies for a weight of 18.19KB (8.15KB gzipped)
ℹ eventsource (2.0.2) has 0 dependencies for a weight of 5.21KB (2.08KB gzipped)
ℹ randombytes (2.1.0) has 1 dependencies for a weight of 1.57KB (720B gzipped)
ℹ toml (3.0.0) has 0 dependencies for a weight of 27.47KB (5.97KB gzipped)
ℹ urijs (1.19.11) has 0 dependencies for a weight of 41.75KB (13.21KB gzipped)

ℹ total (7 packages) has 11 dependencies for a weight of 476.23KB (123.6KB gzipped)
```