### PR TITLE
Move the `cursor` field in `rpc.Server.getEvents` to the right place

### DIFF
--- a/src/rpc/api.ts
+++ b/src/rpc/api.ts
@@ -192,6 +192,7 @@ export namespace Api {
   export interface GetEventsResponse {
     latestLedger: number;
     events: EventResponse[];
+    cursor: string;
   }
 
   export interface EventResponse extends BaseEventResponse {
@@ -203,6 +204,7 @@ export namespace Api {
   export interface RawGetEventsResponse {
     latestLedger: number;
     events: RawEventResponse[];
+    cursor: string;
   }
 
   interface BaseEventResponse {
@@ -210,7 +212,6 @@ export namespace Api {
     type: EventType;
     ledger: number;
     ledgerClosedAt: string;
-    cursor: string;
     pagingToken: string;
     inSuccessfulContractCall: boolean;
     txHash: string;

--- a/src/rpc/parsers.ts
+++ b/src/rpc/parsers.ts
@@ -83,6 +83,7 @@ export function parseRawEvents(
 ): Api.GetEventsResponse {
   return {
     latestLedger: raw.latestLedger,
+    cursor: raw.cursor,
     events: (raw.events ?? []).map((evt) => {
       const clone: Omit<Api.RawEventResponse, 'contractId'> = { ...evt };
       delete (clone as any).contractId; // `as any` hack because contractId field isn't optional

--- a/test/unit/server/soroban/get_events_test.js
+++ b/test/unit/server/soroban/get_events_test.js
@@ -13,7 +13,11 @@ describe("Server#getEvents", function () {
   });
 
   it("requests the correct endpoint", function (done) {
-    let result = { latestLedger: 0, events: [] };
+    let result = {
+      cursor: "164090849041387521-3",
+      latestLedger: 0,
+      events: [],
+    };
     setupMock(
       this.axiosMock,
       {
@@ -38,6 +42,7 @@ describe("Server#getEvents", function () {
   it("can build wildcard filters", function (done) {
     let result = {
       latestLedger: 1,
+      cursor: "164090849041387521-3",
       events: filterEvents(getEventsResponseFixture, "*/*"),
     };
     expect(result.events).to.not.have.lengthOf(0, JSON.stringify(result));
@@ -76,6 +81,7 @@ describe("Server#getEvents", function () {
   it("can build matching filters", function (done) {
     let result = {
       latestLedger: 1,
+      cursor: "164090849041387521-3",
       events: filterEvents(
         getEventsResponseFixture,
         `${topicVals[0]}/${topicVals[1]}`,
@@ -116,6 +122,7 @@ describe("Server#getEvents", function () {
   it("can build mixed filters", function (done) {
     let result = {
       latestLedger: 3,
+      cursor: "164090849041387521-3",
       events: filterEventsByLedger(
         filterEvents(getEventsResponseFixture, `${topicVals[0]}/*`),
         2,
@@ -156,6 +163,7 @@ describe("Server#getEvents", function () {
   it("can paginate", function (done) {
     let result = {
       latestLedger: 3,
+      cursor: "164090849041387521-3",
       events: filterEventsByLedger(
         filterEvents(getEventsResponseFixture, "*/*"),
         2,


### PR DESCRIPTION
It's at the top level not in each event like `pagingToken` was.