### PR TITLE
get rid of statusText error check

### DIFF
--- a/src/horizon/call_builder.ts
+++ b/src/horizon/call_builder.ts
@@ -21,7 +21,7 @@ export interface EventSourceOptions<T> {
 const anyGlobal = global as any;
 type Constructable<T> = new (e: string) => T;
 // require("eventsource") for Node and React Native environment
-/* eslint-disable global-require */ 
+/* eslint-disable global-require */
 /* eslint-disable prefer-import/prefer-import-over-require */
 const EventSource: Constructable<EventSource> = anyGlobal.EventSource ??
   anyGlobal.window?.EventSource ??
@@ -181,7 +181,7 @@ export class CallBuilder<
       return es;
     };
 
-  
+
 
     createEventSource();
     return () => {
@@ -399,15 +399,15 @@ export class CallBuilder<
    */
   // eslint-disable-next-line require-await
   private async _handleNetworkError(error: NetworkError): Promise<void> {
-    if (error.response && error.response.status && error.response.statusText) {
+    if (error.response && error.response.status) {
       switch (error.response.status) {
         case 404:
           return Promise.reject(
-            new NotFoundError(error.response.statusText, error.response.data),
+            new NotFoundError(error.response.statusText ?? "Not Found", error.response.data),
           );
         default:
           return Promise.reject(
-            new NetworkError(error.response.statusText, error.response.data),
+            new NetworkError(error.response.statusText ?? "Unknown", error.response.data),
           );
       }
     } else {


### PR DESCRIPTION
The reason phrase is an optional part of the HTTP spec and could be stripped by proxies, so the best practice is not relying on it. 

HTTP/2 literally [doesn't have it](https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2.4).

closes #638 