### PR TITLE
Expose EffectType types enum

### DIFF
--- a/src/horizon/server_api.ts
+++ b/src/horizon/server_api.ts
@@ -83,6 +83,7 @@ export namespace ServerApi {
     | Trade;
 
   export type EffectRecord = BaseEffectRecordFromTypes & EffectRecordMethods;
+  export const EffectType = Effects.EffectType;
   export interface ClaimableBalanceRecord extends HorizonApi.BaseResponse {
     id: string;
     paging_token: string;

--- a/src/horizon/types/trade.ts
+++ b/src/horizon/types/trade.ts
@@ -1,6 +1,7 @@
-import { BaseEffectRecord } from "./effects";
+import { BaseEffectRecord, EffectType } from "./effects";
 
 export interface Trade extends BaseEffectRecord {
+  type_i: EffectType.trade;
   seller: string;
   offer_id: number | string;
   bought_amount: string;


### PR DESCRIPTION
From #1098 issue

* expose the `EffectType` enum so it can be relied on to test effect objects and infer their members  
```ts
if (effect.type_i == Horizon.ServerApi.EffectType.trustline_created) {
    return effect.limit; // which doesn't exist on all effects
}
```
* Add a `type_i` to the Trade type, so it can also be tested and inferred. Including inferring it out from the previous example.

Note: I am not certain about from where it should be exported since it is a `const` from within a namespace only about types.