### PR TITLE
Respect custom headers when using `rpc.Server`

### DIFF
--- a/src/horizon/server.ts
+++ b/src/horizon/server.ts
@@ -92,6 +92,9 @@ export class Server {
     if (opts.authToken) {
       customHeaders["X-Auth-Token"] = opts.authToken;
     }
+    if (opts.headers) {
+      Object.assign(customHeaders, opts.headers);
+    }
     if (Object.keys(customHeaders).length > 0) {
       AxiosClient.interceptors.request.use((config) => {
         // merge the custom headers with an existing headers, where customs

--- a/src/horizon/server.ts
+++ b/src/horizon/server.ts
@@ -825,6 +825,7 @@ export namespace Server {
     appName?: string;
     appVersion?: string;
     authToken?: string;
+    headers?: Record<string, string>;
   }
 
   export interface Timebounds {

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -75,7 +75,7 @@ export class Server {
   constructor(serverURL: string, opts: Server.Options = {}) {
     this.serverURL = URI(serverURL);
 
-    if (opts.headers && Object.keys(opts.headers).length === 0) {
+    if (opts.headers && Object.keys(opts.headers).length !== 0) {
       AxiosClient.interceptors.request.use((config: any) => {
         // merge the custom headers into any existing headers
         config.headers = Object.assign(config.headers, opts.headers);

--- a/test/integration/client_headers_test.js
+++ b/test/integration/client_headers_test.js
@@ -72,4 +72,26 @@ describe("integration tests: client headers", function (done) {
         .stream({ onerror: (err) => done(err) });
     });
   });
+
+  it("sends client via custom headers", function (done) {
+    let server;
+
+    const requestHandler = (request, response) => {
+      expect(request.headers["authorization"]).to.be.equal("123456789");
+      response.end();
+      server.close(() => done());
+    };
+
+    server = http.createServer(requestHandler);
+    server.listen(port, (err) => {
+      if (err) {
+        done(err);
+        return;
+      }
+
+      new Horizon.Server(`http://localhost:${port}`, { headers: { "authorization": "123456789" }, allowHttp: true })
+        .operations()
+        .call();
+    });
+  });
 });


### PR DESCRIPTION
It's odd to compare the length with 0. In the original code, I need to do this to add a custom header:

let custom_header = {};
let server = new Server('https://url_to_server', {headers: custom_header});
custom_header['MyHeader'] = 'Some header content';

Shouldn't it check for non-zero to add the custom header?