### PR TITLE
enhancement: Change signature of ClientOption.signTransaction to be able to pass KeyPair #1063

### DIFF
--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -690,7 +690,7 @@ export class AssembledTransaction<T> {
 
     if (signTransaction instanceof Keypair) {
       const keypair = signTransaction;
-      signTransaction = basicNodeSigner(keypair, this.options.networkPassphrase).signTransaction;
+      signFunction = basicNodeSigner(keypair, this.options.networkPassphrase).signTransaction;
     } else if (typeof signTransaction === 'function') {
       signFunction = signTransaction;
     }

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -5,6 +5,7 @@ import {
   Address,
   BASE_FEE,
   Contract,
+  Keypair,
   Operation,
   SorobanDataBuilder,
   TransactionBuilder,
@@ -15,6 +16,7 @@ import type {
   AssembledTransactionOptions,
   ClientOptions,
   MethodOptions,
+  SignTransaction,
   Tx,
   WalletError,
   XDR_BASE64,
@@ -32,6 +34,7 @@ import {
 import { DEFAULT_TIMEOUT } from "./types";
 import { SentTransaction } from "./sent_transaction";
 import { Spec } from "./spec";
+import { basicNodeSigner } from './basic_node_signer';
 
 /** @module contract */
 
@@ -682,7 +685,17 @@ export class AssembledTransaction<T> {
       );
     }
 
-    if (!signTransaction) {
+    // Check if signTransaction is a Keypair
+    let signFunction: SignTransaction | undefined;
+
+    if (signTransaction instanceof Keypair) {
+      const keypair = signTransaction;
+      signTransaction = basicNodeSigner(keypair, this.options.networkPassphrase).signTransaction;
+    } else if (typeof signTransaction === 'function') {
+      signFunction = signTransaction;
+    }
+
+    if (!signFunction) {
       throw new AssembledTransaction.Errors.NoSigner(
         "You must provide a signTransaction function, either when calling " +
         "`signAndSend` or when initializing your Client"
@@ -708,7 +721,10 @@ export class AssembledTransaction<T> {
       .setTimeout(timeoutInSeconds)
       .build();
 
-    const signOpts: Parameters<NonNullable<ClientOptions['signTransaction']>>[1] = {
+    // const signOpts: Parameters<NonNullable<ClientOptions['signTransaction']>>[1] = {
+    //   networkPassphrase: this.options.networkPassphrase,
+    // };
+    const signOpts: Parameters<SignTransaction>[1] = {
       networkPassphrase: this.options.networkPassphrase,
     };
   
@@ -716,7 +732,7 @@ export class AssembledTransaction<T> {
     if (this.options.submit !== undefined) signOpts.submit = this.options.submit;
     if (this.options.submitUrl) signOpts.submitUrl = this.options.submitUrl;
 
-    const { signedTxXdr: signature, error } = await signTransaction(
+    const { signedTxXdr: signature, error } = await signFunction(
       this.built.toXDR(),
       signOpts,
     );

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Memo, MemoType, Operation, Transaction, xdr } from "@stellar/stellar-base";
 import type { Client } from "./client";
+import { Keypair } from "@stellar/stellar-base";
 
 export type XDR_BASE64 = string;
 /**
@@ -131,7 +132,7 @@ export type ClientOptions = {
    *
    * Matches signature of `signTransaction` from Freighter.
    */
-  signTransaction?: SignTransaction;
+  signTransaction?: SignTransaction | Keypair;
   /**
    * A function to sign a specific auth entry for a transaction, using the
    * private key corresponding to the provided `publicKey`. This is only needed

--- a/test/e2e/src/test-non-invoker-signing-by-contracts.js
+++ b/test/e2e/src/test-non-invoker-signing-by-contracts.js
@@ -31,6 +31,24 @@ describe("cross-contract auth", function () {
         async () => await this.context.tx.sign({ force: true }),
       ).to.not.throw();
     });
+
+    it("signs transaction using Keypair", async function () {
+      const result = await this.context.tx.sign({
+        signTransaction: this.context.keypair,
+        force: true,
+      });
+      expect(result).to.be.undefined;
+    });
+
+
+    it("signs transaction using basicNodeSigner", async function () {
+      const signer = contract.basicNodeSigner(this.context.keypair, "Standalone Network ; February 2017");
+      const result = await this.context.tx.sign({
+        signTransaction: signer.signTransaction,
+        force: true,
+      });
+      expect(result).to.be.undefined;
+    });
   });
 
   describe("signAuthEntries with custom authorizeEntry", function () {

--- a/test/e2e/src/util.js
+++ b/test/e2e/src/util.js
@@ -89,7 +89,9 @@ module.exports.generateFundedKeypair = generateFundedKeypair;
  */
 async function clientFor(name, { keypair, contractId } = {}) {
   const internalKeypair = keypair ?? (await generateFundedKeypair());
-  const signer = contract.basicNodeSigner(internalKeypair, networkPassphrase);
+  
+  // Pass the Keypair directly instead of using basicNodeSigner
+  const signer = internalKeypair; // Use Keypair directly
 
   if (contractId) {
     return {
@@ -99,7 +101,7 @@ async function clientFor(name, { keypair, contractId } = {}) {
         rpcUrl,
         allowHttp: true,
         publicKey: internalKeypair.publicKey(),
-        ...signer,
+        signTransaction: signer, // Pass Keypair here
       }),
       contractId,
       keypair,
@@ -118,7 +120,7 @@ async function clientFor(name, { keypair, contractId } = {}) {
       allowHttp: true,
       wasmHash: wasmHash,
       publicKey: internalKeypair.publicKey(),
-      ...signer,
+      signTransaction: signer, // Pass Keypair here
     },
   );
   const { result: client } = await deploy.signAndSend();


### PR DESCRIPTION
## Change signature of ClientOption.signTransaction to be able to pass KeyPair #1063
Closes #1063 

### Pull Request Description
Summary

This pull request modifies the `ClientOptions` type to allow the `signTransaction` property to accept a `Keypair` in addition to a function. This change simplifies the process of signing transactions, especially for testing and simple applications, by allowing users to directly use a `Keypair` without needing to implement a custom signing function.

### Changes Made

1. Updated ClientOptions Type:

- Modified the `signTransaction` property to accept either a `SignTransaction` function or a `Keypair`.
```
export type ClientOptions = {
  // ... other properties
  signTransaction?: SignTransaction | Keypair;
  // ... other properties
};
```

2. Modified AssembledTransaction Class:

- Updated the `sign` method to handle the case where `signTransaction` is a `Keypair`.
- If a `Keypair` is provided, it uses the `basicNodeSigner` to create a signing function.
```
sign = async ({
  force = false,
  signTransaction = this.options.signTransaction,
}: {
  force?: boolean;
  signTransaction?: ClientOptions["signTransaction"];
} = {}): Promise<void> => {
  // ... existing logic

  // Check if signTransaction is a Keypair
  let signFunction: SignTransaction | undefined;

  if (signTransaction instanceof Keypair) {
    const keypair = signTransaction;
    signFunction = basicNodeSigner(keypair, this.options.networkPassphrase).signTransaction;
  } else if (typeof signTransaction === 'function') {
    signFunction = signTransaction;
  }
  // ... existing logic
    const signOpts: Parameters<SignTransaction>[1] = {
      networkPassphrase: this.options.networkPassphrase,
    };
};
```
3. Type Safety:

- Ensured that TypeScript correctly infers types when preparing signing options.