### PR TITLE
feat: separate sign and send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Added
+- `contract.AssembledTransaction` now supports separate `sign` and `send` methods so that you can sign a transaction without sending it.
+
 
 ## [v12.0.1](https://github.com/stellar/js-stellar-sdk/compare/v11.3.0...v12.0.1)
 

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -509,9 +509,8 @@ export class AssembledTransaction<T> {
   }
 
   /**
-   * Sign the transaction with the `wallet`, included previously. If you did
-   * not previously include one, you need to include one now that at least
-   * includes the `signTransaction` method. 
+   * Sign the transaction with the signTransaction function included previously. 
+   * If you did not previously include one, you need to include one now.
    */
   sign = async ({
     force = false,
@@ -587,11 +586,10 @@ export class AssembledTransaction<T> {
   }
 
   /**
-   * Sign the transaction with the `wallet`, included previously. If you did
-   * not previously include one, you need to include one now that at least
-   * includes the `signTransaction` method. After signing, this method will
-   * send the transaction to the network and return a `SentTransaction` that
-   * keeps track of all the attempts to fetch the transaction.
+   * Sign the transaction with the `signTransaction` function included previously. 
+   * If you did not previously include one, you need to include one now. 
+   * After signing, this method will send the transaction to the network and 
+   * return a `SentTransaction` that keeps track * of all the attempts to fetch the transaction.
    */
   signAndSend = async ({
     force = false,

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -580,7 +580,7 @@ export class AssembledTransaction<T> {
    */
   async send(){
     if(!this.signed){
-      throw new Error("The transaction has not yet been signed. Run `sign` first.");
+      throw new Error("The transaction has not yet been signed. Run `sign` first, or use `signAndSend` instead.");
     }
     const typeChecked: AssembledTransaction<T> = this;
     const sent = await SentTransaction.init(typeChecked, this.signed);

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -582,8 +582,7 @@ export class AssembledTransaction<T> {
     if(!this.signed){
       throw new Error("The transaction has not yet been signed. Run `sign` first, or use `signAndSend` instead.");
     }
-    const typeChecked: AssembledTransaction<T> = this;
-    const sent = await SentTransaction.init(typeChecked, this.signed);
+    const sent = await SentTransaction.init(this.options, this.signed);
     return sent;
   }
 

--- a/src/contract/sent_transaction.ts
+++ b/src/contract/sent_transaction.ts
@@ -58,12 +58,19 @@ export class SentTransaction<T> {
   }
 
   /**
-   * Initialize a `SentTransaction` from an existing `AssembledTransaction` and
-   * a `signed` AssembledTransaction. This will also send the transaction to the
-   * network.
+   * Initialize a `SentTransaction` from `options` and a `signed` 
+   * AssembledTransaction. This will also send the transaction to the network.
    */
   static init = async <U>(
-    /** {@link SentTransactionOptions} from which this SentTransaction was initialized */
+    /**
+     * Configuration options for initializing the SentTransaction.
+     * 
+     * @typedef {Object} SentTransactionOptions
+     * @property {number} [timeoutInSeconds] - Optional timeout duration in seconds for the transaction.
+     * @property {string} rpcUrl - The RPC URL of the network to which the transaction will be sent.
+     * @property {boolean} [allowHttp] - Optional flag to allow HTTP connections (default is false, HTTPS is preferred).
+     * @property {(xdr: xdr.ScVal) => U} parseResultXdr - Function to parse the XDR result returned by the network.
+     */
     options: SentTransactionOptions<U>,
     /** The signed transaction to send to the network */
     signed: Tx,

--- a/src/contract/sent_transaction.ts
+++ b/src/contract/sent_transaction.ts
@@ -1,7 +1,6 @@
 /* disable max-classes rule, because extending error shouldn't count! */
 /* eslint max-classes-per-file: 0 */
-import { SorobanDataBuilder, TransactionBuilder } from "@stellar/stellar-base";
-import type { ClientOptions, MethodOptions, Tx } from "./types";
+import type { MethodOptions, Tx } from "./types";
 import { Server } from "../rpc/server"
 import { Api } from "../rpc/api"
 import { DEFAULT_TIMEOUT, withExponentialBackoff } from "./utils";
@@ -23,8 +22,6 @@ import type { AssembledTransaction } from "./assembled_transaction";
  */
 export class SentTransaction<T> {
   public server: Server;
-
-  public signed?: Tx;
 
   /**
    * The result of calling `sendTransaction` to broadcast the transaction to the
@@ -53,14 +50,10 @@ export class SentTransaction<T> {
   };
 
   constructor(
-    public signTransaction: ClientOptions["signTransaction"],
     public assembled: AssembledTransaction<T>,
+
+    public signed: Tx,
   ) {
-    if (!signTransaction) {
-      throw new Error(
-        "You must provide a `signTransaction` function to send a transaction",
-      );
-    }
     this.server = new Server(this.assembled.options.rpcUrl, {
       allowHttp: this.assembled.options.allowHttp ?? false,
     });
@@ -68,46 +61,21 @@ export class SentTransaction<T> {
 
   /**
    * Initialize a `SentTransaction` from an existing `AssembledTransaction` and
-   * a `signTransaction` function. This will also send the transaction to the
+   * a `signed` AssembledTransaction. This will also send the transaction to the
    * network.
    */
   static init = async <U>(
-    /** More info in {@link MethodOptions} */
-    signTransaction: ClientOptions["signTransaction"],
     /** {@link AssembledTransaction} from which this SentTransaction was initialized */
     assembled: AssembledTransaction<U>,
+    /** The signed transaction to send to the network */
+    signed: Tx,
   ): Promise<SentTransaction<U>> => {
-    const tx = new SentTransaction(signTransaction, assembled);
+    const tx = new SentTransaction(assembled, signed);
     const sent = await tx.send();
     return sent;
   };
 
   private send = async (): Promise<this> => {
-    const timeoutInSeconds =
-      this.assembled.options.timeoutInSeconds ?? DEFAULT_TIMEOUT;
-    this.assembled.built = TransactionBuilder.cloneFrom(this.assembled.built!, {
-      fee: this.assembled.built!.fee,
-      timebounds: undefined,
-      sorobanData: new SorobanDataBuilder(
-        this.assembled.simulationData.transactionData.toXDR(),
-      ).build(),
-    })
-      .setTimeout(timeoutInSeconds)
-      .build();
-
-    const signature = await this.signTransaction!(
-      // `signAndSend` checks for `this.built` before calling `SentTransaction.init`
-      this.assembled.built!.toXDR(),
-      {
-        networkPassphrase: this.assembled.options.networkPassphrase,
-      },
-    );
-
-    this.signed = TransactionBuilder.fromXDR(
-      signature,
-      this.assembled.options.networkPassphrase,
-    ) as Tx;
-
     this.sendTransactionResponse = await this.server.sendTransaction(
       this.signed,
     );
@@ -124,6 +92,8 @@ export class SentTransaction<T> {
 
     const { hash } = this.sendTransactionResponse;
 
+    const timeoutInSeconds =
+      this.assembled.options.timeoutInSeconds ?? DEFAULT_TIMEOUT;
     this.getTransactionResponseAll = await withExponentialBackoff(
       () => this.server.getTransaction(hash),
       (resp) => resp.status === Api.GetTransactionStatus.NOT_FOUND,

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -117,3 +117,10 @@ export type AssembledTransactionOptions<T = string> = MethodOptions &
     args?: any[];
     parseResultXdr: (xdr: xdr.ScVal) => T;
   };
+
+export type SentTransactionOptions<T> = {
+  timeoutInSeconds?: number,
+  rpcUrl: string,
+  allowHttp?: boolean,
+  parseResultXdr: (xdr: xdr.ScVal) => T,
+};


### PR DESCRIPTION
Adds a `sign` and `send` function to `AssembledTransaction`. Allows signing the transaction without sending. 

Addresses https://github.com/stellar/js-stellar-sdk/issues/979