### PR TITLE
Parse Wasm contract spec manually when lacking WebAssembly support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,8 +9,13 @@ jobs:
   test:
     env:
       NODE: "20"
-    name: test contract.Client
+    name: Test contract.Client (${{ matrix.job }})
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        job: ["test:e2e", "test:e2e:noeval"]
     services:
       rpc:
         image: stellar/quickstart:testing@sha256:5333ec87069efd7bb61f6654a801dc093bf0aad91f43a5ba84806d3efe4a6322
@@ -44,4 +49,4 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - run: yarn install --network-concurrency 1
     - run: yarn build:prod
-    - run: yarn test:e2e
+    - run: yarn ${{ matrix.job }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Fixed
+* Extend support for parsing contract specifications in environments that don't have WebAssembly compilers ([#1157](https://github.com/stellar/js-stellar-sdk/pull/1157)).
+
 
 ## [v13.1.0](https://github.com/stellar/js-stellar-sdk/compare/v13.0.0...v13.1.0)
 

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "docs": "yarn build:docs && jsdoc -c ./config/.jsdoc.json",
     "test": "yarn build:test && yarn test:node && yarn test:integration && yarn test:browser",
     "test:e2e": "./test/e2e/initialize.sh && yarn _nyc mocha --recursive 'test/e2e/src/test-*.js'",
+    "test:e2e:noeval": "NODE_ARGS='--disable-eval' yarn test:e2e",
     "test:node": "NODE_OPTIONS=$(test ! $(node -v | awk -F'.' '{printf substr($1,2)}') = '18' && echo '--no-experimental-detect-module') yarn _nyc mocha --recursive 'test/unit/**/*.js'",
     "test:integration": "yarn _nyc mocha --recursive 'test/integration/**/*.js'",
     "test:browser": "karma start config/karma.conf.js",
@@ -107,7 +108,7 @@
     "prepare": "yarn build:prod",
     "_build": "yarn build:node:all && yarn build:test && yarn build:browser:all",
     "_babel": "babel --extensions '.ts' --out-dir ${OUTPUT_DIR:-lib} src/",
-    "_nyc": "nyc --nycrc-path config/.nycrc",
+    "_nyc": "node $(NODE_ARGS) node_modules/.bin/nyc --nycrc-path config/.nycrc",
     "_prettier": "prettier --ignore-path config/.prettierignore --write './test/**/*.js'"
   },
   "husky": {

--- a/src/contract/client.ts
+++ b/src/contract/client.ts
@@ -12,18 +12,99 @@ import { processSpecEntryStream } from './utils';
 const CONSTRUCTOR_FUNC = "__constructor";
 
 async function specFromWasm(wasm: Buffer) {
-  const wasmModule = await WebAssembly.compile(wasm);
-  const xdrSections = WebAssembly.Module.customSections(
-    wasmModule,
-    "contractspecv0"
-  );
-  if (xdrSections.length === 0) {
+  let xdrSections: ArrayBuffer[] | undefined;
+
+  try {
+    const wasmModule = await WebAssembly.compile(wasm);
+    xdrSections = WebAssembly.Module.customSections(
+      wasmModule,
+      "contractspecv0"
+    );
+  } catch {
+    const customData = parseWasmCustomSections(wasm);
+    xdrSections = customData.get('contractspecv0');
+  }
+
+  if (!xdrSections || xdrSections.length === 0) {
     throw new Error("Could not obtain contract spec from wasm");
   }
-  const bufferSection = Buffer.from(xdrSections[0]);
+
+  const bufferSection = Buffer.from(xdrSections[0]);  
   const specEntryArray = processSpecEntryStream(bufferSection);
   const spec = new Spec(specEntryArray);
+
   return spec;
+}
+
+function parseWasmCustomSections(buffer: Buffer): Map<string, Uint8Array[]> {
+  const sections = new Map<string, Uint8Array[]>();
+  const arrayBuffer = buffer.buffer.slice(
+    buffer.byteOffset,
+    buffer.byteOffset + buffer.byteLength
+  );
+
+  let offset = 0;
+
+  // Helper to read bytes with bounds checking
+  const read = (length: number): Uint8Array => {
+    if (offset + length > buffer.byteLength) throw new Error('Buffer overflow');
+    const bytes = new Uint8Array(arrayBuffer, offset, length);
+    offset += length;
+    return bytes;
+  };
+
+  // Validate header
+  if ([...read(4)].join() !== '0,97,115,109') throw new Error('Invalid WASM magic');
+  if ([...read(4)].join() !== '1,0,0,0') throw new Error('Invalid WASM version');
+
+  while (offset < buffer.byteLength) {
+    const sectionId = read(1)[0];
+    const sectionLength = readVarUint32();
+    const start = offset;
+
+    if (sectionId === 0) { // Custom section
+      const nameLen = readVarUint32();
+
+      if (nameLen === 0 || offset + nameLen > start + sectionLength) continue;
+
+      const nameBytes = read(nameLen);
+      const payload = read(sectionLength - (offset - start));
+
+      try {
+        const name = new TextDecoder('utf-8', { fatal: true }).decode(nameBytes);
+        if (payload.length > 0) {
+          sections.set(name, (sections.get(name) || []).concat(payload));
+        }
+      } catch { /* Invalid UTF-8 */ }
+    } else {
+      offset += sectionLength; // Skip other sections
+    }
+  }
+
+  /**
+   * Decodes a variable-length encoded unsigned 32-bit integer (LEB128 format) from the WASM binary.
+   * 
+   * This function implements the WebAssembly LEB128 (Little Endian Base 128) variable-length 
+   * encoding scheme for unsigned integers. In this encoding:
+   * - Each byte uses 7 bits for the actual value
+   * - The most significant bit (MSB) indicates if more bytes follow (1) or not (0)
+   * - Values are stored with the least significant bytes first
+   * 
+   * @returns {number} The decoded 32-bit unsigned integer
+   * @throws {Error} If the encoding is invalid or exceeds 32 bits
+   */
+  function readVarUint32(): number {
+    let value = 0, shift = 0;
+    while (true) {
+      const byte = read(1)[0];         // Read a single byte from the buffer
+      value |= (byte & 0x7F) << shift; // Extract 7 bits and shift to correct position
+      if ((byte & 0x80) === 0) break;  // If MSB is 0, we've reached the last byte
+      if ((shift += 7) >= 32) throw new Error('Invalid WASM value'); // Ensure we don't exceed 32 bits
+    }
+    return value >>> 0;  // Force conversion to unsigned 32-bit integer
+  }
+
+  return sections;
 }
 
 async function specFromWasmHash(


### PR DESCRIPTION
Solves https://github.com/stellar/js-stellar-sdk/issues/1156#issuecomment-2767186680