### PR TITLE
Drop the `protocol-22-beta` when publishing to npm

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -27,9 +27,9 @@ jobs:
 
       - name: Publish npm package to both places
         run: |
-          yarn publish --access public --tag protocol-22-beta
+          yarn publish --access public
           sed -i -e 's#"@stellar/stellar-sdk"#"stellar-sdk"#' package.json
-          yarn publish --tag protocol-22-beta
+          yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
That way v13.0.0 shows up as the `latest`.