### PR TITLE
add a from method to ContractClient to instantiate from a contractId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ A breaking change will get clearly marked in this log.
 
 ### Added
 * Added a from method in `ContractClient` which takes the `ContractClientOptions` and instantiates the `ContractClient` by utilizing the `contractId` to retrieve the contract wasm from the blockchain. The custom section is then extracted and used to create a `ContractSpec` which is then used to create the client.
-* Similarly adds a `fromWasm` method in `ContractClient` which can be used to initialize a `ContractClient` if you already have the wasm bytes along with the `ContractClientOptions`.
+* Similarly adds `fromWasm` and `fromWasmHash` methods in `ContractClient` which can be used to initialize a `ContractClient` if you already have the wasm bytes or the wasm hash along with the `ContractClientOptions`.
+* Added `getContractWasmByContractId` and `getContractWasmByHash` methods in `Server` which can be used to retrieve the wasm bytecode of a contract via its `contractId` and wasm hash respectively.
 
 ## [v12.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v11.3.0...v12.0.0-rc.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Added
+* Added a from method in `ContractClient` which takes the `ContractClientOptions` and instantiates the `ContractClient` by utilizing the `contractId` to retrieve the contract wasm from the blockchain. The custom section is then extracted and used to create a `ContractSpec` which is then used to create the client.
+* Similarly adds a `fromWasm` method in `ContractClient` which can be used to initialize a `ContractClient` if you already have the wasm bytes along with the `ContractClientOptions`.
 
 ## [v12.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v11.3.0...v12.0.0-rc.2)
 

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
-    "@stellar/stellar-base": "https://github.com/stellar/js-stellar-base.git#expose-js-xdr",
+    "@stellar/stellar-base": "^12.0.0-rc.1",
     "axios": "^1.6.8",
     "bignumber.js": "^9.1.2",
     "eventsource": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
+    "@stellar/js-xdr": "^3.1.1",
     "@stellar/stellar-base": "11.1.0",
     "axios": "^1.6.8",
     "bignumber.js": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
-    "@stellar/stellar-base": "11.1.0",
+    "@stellar/stellar-base": "https://github.com/stellar/js-stellar-base.git#expose-js-xdr",
     "axios": "^1.6.8",
     "bignumber.js": "^9.1.2",
     "eventsource": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
-    "@stellar/js-xdr": "^3.1.1",
     "@stellar/stellar-base": "11.1.0",
     "axios": "^1.6.8",
     "bignumber.js": "^9.1.2",

--- a/src/contract_client/client.ts
+++ b/src/contract_client/client.ts
@@ -56,8 +56,7 @@ export class ContractClient {
     if (xdrSections.length === 0) {
       return Promise.reject(new Error('Could not obtain contract spec from wasm'));
     }
-    const section = xdrSections[0];
-    const bufferSection = Buffer.from(section);
+    const bufferSection = Buffer.from(xdrSections[0]);
     const specEntryArray = processSpecEntryStream(bufferSection);
     const spec = new ContractSpec(specEntryArray);
     return new ContractClient(spec, options);

--- a/src/contract_client/client.ts
+++ b/src/contract_client/client.ts
@@ -70,7 +70,7 @@ export class ContractClient {
       return Promise.reject(new TypeError('options must contain rpcUrl and contractId'));
     }
     const { rpcUrl, contractId, allowHttp } = options;
-    const serverOpts: Server.Options = { allowHttp: allowHttp?? !rpcUrl.startsWith('https') };
+    const serverOpts: Server.Options = { allowHttp };
     const server = new Server(rpcUrl, serverOpts);
     const wasm = await server.getContractWasm(contractId);
     return ContractClient.fromWasm(wasm, options);

--- a/src/contract_client/client.ts
+++ b/src/contract_client/client.ts
@@ -54,7 +54,7 @@ export class ContractClient {
     const wasmModule = await WebAssembly.compile(wasm);
     const xdrSections = WebAssembly.Module.customSections(wasmModule, "contractspecv0");
     if (xdrSections.length === 0) {
-      return Promise.reject(new Error('Could not obtain contract spec from wasm'));
+      throw new Error('Could not obtain contract spec from wasm');
     }
     const bufferSection = Buffer.from(xdrSections[0]);
     const specEntryArray = processSpecEntryStream(bufferSection);
@@ -67,7 +67,7 @@ export class ContractClient {
    */
   static async from(options: ContractClientOptions): Promise<ContractClient> {
     if (!options || !options.rpcUrl || !options.contractId) {
-      return Promise.reject(new TypeError('options must contain rpcUrl and contractId'));
+      throw new TypeError('options must contain rpcUrl and contractId');
     }
     const { rpcUrl, contractId, allowHttp } = options;
     const serverOpts: Server.Options = { allowHttp };

--- a/src/contract_client/client.ts
+++ b/src/contract_client/client.ts
@@ -1,6 +1,8 @@
-import { ContractSpec, xdr } from "..";
+import { Contract, ContractSpec, xdr } from "..";
+import { Server } from '../soroban';
 import { AssembledTransaction } from "./assembled_transaction";
 import type { ContractClientOptions, MethodOptions } from "./types";
+import { processSpecEntryStream } from './utils';
 
 export class ContractClient {
   /**
@@ -45,6 +47,45 @@ export class ContractClient {
     });
   }
 
+  /**
+   * Generate a ContractClient instance from the ContractClientOptions and the wasm binary
+   */
+  static async fromWasm(options: ContractClientOptions, wasm: BufferSource): Promise<ContractClient> {
+    const wasmModule = await WebAssembly.compile(wasm);
+    const xdrSections = WebAssembly.Module.customSections(wasmModule, "contractspecv0");
+    if (xdrSections.length === 0) {
+      return Promise.reject(new Error('Could not obtain contract spec from wasm'));
+    }
+    const section = xdrSections[0];
+    const bufferSection = Buffer.from(section);
+    const specEntryArray = processSpecEntryStream(bufferSection);
+    const spec = new ContractSpec(specEntryArray);
+    return new ContractClient(spec, options);
+  }
+
+  /**
+   * Generate a ContractClient instance from the contractId and rpcUrl
+   */
+  static async from(options: ContractClientOptions): Promise<ContractClient> {
+    if (!options || !options.rpcUrl || !options.contractId) {
+      return Promise.reject(new TypeError('options must contain rpcUrl and contractId'));
+    }
+    const { rpcUrl, contractId, allowHttp } = options;
+    const serverOpts: Server.Options = { allowHttp: allowHttp?? !rpcUrl.startsWith('https') };
+    const server = new Server(rpcUrl, serverOpts);
+    const contractLedgerKey = new Contract(contractId).getFootprint();
+    const response = await server.getLedgerEntries(contractLedgerKey);
+    if (!response.entries[0]?.val)
+      return Promise.reject(new Error(`Could not obtain contract from server`));
+    const wasmHash = ((response.entries[0].val.value() as xdr.ContractDataEntry).val().value() as xdr.ScContractInstance).executable().wasmHash();
+    const ledgerKeyWasmHash = xdr.LedgerKey.contractCode(new xdr.LedgerKeyContractCode({
+      hash: wasmHash,
+    }));
+    const responseWasm = await server.getLedgerEntries(ledgerKeyWasmHash);
+    const wasmBuffer = (responseWasm.entries[0].val.value() as xdr.ContractCodeEntry).code();
+    return ContractClient.fromWasm(options, wasmBuffer);
+  }
+
   txFromJSON = <T>(json: string): AssembledTransaction<T> => {
     const { method, ...tx } = JSON.parse(json);
     return AssembledTransaction.fromJSON(
@@ -58,3 +99,4 @@ export class ContractClient {
     );
   };
 }
+

--- a/src/contract_client/client.ts
+++ b/src/contract_client/client.ts
@@ -1,4 +1,4 @@
-import { Contract, ContractSpec, xdr } from "..";
+import { ContractSpec, xdr } from "..";
 import { Server } from '../soroban';
 import { AssembledTransaction } from "./assembled_transaction";
 import type { ContractClientOptions, MethodOptions } from "./types";

--- a/src/contract_client/client.ts
+++ b/src/contract_client/client.ts
@@ -61,7 +61,7 @@ export class ContractClient {
     options: ContractClientOptions, 
     format: "hex" | "base64" = "hex"
   ): Promise<ContractClient> {
-    if (!options || !options.rpcUrl ) {
+    if (!options || !options.rpcUrl) {
       throw new TypeError('options must contain rpcUrl');
     }
     const { rpcUrl, allowHttp } = options;

--- a/src/contract_client/client.ts
+++ b/src/contract_client/client.ts
@@ -48,9 +48,23 @@ export class ContractClient {
   }
 
   /**
+   * Generate a ContractClient instance from the ContractClientOptions and the wasm hash 
+   */
+  static async fromWasmHash(wasmHash: Buffer, options: ContractClientOptions): Promise<ContractClient> {
+    if (!options || !options.rpcUrl ) {
+      throw new TypeError('options must contain rpcUrl');
+    }
+    const { rpcUrl, allowHttp } = options;
+    const serverOpts: Server.Options = { allowHttp };
+    const server = new Server(rpcUrl, serverOpts);
+    const wasm = await server.getContractWasmByHash(wasmHash);
+    return ContractClient.fromWasm(wasm, options);
+  }
+
+  /**
    * Generate a ContractClient instance from the ContractClientOptions and the wasm binary
    */
-  static async fromWasm(wasm: BufferSource, options: ContractClientOptions): Promise<ContractClient> {
+  static async fromWasm(wasm: Buffer, options: ContractClientOptions): Promise<ContractClient> {
     const wasmModule = await WebAssembly.compile(wasm);
     const xdrSections = WebAssembly.Module.customSections(wasmModule, "contractspecv0");
     if (xdrSections.length === 0) {
@@ -72,7 +86,7 @@ export class ContractClient {
     const { rpcUrl, contractId, allowHttp } = options;
     const serverOpts: Server.Options = { allowHttp };
     const server = new Server(rpcUrl, serverOpts);
-    const wasm = await server.getContractWasm(contractId);
+    const wasm = await server.getContractWasmByContractId(contractId);
     return ContractClient.fromWasm(wasm, options);
   }
 

--- a/src/contract_client/client.ts
+++ b/src/contract_client/client.ts
@@ -50,7 +50,7 @@ export class ContractClient {
   /**
    * Generate a ContractClient instance from the ContractClientOptions and the wasm binary
    */
-  static async fromWasm(options: ContractClientOptions, wasm: BufferSource): Promise<ContractClient> {
+  static async fromWasm(wasm: BufferSource, options: ContractClientOptions): Promise<ContractClient> {
     const wasmModule = await WebAssembly.compile(wasm);
     const xdrSections = WebAssembly.Module.customSections(wasmModule, "contractspecv0");
     if (xdrSections.length === 0) {
@@ -73,7 +73,7 @@ export class ContractClient {
     const serverOpts: Server.Options = { allowHttp: allowHttp?? !rpcUrl.startsWith('https') };
     const server = new Server(rpcUrl, serverOpts);
     const wasm = await server.getContractWasm(contractId);
-    return ContractClient.fromWasm(options, wasm);
+    return ContractClient.fromWasm(wasm, options);
   }
 
   txFromJSON = <T>(json: string): AssembledTransaction<T> => {

--- a/src/contract_client/client.ts
+++ b/src/contract_client/client.ts
@@ -48,21 +48,36 @@ export class ContractClient {
   }
 
   /**
-   * Generate a ContractClient instance from the ContractClientOptions and the wasm hash 
+   * Generates a ContractClient instance from the provided ContractClientOptions and the contract's wasm hash.
+   * The wasmHash can be provided in either hex or base64 format.
+   * 
+   * @param wasmHash The hash of the contract's wasm binary, in either hex or base64 format.
+   * @param options The ContractClientOptions object containing the necessary configuration, including the rpcUrl.
+   * @param format The format of the provided wasmHash, either "hex" or "base64". Defaults to "hex".
+   * @returns A Promise that resolves to a ContractClient instance.
+   * @throws {TypeError} If the provided options object does not contain an rpcUrl.
    */
-  static async fromWasmHash(wasmHash: Buffer, options: ContractClientOptions): Promise<ContractClient> {
+  static async fromWasmHash(wasmHash: Buffer | string, 
+    options: ContractClientOptions, 
+    format: "hex" | "base64" = "hex"
+  ): Promise<ContractClient> {
     if (!options || !options.rpcUrl ) {
       throw new TypeError('options must contain rpcUrl');
     }
     const { rpcUrl, allowHttp } = options;
     const serverOpts: Server.Options = { allowHttp };
     const server = new Server(rpcUrl, serverOpts);
-    const wasm = await server.getContractWasmByHash(wasmHash);
+    const wasm = await server.getContractWasmByHash(wasmHash, format);
     return ContractClient.fromWasm(wasm, options);
   }
 
   /**
-   * Generate a ContractClient instance from the ContractClientOptions and the wasm binary
+   * Generates a ContractClient instance from the provided ContractClientOptions and the contract's wasm binary.
+   * 
+   * @param wasm The contract's wasm binary as a Buffer.
+   * @param options The ContractClientOptions object containing the necessary configuration.
+   * @returns A Promise that resolves to a ContractClient instance.
+   * @throws {Error} If the contract spec cannot be obtained from the provided wasm binary.
    */
   static async fromWasm(wasm: Buffer, options: ContractClientOptions): Promise<ContractClient> {
     const wasmModule = await WebAssembly.compile(wasm);
@@ -77,7 +92,11 @@ export class ContractClient {
   }
 
   /**
-   * Generate a ContractClient instance from the contractId and rpcUrl
+   * Generates a ContractClient instance from the provided ContractClientOptions, which must include the contractId and rpcUrl.
+   * 
+   * @param options The ContractClientOptions object containing the necessary configuration, including the contractId and rpcUrl.
+   * @returns A Promise that resolves to a ContractClient instance.
+   * @throws {TypeError} If the provided options object does not contain both rpcUrl and contractId.
    */
   static async from(options: ContractClientOptions): Promise<ContractClient> {
     if (!options || !options.rpcUrl || !options.contractId) {

--- a/src/contract_client/utils.ts
+++ b/src/contract_client/utils.ts
@@ -1,11 +1,11 @@
 // @ts-ignore
-import * as jsxdr from "@stellar/js-xdr";
-import { xdr } from "@stellar/stellar-base";
+import { XdrReader } from "@stellar/js-xdr";
+import { xdr } from "..";
 
 /**
  * The default timeout for waiting for a transaction to be included in a block.
  */
-export const DEFAULT_TIMEOUT = 10;
+export const DEFAULT_TIMEOUT = 5 * 60;
 
 /**
  * Keep calling a `fn` for `timeoutInSeconds` seconds, if `keepWaitingIf` is true.
@@ -89,8 +89,8 @@ export function implementsToString(obj: unknown): obj is { toString(): string } 
  * Reads a binary stream of ScSpecEntries into an array for processing by ContractSpec
  */
 export function processSpecEntryStream(buffer: Buffer) {
-  let reader = new jsxdr.XdrReader(buffer);
-  let res: xdr.ScSpecEntry[] = [];
+  const reader = new XdrReader(buffer);
+  const res: xdr.ScSpecEntry[] = [];
   while (reader._index < reader._length) {
     res.push(xdr.ScSpecEntry.read(reader));
   }

--- a/src/contract_client/utils.ts
+++ b/src/contract_client/utils.ts
@@ -1,7 +1,11 @@
+// @ts-ignore
+import * as jsxdr from "@stellar/js-xdr";
+import { xdr } from "@stellar/stellar-base";
+
 /**
  * The default timeout for waiting for a transaction to be included in a block.
  */
-export const DEFAULT_TIMEOUT = 5 * 60;
+export const DEFAULT_TIMEOUT = 10;
 
 /**
  * Keep calling a `fn` for `timeoutInSeconds` seconds, if `keepWaitingIf` is true.
@@ -12,7 +16,7 @@ export async function withExponentialBackoff<T>(
   keepWaitingIf: (result: T) => boolean,
   timeoutInSeconds: number,
   exponentialFactor = 1.5,
-  verbose = false,
+  verbose = false
 ): Promise<T[]> {
   const attempts: T[] = [];
 
@@ -34,7 +38,7 @@ export async function withExponentialBackoff<T>(
       console.info(
         `Waiting ${waitTime}ms before trying again (bringing the total wait time to ${totalWaitTime}ms so far, of total ${
           timeoutInSeconds * 1000
-        }ms)`,
+        }ms)`
       );
     }
     await new Promise((res) => setTimeout(res, waitTime));
@@ -56,8 +60,8 @@ export async function withExponentialBackoff<T>(
         } prev attempts. Most recent: ${JSON.stringify(
           attempts[attempts.length - 1],
           null,
-          2,
-        )}`,
+          2
+        )}`
       );
     }
   }
@@ -77,8 +81,18 @@ export const contractErrorPattern = /Error\(Contract, #(\d+)\)/;
 /**
  * A TypeScript type guard that checks if an object has a `toString` method.
  */
-export function implementsToString(
-  obj: unknown,
-): obj is { toString(): string } {
+export function implementsToString(obj: unknown): obj is { toString(): string } {
   return typeof obj === "object" && obj !== null && "toString" in obj;
+}
+
+/**
+ * Reads a binary stream of ScSpecEntries into an array for processing by ContractSpec
+ */
+export function processSpecEntryStream(buffer: Buffer) {
+  let reader = new jsxdr.XdrReader(buffer);
+  let res: xdr.ScSpecEntry[] = [];
+  while (reader._index < reader._length) {
+    res.push(xdr.ScSpecEntry.read(reader));
+  }
+  return res;
 }

--- a/src/contract_client/utils.ts
+++ b/src/contract_client/utils.ts
@@ -1,6 +1,4 @@
-// @ts-ignore
-import { XdrReader } from "@stellar/js-xdr";
-import { xdr } from "..";
+import { xdr, cereal } from "..";
 
 /**
  * The default timeout for waiting for a transaction to be included in a block.
@@ -89,9 +87,10 @@ export function implementsToString(obj: unknown): obj is { toString(): string } 
  * Reads a binary stream of ScSpecEntries into an array for processing by ContractSpec
  */
 export function processSpecEntryStream(buffer: Buffer) {
-  const reader = new XdrReader(buffer);
+  const reader = new cereal.XdrReader(buffer);
   const res: xdr.ScSpecEntry[] = [];
-  while (reader._index < reader._length) {
+  while (!reader.eof){
+    // @ts-ignore 
     res.push(xdr.ScSpecEntry.read(reader));
   }
   return res;

--- a/src/soroban/server.ts
+++ b/src/soroban/server.ts
@@ -248,18 +248,19 @@ export class Server {
    * @returns {Promise<Buffer>}   a Buffer containing the WASM bytecode
    *
    * @throws {Error} If the contract or its associated WASM bytecode cannot be
+   * :
    *    found on the network.
    *
    * @example
    * const contractId = "CCJZ5DGASBWQXR5MPFCJXMBI333XE5U3FSJTNQU7RIKE3P5GN2K2WYD5";
-   * server.getContractWasm(contractId).then(wasmBuffer => {
+   * server.getContractWasmByContractId(contractId).then(wasmBuffer => {
    *   console.log("WASM bytecode length:", wasmBuffer.length);
    *   // ... do something with the WASM bytecode ...
    * }).catch(err => {
    *   console.error("Error fetching WASM bytecode:", err);
    * });
    */
-  public async getContractWasm(
+  public async getContractWasmByContractId(
     contractId: string
   ): Promise<Buffer> {
     const contractLedgerKey = new Contract(contractId).getFootprint();
@@ -275,6 +276,35 @@ export class Server {
       .executable()
       .wasmHash();
 
+    return this.getContractWasmByHash(wasmHash);
+  }
+
+  /**
+   * Retrieves the WASM bytecode for a given contract hash.
+   *
+   * This method allows you to fetch the WASM bytecode associated with a contract
+   * deployed on the Soroban network using the contract's WASM hash. The WASM bytecode
+   * represents the executable code of the contract.
+   *
+   * @param {Buffer} wasmHash    the WASM hash of the contract
+   *
+   * @returns {Promise<Buffer>}   a Buffer containing the WASM bytecode
+   *
+   * @throws {Error} If the contract or its associated WASM bytecode cannot be
+   *    found on the network.
+   *
+   * @example
+   * const wasmHash = Buffer.from("...");
+   * server.getContractWasmByHash(wasmHash).then(wasmBuffer => {
+   *   console.log("WASM bytecode length:", wasmBuffer.length);
+   *   // ... do something with the WASM bytecode ...
+   * }).catch(err => {
+   *   console.error("Error fetching WASM bytecode:", err);
+   * });
+   */
+  public async getContractWasmByHash(
+    wasmHash: Buffer
+  ): Promise<Buffer> {
     const ledgerKeyWasmHash = xdr.LedgerKey.contractCode(
       new xdr.LedgerKeyContractCode({
         hash: wasmHash
@@ -289,6 +319,7 @@ export class Server {
 
     return Buffer.from(wasmBuffer);
   }
+
 
 
   /**

--- a/src/soroban/server.ts
+++ b/src/soroban/server.ts
@@ -305,7 +305,7 @@ export class Server {
     wasmHash: Buffer | string,
     format: undefined | "hex" | "base64" = undefined
   ): Promise<Buffer> {
-    const wasmHashBuffer = Buffer.from(wasmHash, format);
+    const wasmHashBuffer = wasmHash instanceof String ? Buffer.from(wasmHash, format) : wasmHash as Buffer;
 
     const ledgerKeyWasmHash = xdr.LedgerKey.contractCode(
       new xdr.LedgerKeyContractCode({

--- a/src/soroban/server.ts
+++ b/src/soroban/server.ts
@@ -242,9 +242,8 @@ export class Server {
    * deployed on the Soroban network. The WASM bytecode represents the executable
    * code of the contract.
    *
-   * @param {string|Address|Contract} contract    the contract ID containing the
-   *    WASM bytecode to retrieve, as a strkey (`C...` form), a {@link Contract},
-   *    or an {@link Address} instance
+   * @param {string} contractId    the contract ID containing the
+   *    WASM bytecode to retrieve
    *
    * @returns {Promise<Buffer>}   a Buffer containing the WASM bytecode
    *
@@ -261,27 +260,10 @@ export class Server {
    * });
    */
   public async getContractWasm(
-    contract: string | Address | Contract
+    contractId: string
   ): Promise<Buffer> {
     // coalesce `contract` param variants to an ScAddress
-    let scAddress: xdr.ScAddress;
-    if (typeof contract === 'string') {
-      scAddress = new Contract(contract).address().toScAddress();
-    } else if (contract instanceof Address) {
-      scAddress = contract.toScAddress();
-    } else if (contract instanceof Contract) {
-      scAddress = contract.address().toScAddress();
-    } else {
-      throw new TypeError(`unknown contract type: ${contract}`);
-    }
-
-    const contractLedgerKey = xdr.LedgerKey.contractData(
-      new xdr.LedgerKeyContractData({
-        contract: scAddress,
-        key: xdr.ScVal.scvSymbol('footprint'),
-        durability: xdr.ContractDataDurability.persistent()
-      })
-    );
+    const contractLedgerKey = new Contract(contractId).getFootprint();
 
     const response = await this.getLedgerEntries(contractLedgerKey);
     if (!response.entries.length || !response.entries[0]?.val) {

--- a/src/soroban/server.ts
+++ b/src/soroban/server.ts
@@ -285,12 +285,14 @@ export class Server {
 
     const response = await this.getLedgerEntries(contractLedgerKey);
     if (!response.entries.length || !response.entries[0]?.val) {
-      throw new Error(`Could not obtain contract from server`);
+      throw new Error(`Could not obtain contract hash from server`);
     }
 
-    const wasmHash = ((response.entries[0].val.value() as xdr.ContractDataEntry)
+    const wasmHash = response.entries[0].val
+      .contractData()
       .val()
-      .value() as xdr.ScContractInstance).executable()
+      .instance()
+      .executable()
       .wasmHash();
 
     const ledgerKeyWasmHash = xdr.LedgerKey.contractCode(
@@ -300,8 +302,10 @@ export class Server {
     );
 
     const responseWasm = await this.getLedgerEntries(ledgerKeyWasmHash);
-    const wasmBuffer = (responseWasm.entries[0].val.value() as xdr.ContractCodeEntry)
-      .code();
+    if(!responseWasm.entries.length || !responseWasm.entries[0]?.val){
+      throw new Error(`Could not obtain contract wasm from server`);
+    }
+    const wasmBuffer = responseWasm.entries[0].val.contractCode().code();
 
     return Buffer.from(wasmBuffer);
   }

--- a/src/soroban/server.ts
+++ b/src/soroban/server.ts
@@ -305,7 +305,7 @@ export class Server {
     wasmHash: Buffer | string,
     format: undefined | "hex" | "base64" = undefined
   ): Promise<Buffer> {
-    const wasmHashBuffer = wasmHash instanceof String ? Buffer.from(wasmHash, format) : wasmHash as Buffer;
+    const wasmHashBuffer = typeof wasmHash === "string" ? Buffer.from(wasmHash, format) : wasmHash as Buffer;
 
     const ledgerKeyWasmHash = xdr.LedgerKey.contractCode(
       new xdr.LedgerKeyContractCode({

--- a/src/soroban/server.ts
+++ b/src/soroban/server.ts
@@ -303,21 +303,9 @@ export class Server {
    */
   public async getContractWasmByHash(
     wasmHash: Buffer | string,
-    format: "hex" | "base64" = "hex"
+    format: undefined | "hex" | "base64" = undefined
   ): Promise<Buffer> {
-    let wasmHashBuffer: Buffer;
-
-    if (typeof wasmHash === "string") {
-      if (format === "hex") {
-        wasmHashBuffer = Buffer.from(wasmHash, "hex");
-      } else if (format === "base64") {
-        wasmHashBuffer = Buffer.from(wasmHash, "base64");
-      } else {
-        throw new TypeError("Invalid format. Supported formats: 'hex' or 'base64'" );
-      }
-    } else {
-      wasmHashBuffer = wasmHash;
-    }
+    const wasmHashBuffer = Buffer.from(wasmHash, format);
 
     const ledgerKeyWasmHash = xdr.LedgerKey.contractCode(
       new xdr.LedgerKeyContractCode({

--- a/src/soroban/server.ts
+++ b/src/soroban/server.ts
@@ -248,7 +248,6 @@ export class Server {
    * @returns {Promise<Buffer>}   a Buffer containing the WASM bytecode
    *
    * @throws {Error} If the contract or its associated WASM bytecode cannot be
-   * :
    *    found on the network.
    *
    * @example

--- a/src/soroban/server.ts
+++ b/src/soroban/server.ts
@@ -262,12 +262,10 @@ export class Server {
   public async getContractWasm(
     contractId: string
   ): Promise<Buffer> {
-    // coalesce `contract` param variants to an ScAddress
     const contractLedgerKey = new Contract(contractId).getFootprint();
-
     const response = await this.getLedgerEntries(contractLedgerKey);
     if (!response.entries.length || !response.entries[0]?.val) {
-      throw new Error(`Could not obtain contract hash from server`);
+      return Promise.reject({code: 404, message: `Could not obtain contract hash from server`});
     }
 
     const wasmHash = response.entries[0].val
@@ -285,7 +283,7 @@ export class Server {
 
     const responseWasm = await this.getLedgerEntries(ledgerKeyWasmHash);
     if(!responseWasm.entries.length || !responseWasm.entries[0]?.val){
-      throw new Error(`Could not obtain contract wasm from server`);
+      return Promise.reject({code: 404, message: `Could not obtain contract wasm from server`});
     }
     const wasmBuffer = responseWasm.entries[0].val.contractCode().code();
 

--- a/test/e2e/initialize.sh
+++ b/test/e2e/initialize.sh
@@ -22,7 +22,7 @@ else
   (cd "$dirname/../.." && cargo install_soroban)
 fi
 
-NETWORK_STATUS=$(curl -s -X POST "$SOROBAN_RPC_URL" -H "Content-Type: application/json" -d '{ "jsonrpc": "2.0", "id": 8675309, "method": "getHealth" }' | sed -n 's/.*"status":\s*"\([^"]*\)".*/\1/p')
+NETWORK_STATUS=$(curl -s -X POST "$SOROBAN_RPC_URL" -H "Content-Type: application/json" -d '{ "jsonrpc": "2.0", "id": 8675309, "method": "getHealth" }' | jq -r '.result.status')
 
 echo Network
 echo "  RPC:        $SOROBAN_RPC_URL"

--- a/test/e2e/initialize.sh
+++ b/test/e2e/initialize.sh
@@ -22,7 +22,7 @@ else
   (cd "$dirname/../.." && cargo install_soroban)
 fi
 
-NETWORK_STATUS=$(curl -s -X POST "$SOROBAN_RPC_URL" -H "Content-Type: application/json" -d '{ "jsonrpc": "2.0", "id": 8675309, "method": "getHealth" }' | sed 's/.*"status":"\(.*\)".*/\1/')
+NETWORK_STATUS=$(curl -s -X POST "$SOROBAN_RPC_URL" -H "Content-Type: application/json" -d '{ "jsonrpc": "2.0", "id": 8675309, "method": "getHealth" }' | sed -n 's/.*"status":\s*"\([^"]*\)".*/\1/p')
 
 echo Network
 echo "  RPC:        $SOROBAN_RPC_URL"

--- a/test/e2e/initialize.sh
+++ b/test/e2e/initialize.sh
@@ -22,7 +22,7 @@ else
   (cd "$dirname/../.." && cargo install_soroban)
 fi
 
-NETWORK_STATUS=$(curl -s -X POST "$SOROBAN_RPC_URL" -H "Content-Type: application/json" -d '{ "jsonrpc": "2.0", "id": 8675309, "method": "getHealth" }' | jq -r '.result.status')
+NETWORK_STATUS=$(curl -s -X POST "$SOROBAN_RPC_URL" -H "Content-Type: application/json" -d '{ "jsonrpc": "2.0", "id": 8675309, "method": "getHealth" }' | sed -n 's/.*"status":\s*"\([^"]*\)".*/\1/p')
 
 echo Network
 echo "  RPC:        $SOROBAN_RPC_URL"

--- a/test/e2e/src/test-contract-client-constructor.js
+++ b/test/e2e/src/test-contract-client-constructor.js
@@ -39,9 +39,9 @@ async function clientFromConstructor(contract, { keypair = generateFundedKeypair
   const xdr = JSON.parse(spawnSync("./target/bin/soroban", ["contract", "inspect", "--wasm", path, "--output", "xdr-base64-array"], { shell: true, encoding: "utf8" }).stdout.trim())
 
   const spec = new ContractSpec(xdr);
-  const wasmHash = contracts[contract].hash;
+  let wasmHash = contracts[contract].hash;
   if (!wasmHash) {
-    throw new Error(`No wasm hash found for \`contracts[${contract}]\`! ${JSON.stringify(contracts[contract], null, 2)}`)
+    wasmHash = spawnSync("./target/bin/soroban", ["contract", "install", "--wasm", path], { shell: true, encoding: "utf8" }).stdout.trim()
   }
 
   // TODO: do this with js-stellar-sdk, instead of shelling out to the CLI

--- a/test/e2e/src/test-contract-client-constructor.js
+++ b/test/e2e/src/test-contract-client-constructor.js
@@ -1,0 +1,110 @@
+const test = require('ava')
+const { spawnSync } = require('node:child_process')
+const { Address } = require('../../..')
+const { contracts, networkPassphrase, rpcUrl, friendbotUrl } = require('./util')
+const { ContractSpec } = require('../../..')
+const { Keypair } = require('../../..')
+
+const {
+  ContractClient,
+  basicNodeSigner,
+} = require('../../../lib/contract_client')
+
+async function generateFundedKeypair() {
+  const keypair = Keypair.random()
+  await fetch(`${friendbotUrl}/friendbot?addr=${keypair.publicKey()}`)
+  return keypair
+};
+
+/**
+ * Generates a ContractClient for the contract with the given name.
+ * Also generates a new account to use as as the keypair of this contract. This
+ * account is funded by friendbot. You can pass in an account to re-use the
+ * same account with multiple contract clients.
+ *
+ * By default, will re-deploy the contract every time. Pass in the same
+ * `contractId` again if you want to re-use the a contract instance.
+ */
+async function clientFromConstructor(contract, { keypair = generateFundedKeypair(), contractId } = {}) {
+  if (!contracts[contract]) {
+    throw new Error(
+      `Contract ${contract} not found. ` +
+      `Pick one of: ${Object.keys(contracts).join(", ")}`
+    )
+  }
+  keypair = await keypair // eslint-disable-line no-param-reassign
+  const wallet = basicNodeSigner(keypair, networkPassphrase)
+
+  const {path} = contracts[contract];
+  const xdr = JSON.parse(spawnSync("./target/bin/soroban", ["contract", "inspect", "--wasm", path, "--output", "xdr-base64-array"], { shell: true, encoding: "utf8" }).stdout.trim())
+
+  const spec = new ContractSpec(xdr);
+  const wasmHash = contracts[contract].hash;
+  if (!wasmHash) {
+    throw new Error(`No wasm hash found for \`contracts[${contract}]\`! ${JSON.stringify(contracts[contract], null, 2)}`)
+  }
+
+  // TODO: do this with js-stellar-sdk, instead of shelling out to the CLI
+  contractId = contractId ?? spawnSync("./target/bin/soroban", [ // eslint-disable-line no-param-reassign
+    "contract",
+    "deploy",
+    "--source",
+    keypair.secret(),
+    "--wasm-hash",
+    wasmHash,
+  ], { shell: true, encoding: "utf8" }).stdout.trim();
+
+  const client = new ContractClient(spec, {
+    networkPassphrase,
+    contractId,
+    rpcUrl,
+    allowHttp: true,
+    publicKey: keypair.publicKey(),
+    ...wallet,
+  });
+  return {
+    keypair,
+    client,
+    contractId,
+  }
+}
+
+/**
+ * Generates a ContractClient given the contractId using the from method.
+ */
+async function clientForFromTest(contractId, publicKey, keypair) {
+  keypair = await keypair; // eslint-disable-line no-param-reassign
+  const wallet = basicNodeSigner(keypair, networkPassphrase);
+  const options = {
+    networkPassphrase,
+    contractId,
+    rpcUrl,
+    allowHttp: true,
+    publicKey,
+    ...wallet,
+  };
+  return ContractClient.from(options);
+}
+
+test.before(async t => {
+  const { client, keypair, contractId } = await clientFromConstructor('customTypes')
+  const publicKey = keypair.publicKey()
+  const addr = Address.fromString(publicKey)
+  t.context = { client, publicKey, addr, contractId, keypair } // eslint-disable-line no-param-reassign
+});
+
+test('hello from constructor', async t => {
+  const { result } = await t.context.client.hello({ hello: 'tests' })
+  t.is(result, 'tests')
+})
+
+test('from', async (t) => {
+  // objects with different constructors will not pass deepEqual check
+  function constructorWorkaround(object) {
+    return JSON.parse(JSON.stringify(object));
+  }
+
+  const clientFromFrom = await clientForFromTest(t.context.contractId, t.context.publicKey, t.context.keypair);
+  t.deepEqual(constructorWorkaround(clientFromFrom), constructorWorkaround(t.context.client));
+  t.deepEqual(t.context.client.spec.entries, clientFromFrom.spec.entries);
+});

--- a/test/e2e/src/test-custom-types.js
+++ b/test/e2e/src/test-custom-types.js
@@ -1,7 +1,7 @@
 const test = require('ava')
 const { Address } = require('../../..')
 const { Ok, Err } = require('../../../lib/rust_types')
-const { clientFor, clientForFromTest, clientFromConstructor } = require('./util')
+const { clientFor } = require('./util')
 
 test.before(async t => {
   const { client, keypair, contractId } = await clientFor('customTypes')
@@ -14,13 +14,6 @@ test('hello', async t => {
   const { result } = await t.context.client.hello({ hello: 'tests' })
   t.is(result, 'tests')
 })
-
-test('hello from constructor', async t => {
-  const { client } = await clientFromConstructor('customTypes')
-  const { result } = await client.hello({ hello: 'tests' })
-  t.is(result, 'tests')
-})
-
 test("view method with empty keypair", async (t) => {
   const { client: client2 } = await clientFor('customTypes', {
     keypair: undefined,
@@ -150,16 +143,7 @@ test('u128', async t => {
   t.is((await t.context.client.u128({ u128: 1n })).result, 1n)
 })
 
-test('from', async (t) => {
-  // objects with different constructors will not pass deepEqual check
-  function constructorWorkaround(object) {
-    return JSON.parse(JSON.stringify(object));
-  }
 
-  const clientFromFrom = await clientForFromTest(t.context.contractId, t.context.publicKey, t.context.keypair);
-  t.deepEqual(constructorWorkaround(clientFromFrom), constructorWorkaround(t.context.client));
-  t.deepEqual(t.context.client.spec.entries, clientFromFrom.spec.entries);
-});
 
 test('multi_args', async t => {
   t.is((await t.context.client.multi_args({ a: 1, b: true })).result, 1)

--- a/test/e2e/src/test-custom-types.js
+++ b/test/e2e/src/test-custom-types.js
@@ -1,13 +1,13 @@
 const test = require('ava')
 const { Address } = require('../../..')
 const { Ok, Err } = require('../../../lib/rust_types')
-const { clientFor } = require('./util')
+const { clientFor, clientForFromTest } = require('./util')
 
 test.before(async t => {
   const { client, keypair, contractId } = await clientFor('customTypes')
   const publicKey = keypair.publicKey()
   const addr = Address.fromString(publicKey)
-  t.context = { client, publicKey, addr, contractId } // eslint-disable-line no-param-reassign
+  t.context = { client, publicKey, addr, contractId, keypair } // eslint-disable-line no-param-reassign
 });
 
 test('hello', async t => {
@@ -143,6 +143,16 @@ test('i128', async t => {
 test('u128', async t => {
   t.is((await t.context.client.u128({ u128: 1n })).result, 1n)
 })
+
+test('from', async (t) => {
+  function flattenInstance(object) {
+    return JSON.parse(JSON.stringify(object));
+  }
+
+  const clientFromFrom = await clientForFromTest(t.context.contractId, t.context.publicKey, t.context.keypair);
+  t.deepEqual(flattenInstance(clientFromFrom), flattenInstance(t.context.client));
+  t.deepEqual(t.context.client.spec.entries, clientFromFrom.spec.entries);
+});
 
 test('multi_args', async t => {
   t.is((await t.context.client.multi_args({ a: 1, b: true })).result, 1)

--- a/test/e2e/src/test-custom-types.js
+++ b/test/e2e/src/test-custom-types.js
@@ -1,7 +1,7 @@
 const test = require('ava')
 const { Address } = require('../../..')
 const { Ok, Err } = require('../../../lib/rust_types')
-const { clientFor, clientForFromTest } = require('./util')
+const { clientFor, clientForFromTest, clientFromConstructor } = require('./util')
 
 test.before(async t => {
   const { client, keypair, contractId } = await clientFor('customTypes')
@@ -12,6 +12,12 @@ test.before(async t => {
 
 test('hello', async t => {
   const { result } = await t.context.client.hello({ hello: 'tests' })
+  t.is(result, 'tests')
+})
+
+test('hello from constructor', async t => {
+  const { client } = await clientFromConstructor('customTypes')
+  const { result } = await client.hello({ hello: 'tests' })
   t.is(result, 'tests')
 })
 

--- a/test/e2e/src/test-custom-types.js
+++ b/test/e2e/src/test-custom-types.js
@@ -145,12 +145,13 @@ test('u128', async t => {
 })
 
 test('from', async (t) => {
-  function flattenInstance(object) {
+  // objects with different constructors will not pass deepEqual check
+  function constructorWorkaround(object) {
     return JSON.parse(JSON.stringify(object));
   }
 
   const clientFromFrom = await clientForFromTest(t.context.contractId, t.context.publicKey, t.context.keypair);
-  t.deepEqual(flattenInstance(clientFromFrom), flattenInstance(t.context.client));
+  t.deepEqual(constructorWorkaround(clientFromFrom), constructorWorkaround(t.context.client));
   t.deepEqual(t.context.client.spec.entries, clientFromFrom.spec.entries);
 });
 

--- a/test/e2e/src/util.js
+++ b/test/e2e/src/util.js
@@ -91,3 +91,22 @@ async function clientFor(contract, { keypair = generateFundedKeypair(), contract
   }
 }
 module.exports.clientFor = clientFor
+
+/**
+ * Generates a ContractClient given the contractId using the from method.
+ */
+async function clientForFromTest(contractId, publicKey, keypair) {
+  keypair = await keypair; // eslint-disable-line no-param-reassign
+  const wallet = basicNodeSigner(keypair, networkPassphrase);
+  const options = {
+    networkPassphrase,
+    contractId,
+    rpcUrl,
+    allowHttp: true,
+    publicKey,
+    ...wallet,
+  };
+  const client = await ContractClient.from(options);
+  return client;
+}
+module.exports.clientForFromTest = clientForFromTest;

--- a/test/e2e/src/util.js
+++ b/test/e2e/src/util.js
@@ -106,7 +106,6 @@ async function clientForFromTest(contractId, publicKey, keypair) {
     publicKey,
     ...wallet,
   };
-  const client = await ContractClient.from(options);
-  return client;
+  return ContractClient.from(options);
 }
 module.exports.clientForFromTest = clientForFromTest;

--- a/test/e2e/src/util.js
+++ b/test/e2e/src/util.js
@@ -81,7 +81,7 @@ async function clientFor(contract, { keypair = generateFundedKeypair(), contract
     allowHttp: true,
     publicKey: keypair.publicKey(),
     ...wallet,
-  });
+  }, "hex");
   return {
     keypair,
     client,

--- a/test/unit/server/soroban/get_contract_wasm_test.js
+++ b/test/unit/server/soroban/get_contract_wasm_test.js
@@ -1,0 +1,225 @@
+const { Address, xdr, hash, Contract } = StellarSdk;
+const { Server, AxiosClient } = StellarSdk.SorobanRpc;
+
+describe("Server#getContractWasm", () => {
+  beforeEach(function () {
+    this.server = new Server(serverUrl);
+    this.axiosMock = sinon.mock(AxiosClient);
+  });
+
+  afterEach(function () {
+    this.axiosMock.verify();
+    this.axiosMock.restore();
+  });
+
+  const contractId = "CCN57TGC6EXFCYIQJ4UCD2UDZ4C3AQCHVMK74DGZ3JYCA5HD4BY7FNPC";
+  const wasmHash = Buffer.from("kh1dFBiUKv/lXkcD+XnVTsbzi+Lps96lfWEk3rFWNnI=", "base64");
+  const wasmBuffer = Buffer.from("0061730120c0800010ab818080000b20002035503082000336232636439000", "hex");
+  const contractCodeEntryExtension = xdr.ContractCodeEntryExt.fromXDR(
+    "AAAAAQAAAAAAAAAAAAAVqAAAAJwAAAADAAAAAwAAABgAAAABAAAAAQAAABEAAAAgAAABpA==", "base64"
+  );
+
+  const contract = new Contract(contractId);
+  const contractLedgerKey = contract.getFootprint();
+  const address = contract.address();
+
+  const ledgerEntryWasmHash = xdr.LedgerEntryData.contractData(
+    new xdr.ContractDataEntry({
+      ext: new xdr.ExtensionPoint(0),
+      contract: address.toScAddress(),
+      durability: xdr.ContractDataDurability.persistent(),
+      key: xdr.ScVal.scvLedgerKeyContractInstance(),
+      val: xdr.ScVal.scvContractInstance(new xdr.ScContractInstance({executable: xdr.ContractExecutable.contractExecutableWasm(wasmHash), storage: null}))
+    }),
+  );
+  const ledgerKeyWasmHash = xdr.LedgerKey.contractData(
+    new xdr.LedgerKeyContractData({
+      contract: ledgerEntryWasmHash.contractData().contract(),
+      durability: ledgerEntryWasmHash.contractData().durability(),
+      key: ledgerEntryWasmHash.contractData().key(),
+    }),
+  );
+  const ledgerTtlEntryWasmHash = xdr.LedgerEntryData.ttl(
+    new xdr.TtlEntry({
+      keyHash: hash(ledgerKeyWasmHash.toXDR()),
+      liveUntilLedgerSeq: 1000,
+    }),
+  );
+
+  const wasmHashResult = {
+    lastModifiedLedgerSeq: 1,
+    key: ledgerKeyWasmHash,
+    val: ledgerEntryWasmHash,
+    liveUntilLedgerSeq: 1000,
+  };
+
+
+  const wasmLedgerKey = xdr.LedgerKey.contractCode(
+    new xdr.LedgerKeyContractCode({
+      hash: wasmHash
+    })
+  );
+  const wasmLedgerCode = xdr.LedgerEntryData.contractCode(
+    new xdr.ContractCodeEntry({
+      ext: contractCodeEntryExtension,
+      hash: wasmHash,
+      code: wasmBuffer,
+    })
+  );
+
+  const wasmLedgerTtlEntry = xdr.LedgerEntryData.ttl(
+    new xdr.TtlEntry({
+      keyHash: hash(wasmLedgerKey.toXDR()),
+      liveUntilLedgerSeq: 1000,
+    }),
+  );
+
+  const wasmResult = {
+    lastModifiedLedgerSeq: 1,
+    key: wasmLedgerKey,
+    val: wasmLedgerCode,
+    liveUntilLedgerSeq: 1000,
+  };
+
+  it("retrieves WASM bytecode for a contract", function (done) {
+
+
+    this.axiosMock
+      .expects("post")
+      .withArgs(serverUrl, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getLedgerEntries",
+        params: { keys: [contractLedgerKey.toXDR("base64")] },
+      })
+      .returns(
+        Promise.resolve({
+          data: {
+            result: {
+              latestLedger: 18039,
+              entries: [
+                {
+                  liveUntilLedgerSeq: ledgerTtlEntryWasmHash.ttl().liveUntilLedgerSeq(),
+                  lastModifiedLedgerSeq: wasmHashResult.lastModifiedLedgerSeq,
+                  xdr: ledgerEntryWasmHash.toXDR("base64"),
+                  key: contractLedgerKey.toXDR("base64"),
+                },
+              ],
+            },
+          },
+        })
+      );
+
+    this.axiosMock
+      .expects("post")
+      .withArgs(serverUrl, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getLedgerEntries",
+        params: { keys: [wasmLedgerKey.toXDR("base64")] },
+      })
+      .returns(
+        Promise.resolve({
+          data: {
+            result: {
+              latestLedger: 18039,
+              entries: [
+                {
+                  liveUntilLedgerSeq: wasmLedgerTtlEntry.ttl().liveUntilLedgerSeq(),
+                  lastModifiedLedgerSeq: wasmResult.lastModifiedLedgerSeq,
+                  key: wasmLedgerKey.toXDR("base64"),
+                  xdr: wasmLedgerCode.toXDR("base64"),
+                },
+              ],
+            },
+          },
+        })
+      );
+
+    this.server
+      .getContractWasm(contractId)
+      .then((wasmData) => {
+        expect(wasmData).to.eql(wasmBuffer);
+        done();
+      })
+      .catch((err) => done(err));
+  });
+
+  it("fails when wasmHash is not found", function (done) {
+    this.axiosMock
+      .expects("post")
+      .withArgs(serverUrl, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getLedgerEntries",
+        params: { keys: [contractLedgerKey.toXDR("base64")] },
+      })
+      .returns(Promise.resolve({ data: { result: { entries: [] } } }));
+
+    this.server
+      .getContractWasm(contractId)
+      .then(function (_response) {
+        done(new Error("Expected error"));
+      })
+      .catch(function (err) {
+        done(
+          err.code == 404
+            ? null
+            : new Error("Expected error code 404, got: " + err.code),
+        );
+      });
+  });
+
+  it("fails when wasm is not found", function (done) {
+    this.axiosMock
+      .expects("post")
+      .withArgs(serverUrl, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getLedgerEntries",
+        params: { keys: [contractLedgerKey.toXDR("base64")] },
+      })
+      .returns(
+        Promise.resolve({
+          data: {
+            result: {
+              latestLedger: 18039,
+              entries: [
+                {
+                  liveUntilLedgerSeq: ledgerTtlEntryWasmHash.ttl().liveUntilLedgerSeq(),
+                  lastModifiedLedgerSeq: wasmHashResult.lastModifiedLedgerSeq,
+                  xdr: ledgerEntryWasmHash.toXDR("base64"),
+                  key: contractLedgerKey.toXDR("base64"),
+                },
+              ],
+            },
+          },
+        })
+      );
+
+    this.axiosMock
+      .expects("post")
+      .withArgs(serverUrl, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getLedgerEntries",
+        params: { keys: [wasmLedgerKey.toXDR("base64")] },
+      })
+      .returns(Promise.resolve({ data: { result: { entries: [] } } }));
+
+    this.server
+      .getContractWasm(contractId)
+      .then(function (_response) {
+        done(new Error("Expected error"));
+      })
+      .catch(function (err) {
+        done(
+          err.code == 404
+            ? null
+            : new Error("Expected error code 404, got: " + err.code),
+        );
+      });
+  });
+
+
+});

--- a/test/unit/server/soroban/get_contract_wasm_test.js
+++ b/test/unit/server/soroban/get_contract_wasm_test.js
@@ -137,7 +137,7 @@ describe("Server#getContractWasm", () => {
       );
 
     this.server
-      .getContractWasm(contractId)
+      .getContractWasmByContractId(contractId)
       .then((wasmData) => {
         expect(wasmData).to.eql(wasmBuffer);
         done();
@@ -157,7 +157,7 @@ describe("Server#getContractWasm", () => {
       .returns(Promise.resolve({ data: { result: { entries: [] } } }));
 
     this.server
-      .getContractWasm(contractId)
+      .getContractWasmByContractId(contractId)
       .then(function (_response) {
         done(new Error("Expected error"));
       })
@@ -208,7 +208,7 @@ describe("Server#getContractWasm", () => {
       .returns(Promise.resolve({ data: { result: { entries: [] } } }));
 
     this.server
-      .getContractWasm(contractId)
+      .getContractWasmByContractId(contractId)
       .then(function (_response) {
         done(new Error("Expected error"));
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1383,10 +1383,10 @@
   resolved "https://registry.yarnpkg.com/@stellar/js-xdr/-/js-xdr-3.1.1.tgz#be0ff90c8a861d6e1101bca130fa20e74d5599bb"
   integrity sha512-3gnPjAz78htgqsNEDkEsKHKosV2BF2iZkoHCNxpmZwUxiPsw+2VaXMed8RRMe0rGk3d5GZe7RrSba8zV80J3Ag==
 
-"@stellar/stellar-base@11.1.0":
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/@stellar/stellar-base/-/stellar-base-11.1.0.tgz#4b561776cb102a87828379cd1ac5d3ce96db4fb3"
-  integrity sha512-nMg7QSpFqCZFq3Je/lG12+DY18y01QHRNyCxvjM8i4myS9tPRMDq7zqGcd215BGbCJxenckiOW45YJjQjzdcMQ==
+"@stellar/stellar-base@^12.0.0-rc.1":
+  version "12.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@stellar/stellar-base/-/stellar-base-12.0.0-rc.1.tgz#1c290b36eff54cb6492ce7b5f8de523488a276ba"
+  integrity sha512-Nm2WeqAnhfsZ2ETTttIJy8epgxGb03EXmWkcmxhyRd0us0qz++i0ry/cSnWaNYDWKipZTuepITUc4nM7o/s1tA==
   dependencies:
     "@stellar/js-xdr" "^3.1.1"
     base32.js "^0.1.0"
@@ -7721,6 +7721,7 @@ typedarray@^0.0.6:
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
 "typescript-5.4@npm:typescript@~5.4.0-0", typescript@^5.4.3:
+  name typescript-5.4
   version "5.4.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
   integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==


### PR DESCRIPTION
Adds a `from` method which uses the `contractId` to create an instance of the `ContractClient` by retrieving the wasm from the blockchain and extracting its `ContractSpec`. I also add a `fromWasm` method which bypasses the wasm retrieval portion if you already have the wasm buffer.
