### PR TITLE
add toXDR and fromXDR for multiauth flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Added
+- `contract.AssembledTransaction` now has a `toXDR` and `fromXDR` method for serializing the
+transaction to and from XDR. Additionally, `contract.Client` now has a `txFromXDR`. These methods
+should be used in place of `AssembledTransaction.toJSON`, `AssembledTransaction.fromJSON`, and
+`Client.txFromJSON` for multi-auth signing. The JSON methods are now deprecated. **Note you must now
+call `simulate` on the transaction before the final `signAndSend` call after all required signatures
+are gathered when using the XDR methods.
+
+### Deprecated
+- In `contract.AssembledTransaction`, `toJSON` and `fromJSON` should be replaced with `toXDR` and
+`fromXDR`. Similarly, in `contract.Client`, `txFromJSON` should be replaced with `txFromXDR`.
+
 
 ## [v12.0.1](https://github.com/stellar/js-stellar-sdk/compare/v11.3.0...v12.0.1)
 

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -446,7 +446,7 @@ export class AssembledTransaction<T> {
   }
 
   simulate = async (): Promise<this> => {
-    if(!this.built){
+    if (!this.built) {
       if (!this.raw) {
         throw new Error(
           "Transaction has not yet been assembled; " +

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -387,7 +387,6 @@ export class AssembledTransaction<T> {
     const envelope = xdr.TransactionEnvelope.fromXDR(encodedXDR, "base64");
     const built = TransactionBuilder.fromXDR(envelope, options.networkPassphrase) as Tx;
     const method = ((built.operations[0] as Operation.InvokeHostFunction).func.value() as xdr.InvokeContractArgs).functionName().toString('utf-8');
-    console.log(`method name is ${method}`);
     const txn = new AssembledTransaction(
       { ...options, 
         method,

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -28,6 +28,7 @@ import {
   implementsToString,
 } from "./utils";
 import { SentTransaction } from "./sent_transaction";
+import { Spec } from "./spec";
 
 export const NULL_ACCOUNT =
   "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
@@ -364,6 +365,40 @@ export class AssembledTransaction<T> {
     return txn;
   }
 
+  /**
+   * Serialize the AssembledTransaction to a base64-encoded XDR string.
+   */
+  toXDR(): string {
+    if(!this.built) throw new Error(
+        "Transaction has not yet been simulated; " +
+        "call `AssembledTransaction.simulate` first.",
+      );
+    return this.built?.toEnvelope().toXDR('base64');
+  }
+
+  /**
+   * Deserialize the AssembledTransaction from a base64-encoded XDR string.
+   */
+  static fromXDR<T>(
+    options: Omit<AssembledTransactionOptions<T>, "args" | "method" | "parseResultXdr">,
+    encodedXDR: string,
+    spec: Spec
+  ): AssembledTransaction<T> {
+    const envelope = xdr.TransactionEnvelope.fromXDR(encodedXDR, "base64");
+    const built = TransactionBuilder.fromXDR(envelope, options.networkPassphrase) as Tx;
+    const method = ((built.operations[0] as Operation.InvokeHostFunction).func.value() as xdr.InvokeContractArgs).functionName().toString('utf-8');
+    console.log(`method name is ${method}`);
+    const txn = new AssembledTransaction(
+      { ...options, 
+        method,
+        parseResultXdr: (result: xdr.ScVal) =>
+          spec.funcResToNative(method, result),
+      }
+     );
+    txn.built = built;
+    return txn;
+  }
+
   private constructor(public options: AssembledTransactionOptions<T>) {
     this.options.simulate = this.options.simulate ?? true;
     this.server = new Server(this.options.rpcUrl, {
@@ -412,14 +447,16 @@ export class AssembledTransaction<T> {
   }
 
   simulate = async (): Promise<this> => {
-    if (!this.raw) {
-      throw new Error(
-        "Transaction has not yet been assembled; " +
-        "call `AssembledTransaction.build` first.",
-      );
-    }
+    if(!this.built){
+      if (!this.raw) {
+        throw new Error(
+          "Transaction has not yet been assembled; " +
+          "call `AssembledTransaction.build` first.",
+        );
+      }
 
-    this.built = this.raw.build();
+      this.built = this.raw.build();
+    }
     this.simulation = await this.server.simulateTransaction(this.built);
 
     if (Api.isSimulationSuccess(this.simulation)) {

--- a/src/contract/client.ts
+++ b/src/contract/client.ts
@@ -124,5 +124,8 @@ export class Client {
       tx,
     );
   };
+
+  txFromXDR = <T>(xdrBase64: string): AssembledTransaction<T> => AssembledTransaction.fromXDR(this.options, xdrBase64, this.spec);
+
 }
 

--- a/test/e2e/src/test-swap.js
+++ b/test/e2e/src/test-swap.js
@@ -100,32 +100,33 @@ describe("Swap Contract Tests", function () {
     expect(needsNonInvokerSigningBy.indexOf(this.context.bob.publicKey())).to.equal(1, "needsNonInvokerSigningBy does not have bob's public key!");
 
     // root serializes & sends to alice
-    const jsonFromRoot = tx.toJSON();
+    const xdrFromRoot = tx.toXDR();
     const { client: clientAlice } = await clientFor("swap", {
       keypair: this.context.alice,
       contractId: this.context.swapId,
     });
-    const txAlice = clientAlice.txFromJSON(jsonFromRoot);
+    const txAlice = clientAlice.txFromXDR(xdrFromRoot);
     await txAlice.signAuthEntries();
 
     // alice serializes & sends to bob
-    const jsonFromAlice = txAlice.toJSON();
+    const xdrFromAlice = txAlice.toXDR();
     const { client: clientBob } = await clientFor("swap", {
       keypair: this.context.bob,
       contractId: this.context.swapId,
     });
-    const txBob = clientBob.txFromJSON(jsonFromAlice);
+    const txBob = clientBob.txFromXDR(xdrFromAlice);
     await txBob.signAuthEntries();
 
     // bob serializes & sends back to root
-    const jsonFromBob = txBob.toJSON();
+    const xdrFromBob = txBob.toXDR();
     const { client: clientRoot } = await clientFor("swap", {
       keypair: this.context.root,
       contractId: this.context.swapId,
     });
-    const txRoot = clientRoot.txFromJSON(jsonFromBob);
+    const txRoot = clientRoot.txFromXDR(xdrFromBob);
 
-    const result = await txRoot.signAndSend();
+  await txRoot.simulate();
+  const result = await txRoot.signAndSend({force: true});
 
     expect(result).to.have.property('sendTransactionResponse');
     expect(result.sendTransactionResponse).to.have.property('status', 'PENDING');

--- a/test/e2e/src/test-swap.js
+++ b/test/e2e/src/test-swap.js
@@ -125,8 +125,8 @@ describe("Swap Contract Tests", function () {
     });
     const txRoot = clientRoot.txFromXDR(xdrFromBob);
 
-  await txRoot.simulate();
-  const result = await txRoot.signAndSend({force: true});
+    await txRoot.simulate();
+    const result = await txRoot.signAndSend();
 
     expect(result).to.have.property('sendTransactionResponse');
     expect(result.sendTransactionResponse).to.have.property('status', 'PENDING');


### PR DESCRIPTION
Addresses https://github.com/stellar/js-stellar-sdk/issues/976

Adds a `toXDR` and `fromXDR` for `AssembledTransaction` class. Also adds a `txFromXDR` to the Client class. Changes the swap test to use this flow. 

Limitations: If you use the XDR multi-auth flow, you must resimulate before the final `signAndSend` call. This is due to the fact that we can't serialize the XDR of the transaction envelope with the results of the simulation. If we want to do this, we would need to add an AssembledTransaction type to XDR in Stellar Base. 