### PR TITLE
Add `includeFailed` to `PaymentCallBuilder` for including failed transactions in calls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Added
-* Add `includeFailed` to `PaymentCallBuilder` for including failed transactions in calls.
+* Add `includeFailed` to `PaymentCallBuilder` for including failed transactions in calls ([#1168](https://github.com/stellar/js-stellar-sdk/pull/1168)).
 
 ## [v13.2.0](https://github.com/stellar/js-stellar-sdk/compare/v13.1.0...v13.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Added
+* Add `includeFailed` to `PaymentCallBuilder` for including failed transactions in calls.
 
 ## [v13.2.0](https://github.com/stellar/js-stellar-sdk/compare/v13.1.0...v13.2.0)
 

--- a/src/horizon/payment_call_builder.ts
+++ b/src/horizon/payment_call_builder.ts
@@ -58,4 +58,16 @@ export class PaymentCallBuilder extends CallBuilder<
   public forTransaction(transactionId: string): this {
     return this.forEndpoint("transactions", transactionId);
   }
+
+  /**
+   * Adds a parameter defining whether to include failed transactions.
+   *   By default, only operations of successful transactions are returned.
+   *
+   * @param {boolean} value Set to `true` to include operations of failed transactions.
+   * @returns {PaymentCallBuilder} this PaymentCallBuilder instance
+   */
+  public includeFailed(value: boolean): this {
+    this.url.setQuery("include_failed", value.toString());
+    return this;
+  }
 }

--- a/test/unit/horizon_path_test.js
+++ b/test/unit/horizon_path_test.js
@@ -84,6 +84,16 @@ describe("horizon path tests", function () {
         .notify(done);
     });
 
+    it("server.payments().includeFailed(true) " + serverUrl, function (done) {
+      prepareAxios(this.axiosMock, "/payments?include_failed=true");
+      server
+        .payments()
+        .includeFailed(true)
+        .call()
+        .should.eventually.deep.equal(randomResult.data)
+        .notify(done);
+    });
+
     it(
       "server.transactions().transaction('fooTransactionId') " + serverUrl,
       function (done) {


### PR DESCRIPTION
The `payments` endpoint supports setting the includeFailed parameter, but the SDK does not have corresponding support, so let's add it here.

See https://developers.stellar.org/docs/data/apis/horizon/api-reference/list-all-payments