### PR TITLE
feat(contract-client): match CLI's default timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Breaking Changes
+* **Default timeout for transaction calls is now set to 300 seconds (5 minutes) from previous default of 10 seconds**. 10 seconds is often not enough time to review transactions before signing, especially in Freighter or using a hardware wallet like a Ledger, which would cause a `txTooLate` error response from the server. Five minutes is also the value used by the CLI, so this brings the two into alignment.
+
 
 ## [v12.0.0-rc.1](https://github.com/stellar/js-stellar-sdk/compare/v11.3.0...v12.0.0-rc.1)
 

--- a/src/contract_client/utils.ts
+++ b/src/contract_client/utils.ts
@@ -1,7 +1,7 @@
 /**
  * The default timeout for waiting for a transaction to be included in a block.
  */
-export const DEFAULT_TIMEOUT = 60;
+export const DEFAULT_TIMEOUT = 5 * 60;
 
 /**
  * Keep calling a `fn` for `timeoutInSeconds` seconds, if `keepWaitingIf` is true.
@@ -12,7 +12,7 @@ export async function withExponentialBackoff<T>(
   keepWaitingIf: (result: T) => boolean,
   timeoutInSeconds: number,
   exponentialFactor = 1.5,
-  verbose = false
+  verbose = false,
 ): Promise<T[]> {
   const attempts: T[] = [];
 
@@ -34,7 +34,7 @@ export async function withExponentialBackoff<T>(
       console.info(
         `Waiting ${waitTime}ms before trying again (bringing the total wait time to ${totalWaitTime}ms so far, of total ${
           timeoutInSeconds * 1000
-        }ms)`
+        }ms)`,
       );
     }
     await new Promise((res) => setTimeout(res, waitTime));
@@ -56,8 +56,8 @@ export async function withExponentialBackoff<T>(
         } prev attempts. Most recent: ${JSON.stringify(
           attempts[attempts.length - 1],
           null,
-          2
-        )}`
+          2,
+        )}`,
       );
     }
   }
@@ -77,6 +77,8 @@ export const contractErrorPattern = /Error\(Contract, #(\d+)\)/;
 /**
  * A TypeScript type guard that checks if an object has a `toString` method.
  */
-export function implementsToString(obj: unknown): obj is { toString(): string } {
+export function implementsToString(
+  obj: unknown,
+): obj is { toString(): string } {
   return typeof obj === "object" && obj !== null && "toString" in obj;
 }


### PR DESCRIPTION
Even 60 seconds, as it was updated to in 2bcbc6a4acfb67078794059802a479b0b0473c0f, might be too short if someone is cautiously reviewing the transaction in Freighter, or if they need ot unlock their Ledger and walk through its process.

Five minutes is the same as the CLI. Maybe it's a reasonable standard to adopt?