### PR TITLE
chore: use `requestAirdrop` to fund e2e accounts

### DIFF
--- a/test/e2e/src/util.js
+++ b/test/e2e/src/util.js
@@ -1,5 +1,5 @@
 const { spawnSync } = require("node:child_process");
-const { contract, Keypair } = require("../../../lib");
+const { contract, Keypair, rpc } = require("../../../lib");
 const path = require("node:path");
 
 /*
@@ -67,17 +67,13 @@ const networkPassphrase =
   process.env.SOROBAN_NETWORK_PASSPHRASE ??
   "Standalone Network ; February 2017";
 module.exports.networkPassphrase = networkPassphrase;
-const friendbotUrl =
-  process.env.SOROBAN_FRIENDBOT_URL ?? "http://localhost:8000/friendbot";
-module.exports.friendbotUrl = friendbotUrl;
 
 async function generateFundedKeypair() {
   const keypair = Keypair.random();
-  await fetch(
-    friendbotUrl === "https://friendbot.stellar.org"
-      ? `${friendbotUrl}/?addr=${keypair.publicKey()}`
-      : `${friendbotUrl}/friendbot?addr=${keypair.publicKey()}`,
-  );
+  const server = new rpc.Server(rpcUrl, {
+    allowHttp: rpcUrl.startsWith('http://') ?? false,
+  });
+  await server.requestAirdrop(keypair.publicKey())
   return keypair;
 }
 module.exports.generateFundedKeypair = generateFundedKeypair;


### PR DESCRIPTION
@willemneal [pointed out](https://github.com/stellar/stellar-docs/pull/1101#pullrequestreview-2461887053) that it's a bit of a bummer to create accounts with a pure-SDK interface just to revert to `fetch` and a hard-coded Friendbot URL in order to fund that account.

This uses `rpc.Server#requestAirdrop` to do the funding.

I find the name of this method a bit unexpected! I wonder if the language here has evolved since the method was first added.