### PR TITLE
Effects typing fixes

### DIFF
--- a/src/horizon/types/effects.ts
+++ b/src/horizon/types/effects.ts
@@ -67,7 +67,7 @@ export enum EffectType {
   contract_credited = 96,
   contract_debited = 97
 }
-export interface BaseEffectRecord<T extends string> extends HorizonApi.BaseResponse {
+export interface BaseEffectRecord<T extends string = string> extends HorizonApi.BaseResponse {
   id: string;
   account: string;
   paging_token: string;

--- a/src/horizon/types/effects.ts
+++ b/src/horizon/types/effects.ts
@@ -83,7 +83,7 @@ export interface AccountCredited extends BaseEffectRecord<'account_credited'>, O
   type_i: EffectType.account_credited;
   amount: string;
 }
-export interface AccountDebited extends BaseEffectRecord<'account_debited'> {
+export interface AccountDebited extends BaseEffectRecord<'account_debited'>, OfferAsset {
   type_i: EffectType.account_debited;
   amount: string;
 }

--- a/src/horizon/types/effects.ts
+++ b/src/horizon/types/effects.ts
@@ -264,7 +264,7 @@ export type SignerSponsorshipRemoved = Omit<
 > & { type_i: EffectType.signer_sponsorship_removed };
 
 export interface ClaimableBalanceClawedBack extends HorizonApi.BaseResponse {
-    balance_id: string
+  balance_id: string
 }
 
 export interface LiquidityPoolEffectRecord extends HorizonApi.BaseResponse {

--- a/src/horizon/types/effects.ts
+++ b/src/horizon/types/effects.ts
@@ -67,86 +67,86 @@ export enum EffectType {
   contract_credited = 96,
   contract_debited = 97
 }
-export interface BaseEffectRecord extends HorizonApi.BaseResponse {
+export interface BaseEffectRecord<T extends string> extends HorizonApi.BaseResponse {
   id: string;
   account: string;
   paging_token: string;
   type_i: EffectType;
-  type: string;
+  type: T;
   created_at: string;
 }
-export interface AccountCreated extends BaseEffectRecord {
+export interface AccountCreated extends BaseEffectRecord<'account_created'> {
   type_i: EffectType.account_created;
   starting_balance: string;
 }
-export interface AccountCredited extends BaseEffectRecord, OfferAsset {
+export interface AccountCredited extends BaseEffectRecord<'account_credited'>, OfferAsset {
   type_i: EffectType.account_credited;
   amount: string;
 }
-export interface AccountDebited extends BaseEffectRecord {
+export interface AccountDebited extends BaseEffectRecord<'account_debited'> {
   type_i: EffectType.account_debited;
   amount: string;
 }
-export interface AccountThresholdsUpdated extends BaseEffectRecord {
+export interface AccountThresholdsUpdated extends BaseEffectRecord<'account_thresholds_updated'> {
   type_i: EffectType.account_thresholds_updated;
   low_threshold: number;
   med_threshold: number;
   high_threshold: number;
 }
-export interface AccountHomeDomainUpdated extends BaseEffectRecord {
+export interface AccountHomeDomainUpdated extends BaseEffectRecord<'account_home_domain_updated'> {
   type_i: EffectType.account_home_domain_updated;
   home_domain: string;
 }
-export interface AccountFlagsUpdated extends BaseEffectRecord {
+export interface AccountFlagsUpdated extends BaseEffectRecord<'account_flags_updated'> {
   type_i: EffectType.account_flags_updated;
   auth_required_flag: boolean;
   auth_revokable_flag: boolean;
 }
-interface DataEvents extends BaseEffectRecord {
+interface DataEvents<T extends string> extends BaseEffectRecord<T> {
   name: boolean;
   value: boolean;
 }
-export interface DataCreated extends DataEvents {
+export interface DataCreated extends DataEvents<'data_created'> {
   type_i: EffectType.data_created;
 }
-export interface DataUpdated extends DataEvents {
+export interface DataUpdated extends DataEvents<'data_updated'> {
   type_i: EffectType.data_updated;
 }
-export interface DataRemoved extends DataEvents {
+export interface DataRemoved extends DataEvents<'data_removed'> {
   type_i: EffectType.data_removed;
 }
-export interface SequenceBumped extends BaseEffectRecord {
+export interface SequenceBumped extends BaseEffectRecord<'sequence_bumped'> {
   type_i: EffectType.sequence_bumped;
   new_seq: number | string;
 }
-interface SignerEvents extends BaseEffectRecord {
+interface SignerEvents<T extends string> extends BaseEffectRecord<T> {
   weight: number;
   key: string;
   public_key: string;
 }
-export interface SignerCreated extends SignerEvents {
+export interface SignerCreated extends SignerEvents<'signer_created'> {
   type_i: EffectType.signer_created;
 }
-export interface SignerRemoved extends SignerEvents {
+export interface SignerRemoved extends SignerEvents<'signer_removed'> {
   type_i: EffectType.signer_removed;
 }
-export interface SignerUpdated extends SignerEvents {
+export interface SignerUpdated extends SignerEvents<'signer_updated'> {
   type_i: EffectType.signer_updated;
 }
-interface TrustlineEvents extends BaseEffectRecord, OfferAsset {
+interface TrustlineEvents<T extends string> extends BaseEffectRecord<T>, OfferAsset {
   limit: string;
   liquidity_pool_id?: string;
 }
-export interface TrustlineCreated extends TrustlineEvents {
+export interface TrustlineCreated extends TrustlineEvents<'trustline_created'> {
   type_i: EffectType.trustline_created;
 }
-export interface TrustlineRemoved extends TrustlineEvents {
+export interface TrustlineRemoved extends TrustlineEvents<'trustline_removed'> {
   type_i: EffectType.trustline_removed;
 }
-export interface TrustlineUpdated extends TrustlineEvents {
+export interface TrustlineUpdated extends TrustlineEvents<'trustline_updated'> {
   type_i: EffectType.trustline_updated;
 }
-export interface TrustlineAuthorized extends BaseEffectRecord {
+export interface TrustlineAuthorized extends BaseEffectRecord<'trustline_authorized'> {
   type_i: EffectType.trustline_authorized;
   asset_type: OfferAsset["asset_type"];
   asset_code: OfferAsset["asset_code"];
@@ -160,7 +160,7 @@ export interface TrustlineAuthorizedToMaintainLiabilities
   extends Omit<TrustlineAuthorized, "type_i"> {
   type_i: EffectType.trustline_authorized_to_maintain_liabilities;
 }
-export interface ClaimableBalanceCreated extends BaseEffectRecord {
+export interface ClaimableBalanceCreated extends BaseEffectRecord<'claimable_balance_created'> {
   type_i: EffectType.claimable_balance_created;
   amount: string;
   balance_type_i: string;
@@ -180,91 +180,91 @@ interface SponsershipFields {
   new_sponsor: string;
   former_sponsor: string;
 }
-interface AccountSponsorshipEvents
-  extends BaseEffectRecord,
+interface AccountSponsorshipEvents<T extends string>
+  extends BaseEffectRecord<T>,
     SponsershipFields {}
 
 export type AccountSponsorshipCreated = Omit<
-  AccountSponsorshipEvents,
+  AccountSponsorshipEvents<'account_sponsorship_created'>,
   "new_sponsor" | "former_sponsor"
 > & { type_i: EffectType.account_sponsorship_created };
 export type AccountSponsorshipUpdated = Omit<
-  AccountSponsorshipEvents,
+  AccountSponsorshipEvents<'account_sponsorship_updated'>,
   "sponsor"
 > & { type_i: EffectType.account_sponsorship_updated };
 export type AccountSponsorshipRemoved = Omit<
-  AccountSponsorshipEvents,
+  AccountSponsorshipEvents<'account_sponsorship_removed'>,
   "new_sponsor" | "sponsor"
 > & { type_i: EffectType.account_sponsorship_removed };
-interface TrustlineSponsorshipEvents
-  extends BaseEffectRecord,
+interface TrustlineSponsorshipEvents<T extends string>
+  extends BaseEffectRecord<T>,
     SponsershipFields {
   asset?: string;
   liquidity_pool_id?: string;
 }
 export type TrustlineSponsorshipCreated = Omit<
-  TrustlineSponsorshipEvents,
+  TrustlineSponsorshipEvents<'trustline_sponsorship_created'>,
   "new_sponsor" | "former_sponsor"
 > & { type_i: EffectType.trustline_sponsorship_created };
 export type TrustlineSponsorshipUpdated = Omit<
-  TrustlineSponsorshipEvents,
+  TrustlineSponsorshipEvents<'trustline_sponsorship_updated'>,
   "sponsor"
 > & { type_i: EffectType.trustline_sponsorship_updated };
 export type TrustlineSponsorshipRemoved = Omit<
-  TrustlineSponsorshipEvents,
+  TrustlineSponsorshipEvents<'trustline_sponsorship_removed'>,
   "new_sponsor" | "sponsor"
 > & { type_i: EffectType.trustline_sponsorship_removed };
-interface DataSponsorshipEvents extends BaseEffectRecord, SponsershipFields {
+interface DataSponsorshipEvents<T extends string> extends BaseEffectRecord<T>, SponsershipFields {
   data_name: string;
 }
 export type DateSponsorshipCreated = Omit<
-  DataSponsorshipEvents,
+  DataSponsorshipEvents<'data_sponsorship_created'>,
   "new_sponsor" | "former_sponsor"
 > & { type_i: EffectType.data_sponsorship_created };
-export type DateSponsorshipUpdated = Omit<DataSponsorshipEvents, "sponsor"> & {
+export type DateSponsorshipUpdated = Omit<DataSponsorshipEvents<'data_sponsorship_updated'>, "sponsor"> & {
   type_i: EffectType.data_sponsorship_updated;
 };
 export type DateSponsorshipRemoved = Omit<
-  DataSponsorshipEvents,
+  DataSponsorshipEvents<'data_sponsorship_removed'>,
   "new_sponsor" | "sponsor"
 > & { type_i: EffectType.data_sponsorship_removed };
-interface ClaimableBalanceSponsorshipEvents
-  extends BaseEffectRecord,
+interface ClaimableBalanceSponsorshipEvents<T extends string>
+  extends BaseEffectRecord<T>,
     SponsershipFields {
   balance_type_i: string;
 }
 
 export type ClaimableBalanceSponsorshipCreated = Omit<
-  ClaimableBalanceSponsorshipEvents,
+  ClaimableBalanceSponsorshipEvents<'claimable_balance_sponsorship_created'>,
   "new_sponsor" | "former_sponsor"
 > & { type_i: EffectType.claimable_balance_sponsorship_created };
 export type ClaimableBalanceSponsorshipUpdated = Omit<
-  ClaimableBalanceSponsorshipEvents,
+  ClaimableBalanceSponsorshipEvents<'claimable_balance_sponsorship_updated'>,
   "sponsor"
 > & { type_i: EffectType.claimable_balance_sponsorship_updated };
 export type ClaimableBalanceSponsorshipRemoved = Omit<
-  ClaimableBalanceSponsorshipEvents,
+  ClaimableBalanceSponsorshipEvents<'claimable_balance_sponsorship_removed'>,
   "new_sponsor" | "sponsor"
 > & { type_i: EffectType.claimable_balance_sponsorship_removed };
-interface SignerSponsorshipEvents extends BaseEffectRecord, SponsershipFields {
+interface SignerSponsorshipEvents<T extends string> extends BaseEffectRecord<T>, SponsershipFields {
   signer: string;
 }
 
 export type SignerSponsorshipCreated = Omit<
-  SignerSponsorshipEvents,
+  SignerSponsorshipEvents<'signer_sponsorship_created'>,
   "new_sponsor" | "former_sponsor"
 > & { type_i: EffectType.signer_sponsorship_created };
 export type SignerSponsorshipUpdated = Omit<
-  SignerSponsorshipEvents,
+  SignerSponsorshipEvents<'signer_sponsorship_updated'>,
   "sponsor"
 > & { type_i: EffectType.signer_sponsorship_updated };
 export type SignerSponsorshipRemoved = Omit<
-  SignerSponsorshipEvents,
+  SignerSponsorshipEvents<'signer_sponsorship_removed'>,
   "new_sponsor" | "sponsor"
 > & { type_i: EffectType.signer_sponsorship_removed };
 
 export interface ClaimableBalanceClawedBack extends HorizonApi.BaseResponse {
-	balance_id: string
+    balance_id: string
 }
 
 export interface LiquidityPoolEffectRecord extends HorizonApi.BaseResponse {
@@ -275,33 +275,33 @@ export interface LiquidityPoolEffectRecord extends HorizonApi.BaseResponse {
   total_shares: string;
   reserves: HorizonApi.Reserve[];
 }
-export interface LiquidityPoolDeposited extends BaseEffectRecord {
+export interface LiquidityPoolDeposited extends BaseEffectRecord<'liquidity_pool_deposited'> {
   type_i: EffectType.liquidity_pool_deposited;
   liquidity_pool: LiquidityPoolEffectRecord;
   reserves_deposited: HorizonApi.Reserve[];
   shares_received: string;
 }
-export interface LiquidityPoolWithdrew extends BaseEffectRecord {
+export interface LiquidityPoolWithdrew extends BaseEffectRecord<'liquidity_pool_withdrew'> {
   type_i: EffectType.liquidity_pool_withdrew;
   liquidity_pool: LiquidityPoolEffectRecord;
   reserves_received: HorizonApi.Reserve[];
   shares_redeemed: string;
 }
-export interface LiquidityPoolTrade extends BaseEffectRecord {
+export interface LiquidityPoolTrade extends BaseEffectRecord<'liquidity_pool_trade'> {
   type_i: EffectType.liquidity_pool_trade;
   liquidity_pool: LiquidityPoolEffectRecord;
   sold: HorizonApi.Reserve;
   bought: HorizonApi.Reserve;
 }
-export interface LiquidityPoolCreated extends BaseEffectRecord {
+export interface LiquidityPoolCreated extends BaseEffectRecord<'liquidity_pool_created'> {
   type_i: EffectType.liquidity_pool_created;
   liquidity_pool: LiquidityPoolEffectRecord;
 }
-export interface LiquidityPoolRemoved extends BaseEffectRecord {
+export interface LiquidityPoolRemoved extends BaseEffectRecord<'liquidity_pool_removed'> {
   type_i: EffectType.liquidity_pool_removed;
   liquidity_pool_id: string;
 }
-export interface LiquidityPoolRevoked extends BaseEffectRecord {
+export interface LiquidityPoolRevoked extends BaseEffectRecord<'liquidity_pool_revoked'> {
   type_i: EffectType.liquidity_pool_revoked;
   liquidity_pool: LiquidityPoolEffectRecord;
   reserves_revoked: [
@@ -314,12 +314,12 @@ export interface LiquidityPoolRevoked extends BaseEffectRecord {
   shares_revoked: string;
 }
 
-export interface ContractCredited extends BaseEffectRecord, OfferAsset {
+export interface ContractCredited extends BaseEffectRecord<'contract_credited'>, OfferAsset {
   type_i: EffectType.contract_credited;
   contract: string;
   amount: string;
 }
-export interface ContractDebited extends BaseEffectRecord, OfferAsset {
+export interface ContractDebited extends BaseEffectRecord<'contract_debited'>, OfferAsset {
   type_i: EffectType.contract_debited;
   contract: string;
   amount: string;

--- a/src/horizon/types/trade.ts
+++ b/src/horizon/types/trade.ts
@@ -1,14 +1,15 @@
-import { BaseEffectRecord } from "./effects";
+import { BaseEffectRecord, EffectType } from "./effects";
 
-export interface Trade extends BaseEffectRecord {
-  seller: string;
-  offer_id: number | string;
-  bought_amount: string;
-  bought_asset_type: string;
-  bought_asset_code: string;
-  bought_asset_issuer: string;
-  sold_amount: string;
-  sold_asset_type: string;
-  sold_asset_code: string;
-  sold_asset_issuer: string;
+export interface Trade extends BaseEffectRecord<'trade'> {
+    type_i: EffectType.trade;
+    seller: string;
+    offer_id: number | string;
+    bought_amount: string;
+    bought_asset_type: string;
+    bought_asset_code: string;
+    bought_asset_issuer: string;
+    sold_amount: string;
+    sold_asset_type: string;
+    sold_asset_code: string;
+    sold_asset_issuer: string;
 }

--- a/src/horizon/types/trade.ts
+++ b/src/horizon/types/trade.ts
@@ -1,15 +1,15 @@
 import { BaseEffectRecord, EffectType } from "./effects";
 
 export interface Trade extends BaseEffectRecord<'trade'> {
-    type_i: EffectType.trade;
-    seller: string;
-    offer_id: number | string;
-    bought_amount: string;
-    bought_asset_type: string;
-    bought_asset_code: string;
-    bought_asset_issuer: string;
-    sold_amount: string;
-    sold_asset_type: string;
-    sold_asset_code: string;
-    sold_asset_issuer: string;
+  type_i: EffectType.trade;
+  seller: string;
+  offer_id: number | string;
+  bought_amount: string;
+  bought_asset_type: string;
+  bought_asset_code: string;
+  bought_asset_issuer: string;
+  sold_amount: string;
+  sold_asset_type: string;
+  sold_asset_code: string;
+  sold_asset_issuer: string;
 }


### PR DESCRIPTION
Parameterize `BaseEffectRecord` by effect type literals so that it's possible to discriminate based on the `type` field. With this change code like the following type checks whereas before it would have had errors because the type of `effect` wouldn't get appropriately narrowed in each case based on the value of `effect.type`:

```ts
switch (effect.type) {
  case "trade":
    console.log("trade", effect.sold_amount, effect.bought_amount);
    break;
  case "liquidity_pool_trade":
    console.log("liquidity_pool_trade", effect.liquidity_pool.reserves);
    break;
  // ...
}
```

Also added the `type_i` field to the `Trade` interface since it was missing, which was preventing even `type_i` from working correctly to discriminate effect types.