### PR TITLE
Adding missing types to account_response

### DIFF
--- a/src/horizon/account_response.ts
+++ b/src/horizon/account_response.ts
@@ -35,6 +35,9 @@ export class AccountResponse {
   public readonly flags!: HorizonApi.Flags;
   public readonly balances!: HorizonApi.BalanceLine[];
   public readonly signers!: ServerApi.AccountRecordSigners[];
+  public readonly num_sponsoring!: number;
+  public readonly num_sponsored!: number;
+  public readonly sponsor?: string;
   public readonly data!: (options: {
     value: string;
   }) => Promise<{ value: string }>;


### PR DESCRIPTION
Right now we just ts-ignore to be able to get the num_sponsered from the account_response, because the type says the key is not available when in reality it is there.

<img width="1085" alt="Screenshot 2025-05-13 at 6 39 02 PM" src="https://github.com/user-attachments/assets/563a1d45-ec41-4966-92c5-59f75775ff2c" />

Wanted to do a permenant fix because it's not in line with the [Account Response ](https://github.com/scottym5797/js-stellar-sdk/blob/b18004c42e3ac96098d44513ad001ad7a1613207/src/horizon/horizon_api.ts#L167-L196)type from the horizon api type