### PR TITLE
Fix dead link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The usage documentation for this library lives in a handful of places:
 
 You can also refer to:
 
- * the [documentation](https://developers.stellar.org/api/introduction/) for the Horizon REST API (if using the `Horizon` module) and
+ * the [documentation](https://developers.stellar.org/network/horizon) for the Horizon REST API (if using the `Horizon` module) and
  * the [documentation](https://soroban.stellar.org/docs/reference/rpc) for Soroban RPC's API (if using the `SorobanRpc` module)
 
 ### Usage with React-Native


### PR DESCRIPTION
The horizon api docs moved to a different url.