### PR TITLE
Fix types for stream calls

### DIFF
--- a/src/horizon/call_builder.ts
+++ b/src/horizon/call_builder.ts
@@ -13,7 +13,7 @@ import type { Server } from "../federation";
 const JOINABLE = ["transaction"];
 
 export interface EventSourceOptions<T> {
-  onmessage?: (value: T) => void;
+  onmessage?: (value: T extends ServerApi.CollectionPage<infer U> ? U : T) => void;
   onerror?: (event: MessageEvent) => void;
   reconnectTimeout?: number;
 }


### PR DESCRIPTION
I was attempting to listen to a transaction or operation stream on Horizon and I noticed that the types are sent back completely wrong.

<img width="991" alt="Screenshot 2024-09-03 at 3 10 04 PM" src="https://github.com/user-attachments/assets/2eae8924-9d77-4f47-9ad0-56fcdbe87a59">

i.e. I would try to call `.records`, `.next()` or `.previous()`  operations and it would obviously fail as streams do not give collectionPages but rather single operationRecords. Same happens with transaction streams, etc.

here is after the fix with the correct types:
<img width="679" alt="Screenshot 2024-09-03 at 3 03 12 PM" src="https://github.com/user-attachments/assets/baa04552-2d2f-46a0-acfd-f87ebf2b7707">

So I then went in and fixed the line so the types are correct since it's a very tiny fix.

TLDR: in typescript, streams were typed as Collections/pages when in reality they were single records.