### PR TITLE
build: update pinned CLI version for e2e tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 # paths = ["/path/to/override"] # path dependency overrides
 
 [alias] # command aliases
-install_soroban = "install --version 21.0.0-preview.1 --root ./target soroban-cli --debug"
+install_soroban = "install --version 21.0.0-rc.1 --root ./target soroban-cli --debug"
 # b = "build --target wasm32-unknown-unknown --release"
 # c = "check"
 # t = "test"


### PR DESCRIPTION
Using `rc.1` instead of `preview.1`