### PR TITLE
Remove major version upgrades from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,6 @@ updates:
         update-types:
         - "patch"
         - "minor"
-      major:
-        applies-to: version-updates
-        update-types:
-        - "major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/test/e2e/src/test-contract-client-constructor.js
+++ b/test/e2e/src/test-contract-client-constructor.js
@@ -98,7 +98,7 @@ describe("Client", function () {
     this.context = { client, publicKey, addr, contractId, keypair };
   });
 
-  it("can be constructed with `new Client`", async function() {
+  it("can be constructed with `new Client`", async function () {
     const { result } = await this.context.client.hello({ to: "tests" });
     expect(result).to.deep.equal(["Hello", "tests"]);
   });

--- a/test/e2e/src/test-custom-types.js
+++ b/test/e2e/src/test-custom-types.js
@@ -16,15 +16,15 @@ describe("Custom Types Tests", function () {
     ).to.equal("tests");
   });
 
-  it("view method with empty keypair", async function() {
+  it("view method with empty keypair", async function () {
     const { client: client2 } = await clientFor("customTypes", {
       keypair: undefined,
-      contractId: this.context.contractId
+      contractId: this.context.contractId,
     });
     expect((await client2.i32_({ i32_: 1 })).result).to.equal(1);
   });
 
-  it("should increment the counter correctly", async function() {
+  it("should increment the counter correctly", async function () {
     const { result: startingBalance } = await this.context.client.get_count();
     const inc = await this.context.client.inc();
     const incrementResponse = await inc.signAndSend();
@@ -34,7 +34,7 @@ describe("Custom Types Tests", function () {
     expect(newBalance).to.equal(startingBalance + 1);
   });
 
-  it("should accept only options object for methods with no arguments", async function() {
+  it("should accept only options object for methods with no arguments", async function () {
     const inc = await this.context.client.inc({ simulate: false });
     expect(inc.simulation).to.be.undefined;
   });
@@ -43,13 +43,19 @@ describe("Custom Types Tests", function () {
     expect((await this.context.client.woid()).result).to.be.null;
   });
 
-  it("should authenticate the user correctly", async function() {
-    const { result } = await this.context.client.auth({ addr: this.context.publicKey, world: "lol" });
+  it("should authenticate the user correctly", async function () {
+    const { result } = await this.context.client.auth({
+      addr: this.context.publicKey,
+      world: "lol",
+    });
     expect(result).to.equal(this.context.publicKey);
   });
 
-  it("should authenticate the user correctly", async function() {
-    const { result } = await this.context.client.auth({ addr: this.context.publicKey, world: "lol" });
+  it("should authenticate the user correctly", async function () {
+    const { result } = await this.context.client.auth({
+      addr: this.context.publicKey,
+      world: "lol",
+    });
     expect(result).to.equal(this.context.publicKey);
   });
 

--- a/test/e2e/src/util.js
+++ b/test/e2e/src/util.js
@@ -19,12 +19,7 @@ const contracts = {
   helloWorld: {
     hash: spawnSync(
       "./target/bin/soroban",
-      [
-        "contract",
-        "install",
-        "--wasm",
-        `${basePath}/hello_world.wasm`,
-      ],
+      ["contract", "install", "--wasm", `${basePath}/hello_world.wasm`],
       { shell: true, encoding: "utf8" },
     ).stdout.trim(),
     path: `${basePath}/hello_world.wasm`,
@@ -84,7 +79,11 @@ module.exports.friendbotUrl = friendbotUrl;
 
 async function generateFundedKeypair() {
   const keypair = Keypair.random();
-  await fetch(friendbotUrl === 'https://friendbot.stellar.org' ? `${friendbotUrl}/?addr=${keypair.publicKey()}` : `${friendbotUrl}/friendbot?addr=${keypair.publicKey()}`);
+  await fetch(
+    friendbotUrl === "https://friendbot.stellar.org"
+      ? `${friendbotUrl}/?addr=${keypair.publicKey()}`
+      : `${friendbotUrl}/friendbot?addr=${keypair.publicKey()}`,
+  );
   return keypair;
 }
 module.exports.generateFundedKeypair = generateFundedKeypair;


### PR DESCRIPTION
This removes the major version upgrade PRs such as https://github.com/stellar/js-stellar-sdk/pull/1011 from dependabot's automatic process. This is because major versions often require significant code changes and also often have other breaking changes such as dropping support for certain environments that we need to support. I regularly evaluate the workload needed to support the major upgrades whenever doing releases (e.g., in https://github.com/stellar/js-stellar-sdk/pull/993 you can see lots of dependency upgrades), so the automated process isn't necessary and in fact is risky in keeping this repository stable.

(Also for some reason `yarn _prettier` needed to be run to auto-format some test files which were causing CI to fail.)