### PR TITLE
Add muxed payments support for PaymentOperationResponse type

### DIFF
--- a/src/horizon/horizon_api.ts
+++ b/src/horizon/horizon_api.ts
@@ -290,6 +290,8 @@ export namespace HorizonApi {
     asset_code?: string;
     asset_issuer?: string;
     amount: string;
+    to_muxed?: string;
+    to_muxed_id?: string;
   }
   export interface PathPaymentOperationResponse
     extends BaseOperationResponse<


### PR DESCRIPTION
In the case of a muxed payment, the PaymentOperationResponse type does not include the muxed payment related field which are to_muxed and to_muxed_id