### PR TITLE
feature: add auto restore functionality for contract client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ interface LedgerEntryChange {
 }
 ```
 
+- `contract.AssembledTransaction` now has a `restoreFootprint` method which accepts the
+`restorePreamble` returned when a simulation call fails due to some contract state that
+has expired. When invoking a contract function, one can now set `restore` to `true` in the
+`MethodOptions`. When enabled, a `restoreFootprint` transaction will be created and await
+signing whenever contract state is required to be restored before a contract function can
+be invoked.
 
 ## [v12.0.0-rc.3](https://github.com/stellar/js-stellar-sdk/compare/v11.3.0...v12.0.0-rc.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Added
+- `contract.AssembledTransaction` now has a `restoreFootprint` method which accepts the
+`restorePreamble` returned when a simulation call fails due to some contract state that
+has expired. When invoking a contract function, one can now set `restore` to `true` in the
+`MethodOptions`. When enabled, a `restoreFootprint` transaction will be created and await
+signing when required.
+
 
 ## [v12.0.1](https://github.com/stellar/js-stellar-sdk/compare/v11.3.0...v12.0.1)
 
@@ -24,11 +31,6 @@ interface LedgerEntryChange {
 }
 ```
 
-- `contract.AssembledTransaction` now has a `restoreFootprint` method which accepts the
-`restorePreamble` returned when a simulation call fails due to some contract state that
-has expired. When invoking a contract function, one can now set `restore` to `true` in the
-`MethodOptions`. When enabled, a `restoreFootprint` transaction will be created and await
-signing when required.
 
 ## [v12.0.0-rc.3](https://github.com/stellar/js-stellar-sdk/compare/v11.3.0...v12.0.0-rc.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,7 @@ interface LedgerEntryChange {
 `restorePreamble` returned when a simulation call fails due to some contract state that
 has expired. When invoking a contract function, one can now set `restore` to `true` in the
 `MethodOptions`. When enabled, a `restoreFootprint` transaction will be created and await
-signing whenever contract state is required to be restored before a contract function can
-be invoked.
+signing when required.
 
 ## [v12.0.0-rc.3](https://github.com/stellar/js-stellar-sdk/compare/v11.3.0...v12.0.0-rc.3)
 

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -821,27 +821,23 @@ export class AssembledTransaction<T> {
    *   transaction data.
    * - The `account` parameter should be an instance of a valid blockchain account.
    * 
-   * @param {Object} restorePreamble - The preamble object containing data required to 
-   * build the restore transaction.
-   * @param {string} restorePreamble.minResourceFee - The minimum fee required to restore 
-   * the necessary resources.
-   * @param {SorobanDataBuilder} restorePreamble.transactionData - The transaction data 
-   * required for the restoration process.
-   * @param {Account} account - The account that is executing the footprint restore operation.
-   * 
-   * @returns {Promise<Api.GetTransactionResponse>} - A promise resolving to the response 
-   * from the network after the restore transaction is submitted.
-   * 
    * @throws {Error} - Throws an error if no `signTransaction` function is provided during 
    * Client initialization.
    * @throws {AssembledTransaction.Errors.RestoreFailure} - Throws a custom error if the 
    * restore transaction fails, providing the details of the failure.
  */
   async restoreFootprint(
+    /**
+     * The preamble object containing data required to 
+     * build the restore transaction.
+     */
     restorePreamble: {
       minResourceFee: string;
       transactionData: SorobanDataBuilder;
     },
+    /**
+     * The account that is executing the footprint restore operation.
+     */
     account: Account
   ): Promise<Api.GetTransactionResponse> {
     if(!this.options.signTransaction){

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -513,16 +513,6 @@ export class AssembledTransaction<T> {
       );
     }
 
-    /*if (!simulation.result) {
-      throw new Error(
-        `Expected an invocation simulation, but got no 'result' field. Simulation: ${JSON.stringify(
-          simulation,
-          null,
-          2,
-        )}`,
-      );
-    }*/
-
     // add to object for serialization & deserialization
     this.simulationResult = simulation.result;
     this.simulationTransactionData = simulation.transactionData.build();

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -819,7 +819,6 @@ export class AssembledTransaction<T> {
    * - A `signTransaction` function must be provided during the Client initialization.
    * - The provided `restorePreamble` should include a minimum resource fee and valid
    *   transaction data.
-   * - The `account` parameter should be an instance of a valid blockchain account.
    * 
    * @throws {Error} - Throws an error if no `signTransaction` function is provided during 
    * Client initialization.
@@ -838,11 +837,12 @@ export class AssembledTransaction<T> {
     /**
      * The account that is executing the footprint restore operation.
      */
-    account: Account
+    account?: Account
   ): Promise<Api.GetTransactionResponse> {
     if(!this.options.signTransaction){
       throw new Error("For automatic restore to work you must provide a signTransaction function when initializing your Client");
     }
+    account = account ?? await getAccount(this.options, this.server);
     // first try restoring the contract
     const restoreTx = await AssembledTransaction.buildFootprintRestoreTransaction(
       { ...this.options },

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -485,7 +485,7 @@ export class AssembledTransaction<T> {
         return this;
       }
       throw new AssembledTransaction.Errors.RestoreFailure(
-        `You need to restore some contract state before invoking this method. Automatic restore failed:\n${JSON.stringify(result)}`
+        `Automatic restore failed! You set 'restore: true' but the attempted restore did not work. Result:\n${JSON.stringify(result)}`
       );
     }
 

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -27,6 +27,7 @@ import {
   DEFAULT_TIMEOUT,
   contractErrorPattern,
   implementsToString,
+  getAccount
 } from "./utils";
 import { SentTransaction } from "./sent_transaction";
 
@@ -373,20 +374,7 @@ export class AssembledTransaction<T> {
     });
   }
 
-  private static async getAccount<T>(
-    options: AssembledTransactionOptions<T>,
-    server?: Server
-  ): Promise<Account> {
-    if (!server) {
-      server = new Server(options.rpcUrl, {
-        allowHttp: options.allowHttp ?? false,
-      });
-    }
-    const account = options.publicKey
-      ? await server.getAccount(options.publicKey)
-      : new Account(NULL_ACCOUNT, "0");
-    return account;
-  }
+ 
 
   /**
    * Construct a new AssembledTransaction. This is the only way to create a new
@@ -412,7 +400,7 @@ export class AssembledTransaction<T> {
     const tx = new AssembledTransaction(options);
     const contract = new Contract(options.contractId);
 
-    const account = await AssembledTransaction.getAccount(
+    const account = await getAccount(
       options,
       tx.server
     );
@@ -460,7 +448,7 @@ export class AssembledTransaction<T> {
     this.simulation = await this.server.simulateTransaction(this.built);
 
     if (Api.isSimulationRestore(this.simulation) && restore) {
-      const account = await AssembledTransaction.getAccount(this.options, this.server);
+      const account = await getAccount(this.options, this.server);
       const result = await this.restoreFootprint(
         this.simulation.restorePreamble,
         account

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -431,11 +431,11 @@ export class AssembledTransaction<T> {
       .setSorobanData(sorobanData instanceof SorobanDataBuilder ? sorobanData.build() : sorobanData)
       .addOperation(Operation.restoreFootprint({}))
       .setTimeout(options.timeoutInSeconds ?? DEFAULT_TIMEOUT);
-    await tx.simulate(false);
+    await tx.simulate({ restore: false });
     return tx;
   }
 
-  simulate = async (restore?: boolean): Promise<this> => {
+  simulate = async ({ restore }: {restore?: boolean} = {}): Promise<this> => {
     if (!this.raw) {
       throw new Error(
         "Transaction has not yet been assembled; " +

--- a/src/contract/sent_transaction.ts
+++ b/src/contract/sent_transaction.ts
@@ -66,7 +66,6 @@ export class SentTransaction<T> {
     });
   }
 
-
   /**
    * Initialize a `SentTransaction` from an existing `AssembledTransaction` and
    * a `signTransaction` function. This will also send the transaction to the
@@ -80,11 +79,11 @@ export class SentTransaction<T> {
     updateTimeout: boolean = true,
   ): Promise<SentTransaction<U>> => {
     const tx = new SentTransaction(signTransaction, assembled);
-    const sent = await tx.send(updateTimeout);
+    const sent = await tx.send({ updateTimeout });
     return sent;
   };
 
-  private send = async (updateTimeout: boolean = true): Promise<this> => {
+  private send = async ({ updateTimeout }: {updateTimeout?: boolean } =  { updateTimeout: true }): Promise<this> => {
     const timeoutInSeconds =
       this.assembled.options.timeoutInSeconds ?? DEFAULT_TIMEOUT;
     if(updateTimeout) {

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -109,6 +109,12 @@ export type MethodOptions = {
    * AssembledTransaction. Default: true
    */
   simulate?: boolean;
+
+  /**
+   * If true, will automatically attempt to restore the transaction if there 
+   * are archived entries that need renewal. @default false
+   */
+  restore?: boolean;
 };
 
 export type AssembledTransactionOptions<T = string> = MethodOptions &

--- a/src/contract/utils.ts
+++ b/src/contract/utils.ts
@@ -1,5 +1,8 @@
-import { xdr, cereal } from "@stellar/stellar-base";
-import type { AssembledTransaction } from "./assembled_transaction";
+import { xdr, cereal, Account } from "@stellar/stellar-base";
+import { Server } from "../rpc/server";
+import { NULL_ACCOUNT, type AssembledTransaction } from "./assembled_transaction";
+import { AssembledTransactionOptions } from "./types";
+
 
 /**
  * The default timeout for waiting for a transaction to be included in a block.
@@ -106,4 +109,13 @@ export function processSpecEntryStream(buffer: Buffer) {
     res.push(xdr.ScSpecEntry.read(reader));
   }
   return res;
+}
+
+export async function getAccount<T>(
+  options: AssembledTransactionOptions<T>,
+  server: Server
+): Promise<Account> {
+  return options.publicKey
+    ? await server.getAccount(options.publicKey)
+    : new Account(NULL_ACCOUNT, "0");
 }

--- a/test/unit/server/soroban/assembled_transaction_test.js
+++ b/test/unit/server/soroban/assembled_transaction_test.js
@@ -38,7 +38,7 @@ describe("AssembledTransaction.buildFootprintRestoreTransaction", () => {
 
 
 
-  it("assembled transaction restore footprint works", function (done) {
+  it("makes expected RPC calls", function (done) {
     const simulateTransactionResponse = {
       transactionData: restoreTxnData,
       minResourceFee: "52641",

--- a/test/unit/server/soroban/assembled_transaction_test.js
+++ b/test/unit/server/soroban/assembled_transaction_test.js
@@ -12,7 +12,7 @@ const { Server, AxiosClient, parseRawSimulation } = StellarSdk.rpc;
 const randomSecret = Keypair.random().secret();
 const restoreTxnData = StellarSdk.SorobanDataBuilder.fromXDR("AAAAAAAAAAAAAAAEAAAABgAAAAHZ4Y4l0GNoS97QH0fa5Jbbm61Ou3t9McQ09l7wREKJYwAAAA8AAAAJUEVSU19DTlQxAAAAAAAAAQAAAAYAAAAB2eGOJdBjaEve0B9H2uSW25utTrt7fTHENPZe8ERCiWMAAAAPAAAACVBFUlNfQ05UMgAAAAAAAAEAAAAGAAAAAdnhjiXQY2hL3tAfR9rkltubrU67e30xxDT2XvBEQoljAAAAFAAAAAEAAAAH+BoQswzzGTKRzrdC6axxKaM4qnyDP8wgQv8Id3S4pbsAAAAAAAAGNAAABjQAAAAAAADNoQ==");
 
-describe("Server#assembledTransaction", () => {
+describe("AssembledTransaction.buildFootprintRestoreTransaction", () => {
   const keypair = Keypair.random();
   const contractId = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
   const networkPassphrase = "Standalone Network ; February 2017";

--- a/test/unit/server/soroban/assembled_transaction_test.js
+++ b/test/unit/server/soroban/assembled_transaction_test.js
@@ -9,7 +9,6 @@ const {
 } = StellarSdk;
 const { Server, AxiosClient, parseRawSimulation } = StellarSdk.rpc;
 
-const randomSecret = Keypair.random().secret();
 const restoreTxnData = StellarSdk.SorobanDataBuilder.fromXDR("AAAAAAAAAAAAAAAEAAAABgAAAAHZ4Y4l0GNoS97QH0fa5Jbbm61Ou3t9McQ09l7wREKJYwAAAA8AAAAJUEVSU19DTlQxAAAAAAAAAQAAAAYAAAAB2eGOJdBjaEve0B9H2uSW25utTrt7fTHENPZe8ERCiWMAAAAPAAAACVBFUlNfQ05UMgAAAAAAAAEAAAAGAAAAAdnhjiXQY2hL3tAfR9rkltubrU67e30xxDT2XvBEQoljAAAAFAAAAAEAAAAH+BoQswzzGTKRzrdC6axxKaM4qnyDP8wgQv8Id3S4pbsAAAAAAAAGNAAABjQAAAAAAADNoQ==");
 
 describe("AssembledTransaction.buildFootprintRestoreTransaction", () => {

--- a/test/unit/server/soroban/assembled_transaction_test.js
+++ b/test/unit/server/soroban/assembled_transaction_test.js
@@ -1,0 +1,123 @@
+const {
+  Account,
+  Keypair,
+  Networks,
+  rpc,
+  SorobanDataBuilder,
+  xdr,
+  contract,
+} = StellarSdk;
+const { Server, AxiosClient, parseRawSimulation } = StellarSdk.rpc;
+
+const randomSecret = Keypair.random().secret();
+const restoreTxnData = StellarSdk.SorobanDataBuilder.fromXDR("AAAAAAAAAAAAAAAEAAAABgAAAAHZ4Y4l0GNoS97QH0fa5Jbbm61Ou3t9McQ09l7wREKJYwAAAA8AAAAJUEVSU19DTlQxAAAAAAAAAQAAAAYAAAAB2eGOJdBjaEve0B9H2uSW25utTrt7fTHENPZe8ERCiWMAAAAPAAAACVBFUlNfQ05UMgAAAAAAAAEAAAAGAAAAAdnhjiXQY2hL3tAfR9rkltubrU67e30xxDT2XvBEQoljAAAAFAAAAAEAAAAH+BoQswzzGTKRzrdC6axxKaM4qnyDP8wgQv8Id3S4pbsAAAAAAAAGNAAABjQAAAAAAADNoQ==");
+
+describe("Server#assembledTransaction", () => {
+  const keypair = Keypair.random();
+  const contractId = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
+  const networkPassphrase = "Standalone Network ; February 2017";
+  const wallet = contract.basicNodeSigner(keypair, networkPassphrase);
+  const options = {
+      networkPassphrase,
+      contractId,
+      rpcUrl: serverUrl,
+      allowHttp: true,
+      publicKey: keypair.publicKey(),
+      ...wallet,
+    }
+
+  beforeEach(function () {
+    this.server = new Server(serverUrl);
+    this.axiosMock = sinon.mock(AxiosClient);
+  });
+
+  afterEach(function () {
+    this.axiosMock.verify();
+    this.axiosMock.restore();
+  });
+
+
+
+  it("assembled transaction restore footprint works", function (done) {
+    const simulateTransactionResponse = {
+      transactionData: restoreTxnData,
+      minResourceFee: "52641",
+      cost: { cpuInsns: "0", memBytes: "0" },
+      latestLedger: 17027,
+    };
+
+    const sendTransactionResponse = {
+      "status": "PENDING",
+      "hash": "05870e35fc94e5424f72d125959760b5f60631d91452bde2d11126fb5044e35d",
+      "latestLedger": 17034,
+      "latestLedgerCloseTime": "1716483573"
+    };
+    const getTransactionResponse = {
+      status: "SUCCESS",
+      latestLedger: 17037,
+      latestLedgerCloseTime: "1716483576",
+      oldestLedger: 15598,
+      oldestLedgerCloseTime: "1716482133",
+      applicationOrder: 1,
+      envelopeXdr: "AAAAAgAAAAARwpJYOq4lKj/RdtS7ds3ciGSMfZUp+7d4xgg9vsN7qQABm0IAAAvWAAAAAwAAAAEAAAAAAAAAAAAAAABmT3cbAAAAAAAAAAEAAAAAAAAAGgAAAAAAAAABAAAAAAAAAAAAAAAEAAAABgAAAAHZ4Y4l0GNoS97QH0fa5Jbbm61Ou3t9McQ09l7wREKJYwAAAA8AAAAJUEVSU19DTlQxAAAAAAAAAQAAAAYAAAAB2eGOJdBjaEve0B9H2uSW25utTrt7fTHENPZe8ERCiWMAAAAPAAAACVBFUlNfQ05UMgAAAAAAAAEAAAAGAAAAAdnhjiXQY2hL3tAfR9rkltubrU67e30xxDT2XvBEQoljAAAAFAAAAAEAAAAH+BoQswzzGTKRzrdC6axxKaM4qnyDP8wgQv8Id3S4pbsAAAAAAAAGNAAABjQAAAAAAADNoQAAAAG+w3upAAAAQGBfsx+gyi/2Dh6i+7Vbb6Ongw3HDcFDZ48eoadkUUvkq97zdPe3wYGFswZgT5/GXPqGDBi+iqHuZiYx5eSy3Qk=",
+      resultXdr: "AAAAAAAAiRkAAAAAAAAAAQAAAAAAAAAaAAAAAAAAAAA=",
+      resultMetaXdr: "AAAAAwAAAAAAAAACAAAAAwAAQowAAAAAAAAAABHCklg6riUqP9F21Lt2zdyIZIx9lSn7t3jGCD2+w3upAAAAF0h1Pp0AAAvWAAAAAgAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAMAAAAAAAAMMQAAAABmTz9yAAAAAAAAAAEAAEKMAAAAAAAAAAARwpJYOq4lKj/RdtS7ds3ciGSMfZUp+7d4xgg9vsN7qQAAABdIdT6dAAAL1gAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAAAAQowAAAAAZk919wAAAAAAAAABAAAACAAAAAMAAAwrAAAACc4pIDe7y0sRFHAghrdpB7ypfj4BVuZStvX4u0BC1S/YAAANVgAAAAAAAAABAABCjAAAAAnOKSA3u8tLERRwIIa3aQe8qX4+AVbmUrb1+LtAQtUv2AAAQ7cAAAAAAAAAAwAADCsAAAAJikpmJa7Pr3lTb+dhRP2N4TOYCqK4tL4tQhDYnNEijtgAAA1WAAAAAAAAAAEAAEKMAAAACYpKZiWuz695U2/nYUT9jeEzmAqiuLS+LUIQ2JzRIo7YAABDtwAAAAAAAAADAAAMMQAAAAlT7LdEin/CaQA3iscHqkwnEFlSh8jfTPTIhSQ5J8Ao0wAADVwAAAAAAAAAAQAAQowAAAAJU+y3RIp/wmkAN4rHB6pMJxBZUofI30z0yIUkOSfAKNMAAEO3AAAAAAAAAAMAAAwxAAAACQycyCYjh7j9CHnTm9OKCYXhgmXw6jdtoMsGHyPk8Aa+AAANXAAAAAAAAAABAABCjAAAAAkMnMgmI4e4/Qh505vTigmF4YJl8Oo3baDLBh8j5PAGvgAAQ7cAAAAAAAAAAgAAAAMAAEKMAAAAAAAAAAARwpJYOq4lKj/RdtS7ds3ciGSMfZUp+7d4xgg9vsN7qQAAABdIdT6dAAAL1gAAAAMAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAAAAQowAAAAAZk919wAAAAAAAAABAABCjAAAAAAAAAAAEcKSWDquJSo/0XbUu3bN3IhkjH2VKfu3eMYIPb7De6kAAAAXSHWDiQAAC9YAAAADAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAAAAEKMAAAAAGZPdfcAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      ledger: 17036,
+      createdAt: "1716483575",
+    };
+    this.axiosMock
+      .expects("post")
+      .withArgs(
+        serverUrl,
+        sinon.match({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "simulateTransaction",
+        })
+      )
+      .returns(Promise.resolve({ data: { result: simulateTransactionResponse } }));
+    this.axiosMock
+      .expects("post")
+      .withArgs(serverUrl, 
+        sinon.match({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "getTransaction",
+        })
+      )
+      .returns(Promise.resolve({ data: { result: getTransactionResponse } }));
+
+    this.axiosMock
+      .expects("post")
+      .withArgs(serverUrl, 
+        sinon.match({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "sendTransaction",
+        })
+      )
+      .returns(Promise.resolve({ data: { result: sendTransactionResponse } }));
+
+  contract.AssembledTransaction.buildFootprintRestoreTransaction(
+    options,
+    restoreTxnData,
+    new StellarSdk.Account(
+      "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI",
+      "1",
+    ),
+    52641,
+  )
+    .then((txn) => txn.signAndSend({force: true, ...wallet,
+      updateTimeout: false
+    }))
+    .then((result) => {
+      expect(result.getTransactionResponse.status).to.equal(rpc.Api.GetTransactionStatus.SUCCESS);
+      done();
+    })
+    .catch((error) => {
+      // handle any errors that occurred during the promise chain
+      done(error);
+    });
+
+  })
+});

--- a/test/unit/server/soroban/assembled_transaction_test.js
+++ b/test/unit/server/soroban/assembled_transaction_test.js
@@ -107,9 +107,7 @@ describe("AssembledTransaction.buildFootprintRestoreTransaction", () => {
     ),
     52641,
   )
-    .then((txn) => txn.signAndSend({force: true, ...wallet,
-      updateTimeout: false
-    }))
+    .then((txn) => txn.signAndSend({ ...wallet }))
     .then((result) => {
       expect(result.getTransactionResponse.status).to.equal(rpc.Api.GetTransactionStatus.SUCCESS);
       done();


### PR DESCRIPTION
Adds the ability to set `restore` to true in contract method invocation options. This will utilize the signTransaction method to sign a restoreFootprint operation when found that it is needed during a simulation. 