### PR TITLE
Stream messages are actually items of a collection

### DIFF
--- a/src/horizon/call_builder.ts
+++ b/src/horizon/call_builder.ts
@@ -102,7 +102,7 @@ export class CallBuilder<
    * @param {number} [options.reconnectTimeout] Custom stream connection timeout in ms, default is 15 seconds.
    * @returns {Function} Close function. Run to close the connection and stop listening for new events.
    */
-  public stream(options: EventSourceOptions<T> = {}): () => void {
+  public stream(options: EventSourceOptions<T extends ServerApi.CollectionPage ? T["records"][number] : T> = {}): () => void {
     // Check if EventSource use is enabled
     if (EventSource === undefined){
       throw new Error("Streaming requires eventsource to be enabled. If you need this functionality, compile with USE_EVENTSOURCE=true.");


### PR DESCRIPTION
When using the *stream* function of the call builders, typescript thinks the messages passed to the `onmessage` callback are of type `ServerApi.CollectionPage<TypeFromTheBuilderClass>` when they are actually single items from the said collection.