### PR TITLE
Fetch metadata via RPC instead of relying on the Friendbot response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Fixed
+* When using a friendbot that points to a Horizon instance that has ledger metadata disabled, you can no longer extract the account sequence from the response. Instead, we hit RPC directly ([#1107](https://github.com/stellar/js-stellar-sdk/pull/1107/)).
+
 
 ## [v13.0.0](https://github.com/stellar/js-stellar-sdk/compare/v12.3.0...v13.0.0)
 This is a direct re-tag of rc.2 with the only change being an upgrade to the `stellar-base` library to incorporate a patch release. Nonetheless, the entire changelog from the prior major version here is replicated for a comprehensive view on what's broken, added, and fixed.

--- a/src/friendbot/index.ts
+++ b/src/friendbot/index.ts
@@ -1,6 +1,7 @@
 export namespace Api {
   // Just the fields we are interested in
   export interface Response {
+    hash: string;
     result_meta_xdr: string;
   }
 }

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -977,11 +977,14 @@ export class RpcServer {
         `${friendbotUrl}?addr=${encodeURIComponent(account)}`
       );
 
-      const meta = xdr.TransactionMeta.fromXDR(
-        response.data.result_meta_xdr,
-        'base64'
+      const txMeta = await this.getTransaction(response.data.hash)
+      if (txMeta.status !== Api.GetTransactionStatus.SUCCESS) {
+        throw new Error(`Funding account ${address} failed`);
+      }
+
+      const sequence = findCreatedAccountSequenceInTransactionMeta(
+        txMeta.resultMetaXdr
       );
-      const sequence = findCreatedAccountSequenceInTransactionMeta(meta);
       return new Account(account, sequence);
     } catch (error: any) {
       if (error.response?.status === 400) {

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -977,14 +977,18 @@ export class RpcServer {
         `${friendbotUrl}?addr=${encodeURIComponent(account)}`
       );
 
-      const txMeta = await this.getTransaction(response.data.hash)
-      if (txMeta.status !== Api.GetTransactionStatus.SUCCESS) {
-        throw new Error(`Funding account ${address} failed`);
+      let meta: xdr.TransactionMeta;
+      if (!response.data.result_meta_xdr) {
+        const txMeta = await this.getTransaction(response.data.hash)
+        if (txMeta.status !== Api.GetTransactionStatus.SUCCESS) {
+          throw new Error(`Funding account ${address} failed`);
+        }
+        meta = txMeta.resultMetaXdr;
+      } else {
+        meta = xdr.TransactionMeta.fromXDR(response.data.result_meta_xdr, 'base64');
       }
 
-      const sequence = findCreatedAccountSequenceInTransactionMeta(
-        txMeta.resultMetaXdr
-      );
+      const sequence = findCreatedAccountSequenceInTransactionMeta(meta);
       return new Account(account, sequence);
     } catch (error: any) {
       if (error.response?.status === 400) {

--- a/test/unit/server/soroban/request_airdrop_test.js
+++ b/test/unit/server/soroban/request_airdrop_test.js
@@ -1,4 +1,5 @@
-const { Account, Keypair, StrKey, Networks, xdr, hash, nativeToScVal } = StellarSdk;
+const { Account, Keypair, StrKey, Networks, xdr, hash, nativeToScVal } =
+  StellarSdk;
 const { Server, AxiosClient } = StellarSdk.rpc;
 
 describe("Server#requestAirdrop", function () {
@@ -267,7 +268,9 @@ describe("Server#requestAirdrop", function () {
 
     const txResult = makeTxResult("SUCCESS");
     txResult.txHash = "deadbeef";
-    txResult.resultMetaXdr = transactionMetaFor(accountId, "1234").toXDR("base64");
+    txResult.resultMetaXdr = transactionMetaFor(accountId, "1234").toXDR(
+      "base64",
+    );
 
     this.axiosMock
       .expects("post")
@@ -276,7 +279,7 @@ describe("Server#requestAirdrop", function () {
         id: 1,
         method: "getTransaction",
         params: {
-          "hash": "deadbeef"
+          hash: "deadbeef",
         },
       })
       .returns(Promise.resolve({ data: { result: txResult } }));

--- a/test/unit/server/soroban/request_airdrop_test.js
+++ b/test/unit/server/soroban/request_airdrop_test.js
@@ -1,4 +1,4 @@
-const { Account, Keypair, StrKey, Networks, xdr, hash } = StellarSdk;
+const { Account, Keypair, StrKey, Networks, xdr, hash, nativeToScVal } = StellarSdk;
 const { Server, AxiosClient } = StellarSdk.rpc;
 
 describe("Server#requestAirdrop", function () {
@@ -253,4 +253,91 @@ describe("Server#requestAirdrop", function () {
         done();
       });
   });
+
+  it("falls back to RPC if no meta is present", function (done) {
+    const friendbotUrl = "https://friendbot.stellar.org";
+    const accountId =
+      "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
+    mockGetNetwork.call(this, friendbotUrl);
+
+    this.axiosMock
+      .expects("post")
+      .withArgs(`${friendbotUrl}?addr=${accountId}`)
+      .returns(Promise.resolve({ data: { hash: "deadbeef" } }));
+
+    const txResult = makeTxResult("SUCCESS");
+    txResult.txHash = "deadbeef";
+    txResult.resultMetaXdr = transactionMetaFor(accountId, "1234").toXDR("base64");
+
+    this.axiosMock
+      .expects("post")
+      .withArgs(serverUrl, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getTransaction",
+        params: {
+          "hash": "deadbeef"
+        },
+      })
+      .returns(Promise.resolve({ data: { result: txResult } }));
+
+    this.server
+      .requestAirdrop(accountId)
+      .then((response) => {
+        expect(response).to.be.deep.equal(new Account(accountId, "1234"));
+        done();
+      })
+      .catch((err) => done(err));
+  });
 });
+
+// ripped out of ./get_transaction_test.js
+function makeTxResult(status, addSoroban = true) {
+  const metaV3 = new xdr.TransactionMeta(
+    3,
+    new xdr.TransactionMetaV3({
+      ext: new xdr.ExtensionPoint(0),
+      txChangesBefore: [],
+      operations: [],
+      txChangesAfter: [],
+      sorobanMeta: new xdr.SorobanTransactionMeta({
+        ext: new xdr.SorobanTransactionMetaExt(0),
+        events: [],
+        diagnosticEvents: [],
+        returnValue: nativeToScVal(1234),
+      }),
+    }),
+  );
+
+  // only injected in the success case
+  //
+  // this data was picked from a random transaction in horizon:
+  // aa6a8e198abe53c7e852e4870413b29fe9ef04da1415a97a5de1a4ae489e11e2
+  const successInfo = {
+    ledger: 1234,
+    createdAt: 123456789010,
+    applicationOrder: 2,
+    feeBump: false,
+    envelopeXdr:
+      "AAAAAgAAAAAT/LQZdYz0FcQ4Xwyg8IM17rkUx3pPCCWLu+SowQ/T+gBLB24poiQa9iwAngAAAAEAAAAAAAAAAAAAAABkwdeeAAAAAAAAAAEAAAABAAAAAC/9E8hDhnktyufVBS5tqA734Yz5XrLX2XNgBgH/YEkiAAAADQAAAAAAAAAAAAA1/gAAAAAv/RPIQ4Z5Lcrn1QUubagO9+GM+V6y19lzYAYB/2BJIgAAAAAAAAAAAAA1/gAAAAQAAAACU0lMVkVSAAAAAAAAAAAAAFDutWuu6S6UPJBrotNSgfmXa27M++63OT7TYn1qjgy+AAAAAVNHWAAAAAAAUO61a67pLpQ8kGui01KB+Zdrbsz77rc5PtNifWqODL4AAAACUEFMTEFESVVNAAAAAAAAAFDutWuu6S6UPJBrotNSgfmXa27M++63OT7TYn1qjgy+AAAAAlNJTFZFUgAAAAAAAAAAAABQ7rVrrukulDyQa6LTUoH5l2tuzPvutzk+02J9ao4MvgAAAAAAAAACwQ/T+gAAAEA+ztVEKWlqHXNnqy6FXJeHr7TltHzZE6YZm5yZfzPIfLaqpp+5cyKotVkj3d89uZCQNsKsZI48uoyERLne+VwL/2BJIgAAAEA7323gPSaezVSa7Vi0J4PqsnklDH1oHLqNBLwi5EWo5W7ohLGObRVQZ0K0+ufnm4hcm9J4Cuj64gEtpjq5j5cM",
+    resultXdr:
+      "AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAANAAAAAAAAAAUAAAACZ4W6fmN63uhVqYRcHET+D2NEtJvhCIYflFh9GqtY+AwAAAACU0lMVkVSAAAAAAAAAAAAAFDutWuu6S6UPJBrotNSgfmXa27M++63OT7TYn1qjgy+AAAYW0toL2gAAAAAAAAAAAAANf4AAAACcgyAkXD5kObNTeRYciLh7R6ES/zzKp0n+cIK3Y6TjBkAAAABU0dYAAAAAABQ7rVrrukulDyQa6LTUoH5l2tuzPvutzk+02J9ao4MvgAAGlGnIJrXAAAAAlNJTFZFUgAAAAAAAAAAAABQ7rVrrukulDyQa6LTUoH5l2tuzPvutzk+02J9ao4MvgAAGFtLaC9oAAAAApmc7UgUBInrDvij8HMSridx2n1w3I8TVEn4sLr1LSpmAAAAAlBBTExBRElVTQAAAAAAAABQ7rVrrukulDyQa6LTUoH5l2tuzPvutzk+02J9ao4MvgAAIUz88EqYAAAAAVNHWAAAAAAAUO61a67pLpQ8kGui01KB+Zdrbsz77rc5PtNifWqODL4AABpRpyCa1wAAAAKYUsaaCZ233xB1p+lG7YksShJWfrjsmItbokiR3ifa0gAAAAJTSUxWRVIAAAAAAAAAAAAAUO61a67pLpQ8kGui01KB+Zdrbsz77rc5PtNifWqODL4AABv52PPa5wAAAAJQQUxMQURJVU0AAAAAAAAAUO61a67pLpQ8kGui01KB+Zdrbsz77rc5PtNifWqODL4AACFM/PBKmAAAAAJnhbp+Y3re6FWphFwcRP4PY0S0m+EIhh+UWH0aq1j4DAAAAAAAAAAAAAA9pAAAAAJTSUxWRVIAAAAAAAAAAAAAUO61a67pLpQ8kGui01KB+Zdrbsz77rc5PtNifWqODL4AABv52PPa5wAAAAAv/RPIQ4Z5Lcrn1QUubagO9+GM+V6y19lzYAYB/2BJIgAAAAAAAAAAAAA9pAAAAAA=",
+    resultMetaXdr: metaV3.toXDR("base64"),
+  };
+
+  if (!addSoroban) {
+    // replace the V3 Soroban meta with a "classic" V2 version
+    successInfo.resultMetaXdr =
+      "AAAAAgAAAAIAAAADAtL5awAAAAAAAAAAS0CFMhOtWUKJWerx66zxkxORaiH6/3RUq7L8zspD5RoAAAAAAcm9QAKVkpMAAHpMAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAAAwAAAAAC0vi5AAAAAGTB02oAAAAAAAAAAQLS+WsAAAAAAAAAAEtAhTITrVlCiVnq8eus8ZMTkWoh+v90VKuy/M7KQ+UaAAAAAAHJvUAClZKTAAB6TQAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAMAAAAAAtL5awAAAABkwdd1AAAAAAAAAAEAAAAGAAAAAwLS+VQAAAACAAAAAG4cwu71zHNXx3jHCzRGOIthcnfwRgfN2f/AoHFLLMclAAAAAEySDkgAAAAAAAAAAkJVU0lORVNTAAAAAAAAAAC3JfDeo9vreItKNPoe74EkFIqWybeUQNFvLvURhHtskAAAAAAeQtHTL5f6TAAAXH0AAAAAAAAAAAAAAAAAAAABAtL5awAAAAIAAAAAbhzC7vXMc1fHeMcLNEY4i2Fyd/BGB83Z/8CgcUssxyUAAAAATJIOSAAAAAAAAAACQlVTSU5FU1MAAAAAAAAAALcl8N6j2+t4i0o0+h7vgSQUipbJt5RA0W8u9RGEe2yQAAAAAB5C0dNHf4CAAACLCQAAAAAAAAAAAAAAAAAAAAMC0vlUAAAAAQAAAABuHMLu9cxzV8d4xws0RjiLYXJ38EYHzdn/wKBxSyzHJQAAAAJCVVNJTkVTUwAAAAAAAAAAtyXw3qPb63iLSjT6Hu+BJBSKlsm3lEDRby71EYR7bJAAAAAAAABAL3//////////AAAAAQAAAAEAE3H3TnhnuQAAAAAAAAAAAAAAAAAAAAAAAAABAtL5awAAAAEAAAAAbhzC7vXMc1fHeMcLNEY4i2Fyd/BGB83Z/8CgcUssxyUAAAACQlVTSU5FU1MAAAAAAAAAALcl8N6j2+t4i0o0+h7vgSQUipbJt5RA0W8u9RGEe2yQAAAAAAAAQC9//////////wAAAAEAAAABABNx9J6Z4RkAAAAAAAAAAAAAAAAAAAAAAAAAAwLS+WsAAAAAAAAAAG4cwu71zHNXx3jHCzRGOIthcnfwRgfN2f/AoHFLLMclAAAAH37+zXQCXdRTAAASZAAAApIAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAEAAABbBXKIigAAABhZWyiOAAAAAgAAAAAAAAAAAAAAAAAAAAMAAAAAAtL0awAAAABkwbqrAAAAAAAAAAEC0vlrAAAAAAAAAABuHMLu9cxzV8d4xws0RjiLYXJ38EYHzdn/wKBxSyzHJQAAAB9+/s10Al3UUwAAEmQAAAKSAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAABAAAAWwVyiIoAAAAYWVsojgAAAAIAAAAAAAAAAAAAAAAAAAADAAAAAALS9GsAAAAAZMG6qwAAAAAAAAAA";
+  }
+
+  return {
+    status,
+    txHash: "ae9f315c048d87a5f853bc15bf284a2c3c89eb0e1cb38c10409b77a877b830a8",
+    latestLedger: 100,
+    latestLedgerCloseTime: 12345,
+    oldestLedger: 50,
+    oldestLedgerCloseTime: 500,
+    ...(status === "SUCCESS" && successInfo),
+  };
+}


### PR DESCRIPTION
When `SKIP_TXMETA` is enabled on a Horizon instance (like SDF's), the metadata isn't available in the friendbot response, either. This means we need to rely on a different source of metadata, so we fetch the transaction from RPC, instead.