### PR TITLE
Streaming example: implement `onerror()`

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -42,11 +42,21 @@ var txHandler = function (txResponse) {
     console.log(txResponse);
 };
 
+var errorHandler = function (error) {
+    console.error("Stream encountered an error:", error);
+
+    setTimeout(() => {
+        console.log("Reconnecting...");
+        es();
+    }, 5000);
+};
+
 var es = server.transactions()
     .forAccount(accountAddress)
     .cursor(lastCursor)
     .stream({
-        onmessage: txHandler
+        onmessage: txHandler,
+        onerror: errorHandler
     })
 ```
 


### PR DESCRIPTION
I have added error handling . It catches the error that occurs during the streaming process. When an error occurs, the code waits for 5 seconds and tries to reconnect by calling the es() function again.

fixed #520 