### PR TITLE
support passing in an optional address to the deploy method

### DIFF
--- a/src/contract/client.ts
+++ b/src/contract/client.ts
@@ -68,13 +68,15 @@ export class Client {
         salt?: Buffer | Uint8Array;
         /** The format used to decode `wasmHash`, if it's provided as a string. */
         format?: "hex" | "base64";
+        /** The address to use to deploy the custom contract */
+        address?: string;
       }
   ): Promise<AssembledTransaction<T>> {
     const { wasmHash, salt, format, fee, timeoutInSeconds, simulate, ...clientOptions } = options;
     const spec = await specFromWasmHash(wasmHash, clientOptions, format);
 
     const operation = Operation.createCustomContract({
-      address: new Address(options.publicKey!),
+      address: new Address(options.address || options.publicKey!),
       wasmHash: typeof wasmHash === "string"
         ? Buffer.from(wasmHash, format ?? "hex")
         : (wasmHash as Buffer),


### PR DESCRIPTION
When deploying new custom contracts we're currently assuming the transaction source and deployer address are the same. We cannot make this assumption as this won't allow A) smart wallets to deploy custom contracts or B) a separation of the outer transaction source and the inner soroban auth entry. This PR feeds both those birds with one scone.