### PR TITLE
feat(client): `watcher` for `signAndSend`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Added
+* `AssembledTransaction#signAndSend` now takes a `watcher` argument ([#1174](https://github.com/stellar/js-stellar-sdk/pull/1174)). This `watcher` is an abstract class with two optional methods: 
+
+  - `onSubmitted`: called with the return value from the `sendTransaction` call that submits the transaction to the network for processing
+  - `onProgress`: called with each return value of `getTransaction` that checks on the ongoing status of the transaction
+
+  For example, a `watcher` like this:
+
+  ```ts
+  await tx.signAndSend({ watcher: {
+    onSubmitted: ({ status, hash, latestLedger }) => {
+      console.log({ status, hash, latestLedger });
+    },
+    onProgress: ({ status, txHash, latestLedger }) => {
+      console.log({ status, txHash, latestLedger });
+    }
+  }});
+  ```
+
+  ...will result in output like:
+
+  ```
+  {
+    status: 'PENDING',
+    hash: '8239a5c6a3248966291a202bab2ba393dabc872947b5ee4224921b071850b021',
+    latestLedger: 25076
+  }
+  {
+    status: 'NOT_FOUND',
+    txHash: '8239a5c6a3248966291a202bab2ba393dabc872947b5ee4224921b071850b021',
+    latestLedger: 25076
+  }
+  {
+    status: 'SUCCESS',
+    txHash: '8239a5c6a3248966291a202bab2ba393dabc872947b5ee4224921b071850b021',
+    latestLedger: 25077
+  }
+  ```
+
 
 ## [v13.3.0](https://github.com/stellar/js-stellar-sdk/compare/v13.2.0...v13.3.0)
 

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -24,11 +24,7 @@ import { Api } from "../rpc/api";
 import { assembleTransaction } from "../rpc/transaction";
 import type { Client } from "./client";
 import { Err } from "./rust_result";
-import {
-  contractErrorPattern,
-  implementsToString,
-  getAccount
-} from "./utils";
+import { contractErrorPattern, implementsToString, getAccount } from "./utils";
 import { DEFAULT_TIMEOUT } from "./types";
 import { SentTransaction, Watcher } from "./sent_transaction";
 import { Spec } from "./spec";
@@ -316,19 +312,19 @@ export class AssembledTransaction<T> {
    * logic.
    */
   static Errors = {
-    ExpiredState: class ExpiredStateError extends Error { },
-    RestorationFailure: class RestoreFailureError extends Error { },
-    NeedsMoreSignatures: class NeedsMoreSignaturesError extends Error { },
-    NoSignatureNeeded: class NoSignatureNeededError extends Error { },
-    NoUnsignedNonInvokerAuthEntries: class NoUnsignedNonInvokerAuthEntriesError extends Error { },
-    NoSigner: class NoSignerError extends Error { },
-    NotYetSimulated: class NotYetSimulatedError extends Error { },
-    FakeAccount: class FakeAccountError extends Error { },
-    SimulationFailed: class SimulationFailedError extends Error { },
-    InternalWalletError: class InternalWalletError extends Error { },
-    ExternalServiceError: class ExternalServiceError extends Error { },
-    InvalidClientRequest: class InvalidClientRequestError extends Error { },
-    UserRejected: class UserRejectedError extends Error { },
+    ExpiredState: class ExpiredStateError extends Error {},
+    RestorationFailure: class RestoreFailureError extends Error {},
+    NeedsMoreSignatures: class NeedsMoreSignaturesError extends Error {},
+    NoSignatureNeeded: class NoSignatureNeededError extends Error {},
+    NoUnsignedNonInvokerAuthEntries: class NoUnsignedNonInvokerAuthEntriesError extends Error {},
+    NoSigner: class NoSignerError extends Error {},
+    NotYetSimulated: class NotYetSimulatedError extends Error {},
+    FakeAccount: class FakeAccountError extends Error {},
+    SimulationFailed: class SimulationFailedError extends Error {},
+    InternalWalletError: class InternalWalletError extends Error {},
+    ExternalServiceError: class ExternalServiceError extends Error {},
+    InvalidClientRequest: class InvalidClientRequestError extends Error {},
+    UserRejected: class UserRejectedError extends Error {},
   };
 
   /**
@@ -384,39 +380,49 @@ export class AssembledTransaction<T> {
    * Serialize the AssembledTransaction to a base64-encoded XDR string.
    */
   toXDR(): string {
-    if(!this.built) throw new Error(
+    if (!this.built)
+      throw new Error(
         "Transaction has not yet been simulated; " +
-        "call `AssembledTransaction.simulate` first.",
+          "call `AssembledTransaction.simulate` first.",
       );
-    return this.built?.toEnvelope().toXDR('base64');
+    return this.built?.toEnvelope().toXDR("base64");
   }
 
   /**
    * Deserialize the AssembledTransaction from a base64-encoded XDR string.
    */
   static fromXDR<T>(
-    options: Omit<AssembledTransactionOptions<T>, "args" | "method" | "parseResultXdr">,
+    options: Omit<
+      AssembledTransactionOptions<T>,
+      "args" | "method" | "parseResultXdr"
+    >,
     encodedXDR: string,
-    spec: Spec
+    spec: Spec,
   ): AssembledTransaction<T> {
     const envelope = xdr.TransactionEnvelope.fromXDR(encodedXDR, "base64");
-    const built = TransactionBuilder.fromXDR(envelope, options.networkPassphrase) as Tx;
+    const built = TransactionBuilder.fromXDR(
+      envelope,
+      options.networkPassphrase,
+    ) as Tx;
     const operation = built.operations[0] as Operation.InvokeHostFunction;
-    if (!operation?.func?.value || typeof operation.func.value !== 'function') {
-      throw new Error("Could not extract the method from the transaction envelope.");
+    if (!operation?.func?.value || typeof operation.func.value !== "function") {
+      throw new Error(
+        "Could not extract the method from the transaction envelope.",
+      );
     }
     const invokeContractArgs = operation.func.value() as xdr.InvokeContractArgs;
     if (!invokeContractArgs?.functionName) {
-      throw new Error("Could not extract the method name from the transaction envelope.");
+      throw new Error(
+        "Could not extract the method name from the transaction envelope.",
+      );
     }
-    const method = invokeContractArgs.functionName().toString('utf-8');
-    const txn = new AssembledTransaction(
-      { ...options,
-        method,
-        parseResultXdr: (result: xdr.ScVal) =>
-          spec.funcResToNative(method, result),
-      }
-     );
+    const method = invokeContractArgs.functionName().toString("utf-8");
+    const txn = new AssembledTransaction({
+      ...options,
+      method,
+      parseResultXdr: (result: xdr.ScVal) =>
+        spec.funcResToNative(method, result),
+    });
     txn.built = built;
     return txn;
   }
@@ -425,7 +431,7 @@ export class AssembledTransaction<T> {
     if (!error) return;
 
     const { message, code } = error;
-    const fullMessage = `${message}${error.ext ? ` (${  error.ext.join(', ')  })` : ''}`;
+    const fullMessage = `${message}${error.ext ? ` (${error.ext.join(", ")})` : ""}`;
 
     switch (code) {
       case -1:
@@ -471,12 +477,12 @@ export class AssembledTransaction<T> {
    * })
    */
   static build<T>(
-    options: AssembledTransactionOptions<T>
+    options: AssembledTransactionOptions<T>,
   ): Promise<AssembledTransaction<T>> {
     const contract = new Contract(options.contractId);
     return AssembledTransaction.buildWithOp(
       contract.call(options.method, ...(options.args ?? [])),
-      options
+      options,
     );
   }
 
@@ -499,7 +505,7 @@ export class AssembledTransaction<T> {
    */
   static async buildWithOp<T>(
     operation: xdr.Operation,
-    options: AssembledTransactionOptions<T>
+    options: AssembledTransactionOptions<T>,
   ): Promise<AssembledTransaction<T>> {
     const tx = new AssembledTransaction(options);
     const account = await getAccount(options, tx.server);
@@ -519,26 +525,30 @@ export class AssembledTransaction<T> {
     options: AssembledTransactionOptions<T>,
     sorobanData: SorobanDataBuilder | xdr.SorobanTransactionData,
     account: Account,
-    fee: string
+    fee: string,
   ): Promise<AssembledTransaction<T>> {
     const tx = new AssembledTransaction(options);
     tx.raw = new TransactionBuilder(account, {
       fee,
       networkPassphrase: options.networkPassphrase,
     })
-      .setSorobanData(sorobanData instanceof SorobanDataBuilder ? sorobanData.build() : sorobanData)
+      .setSorobanData(
+        sorobanData instanceof SorobanDataBuilder
+          ? sorobanData.build()
+          : sorobanData,
+      )
       .addOperation(Operation.restoreFootprint({}))
       .setTimeout(options.timeoutInSeconds ?? DEFAULT_TIMEOUT);
     await tx.simulate({ restore: false });
     return tx;
   }
 
-  simulate = async ({ restore }: {restore?: boolean} = {}): Promise<this> => {
-    if (!this.built){
-      if(!this.raw) {
+  simulate = async ({ restore }: { restore?: boolean } = {}): Promise<this> => {
+    if (!this.built) {
+      if (!this.raw) {
         throw new Error(
           "Transaction has not yet been assembled; " +
-          "call `AssembledTransaction.build` first."
+            "call `AssembledTransaction.build` first.",
         );
       }
       this.built = this.raw.build();
@@ -554,7 +564,7 @@ export class AssembledTransaction<T> {
       const account = await getAccount(this.options, this.server);
       const result = await this.restoreFootprint(
         this.simulation.restorePreamble,
-        account
+        account,
       );
       if (result.status === Api.GetTransactionStatus.SUCCESS) {
         // need to rebuild the transaction with bumped account sequence number
@@ -564,27 +574,19 @@ export class AssembledTransaction<T> {
           networkPassphrase: this.options.networkPassphrase,
         })
           .addOperation(
-            contract.call(
-              this.options.method,
-              ...(this.options.args ?? [])
-            )
+            contract.call(this.options.method, ...(this.options.args ?? [])),
           )
-          .setTimeout(
-            this.options.timeoutInSeconds ?? DEFAULT_TIMEOUT
-          );
+          .setTimeout(this.options.timeoutInSeconds ?? DEFAULT_TIMEOUT);
         await this.simulate();
         return this;
       }
       throw new AssembledTransaction.Errors.RestorationFailure(
-        `Automatic restore failed! You set 'restore: true' but the attempted restore did not work. Result:\n${JSON.stringify(result)}`
+        `Automatic restore failed! You set 'restore: true' but the attempted restore did not work. Result:\n${JSON.stringify(result)}`,
       );
     }
 
     if (Api.isSimulationSuccess(this.simulation)) {
-      this.built = assembleTransaction(
-        this.built,
-        this.simulation
-      ).build();
+      this.built = assembleTransaction(this.built, this.simulation).build();
     }
 
     return this;
@@ -608,20 +610,23 @@ export class AssembledTransaction<T> {
     }
     if (Api.isSimulationError(simulation)) {
       throw new AssembledTransaction.Errors.SimulationFailed(
-        `Transaction simulation failed: "${simulation.error}"`
+        `Transaction simulation failed: "${simulation.error}"`,
       );
     }
 
     if (Api.isSimulationRestore(simulation)) {
       throw new AssembledTransaction.Errors.ExpiredState(
         `You need to restore some contract state before you can invoke this method.\n` +
-        'You can set `restore` to true in the method options in order to ' +
-        'automatically restore the contract state when needed.'
+          "You can set `restore` to true in the method options in order to " +
+          "automatically restore the contract state when needed.",
       );
     }
 
     // add to object for serialization & deserialization
-    this.simulationResult = simulation.result ?? { auth: [], retval: xdr.ScVal.scvVoid() };
+    this.simulationResult = simulation.result ?? {
+      auth: [],
+      retval: xdr.ScVal.scvVoid(),
+    };
     this.simulationTransactionData = simulation.transactionData.build();
 
     return {
@@ -678,28 +683,29 @@ export class AssembledTransaction<T> {
     if (!force && this.isReadCall) {
       throw new AssembledTransaction.Errors.NoSignatureNeeded(
         "This is a read call. It requires no signature or sending. " +
-        "Use `force: true` to sign and send anyway."
+          "Use `force: true` to sign and send anyway.",
       );
     }
 
     if (!signTransaction) {
       throw new AssembledTransaction.Errors.NoSigner(
         "You must provide a signTransaction function, either when calling " +
-        "`signAndSend` or when initializing your Client"
+          "`signAndSend` or when initializing your Client",
       );
     }
 
     // filter out contracts, as these are dealt with via cross contract calls
-    const sigsNeeded = this.needsNonInvokerSigningBy().filter(id => !id.startsWith('C'));
+    const sigsNeeded = this.needsNonInvokerSigningBy().filter(
+      (id) => !id.startsWith("C"),
+    );
     if (sigsNeeded.length) {
       throw new AssembledTransaction.Errors.NeedsMoreSignatures(
         `Transaction requires signatures from ${sigsNeeded}. ` +
-        "See `needsNonInvokerSigningBy` for details.",
+          "See `needsNonInvokerSigningBy` for details.",
       );
     }
 
-    const timeoutInSeconds =
-      this.options.timeoutInSeconds ?? DEFAULT_TIMEOUT;
+    const timeoutInSeconds = this.options.timeoutInSeconds ?? DEFAULT_TIMEOUT;
     this.built = TransactionBuilder.cloneFrom(this.built!, {
       fee: this.built!.fee,
       timebounds: undefined,
@@ -708,12 +714,15 @@ export class AssembledTransaction<T> {
       .setTimeout(timeoutInSeconds)
       .build();
 
-    const signOpts: Parameters<NonNullable<ClientOptions['signTransaction']>>[1] = {
+    const signOpts: Parameters<
+      NonNullable<ClientOptions["signTransaction"]>
+    >[1] = {
       networkPassphrase: this.options.networkPassphrase,
     };
-  
+
     if (this.options.address) signOpts.address = this.options.address;
-    if (this.options.submit !== undefined) signOpts.submit = this.options.submit;
+    if (this.options.submit !== undefined)
+      signOpts.submit = this.options.submit;
     if (this.options.submitUrl) signOpts.submitUrl = this.options.submitUrl;
 
     const { signedTxXdr: signature, error } = await signTransaction(
@@ -735,9 +744,11 @@ export class AssembledTransaction<T> {
    * a {@link Watcher} that allows you to keep track of the progress as the
    * transaction is sent and processed.
    */
-  async send(watcher?: Watcher){
-    if(!this.signed){
-      throw new Error("The transaction has not yet been signed. Run `sign` first, or use `signAndSend` instead.");
+  async send(watcher?: Watcher) {
+    if (!this.signed) {
+      throw new Error(
+        "The transaction has not yet been signed. Run `sign` first, or use `signAndSend` instead.",
+      );
     }
     const sent = await SentTransaction.init(this, watcher);
     return sent;
@@ -769,9 +780,9 @@ export class AssembledTransaction<T> {
      * submitted to the network (`onSubmitted`) and as the transaction is
      * processed (`onProgress`).
      */
-    watcher?: Watcher,
+    watcher?: Watcher;
   } = {}): Promise<SentTransaction<T>> => {
-    if(!this.signed){
+    if (!this.signed) {
       // Store the original submit option
       const originalSubmit = this.options.submit;
 
@@ -841,10 +852,10 @@ export class AssembledTransaction<T> {
           .filter(
             (entry) =>
               entry.credentials().switch() ===
-              xdr.SorobanCredentialsType.sorobanCredentialsAddress() &&
+                xdr.SorobanCredentialsType.sorobanCredentialsAddress() &&
               (includeAlreadySigned ||
                 entry.credentials().address().signature().switch().name ===
-                "scvVoid"),
+                  "scvVoid"),
           )
           .map((entry) =>
             Address.fromScAddress(
@@ -919,7 +930,7 @@ export class AssembledTransaction<T> {
       }
       if (!signAuthEntry) {
         throw new AssembledTransaction.Errors.NoSigner(
-          "You must provide `signAuthEntry` or a custom `authorizeEntry`"
+          "You must provide `signAuthEntry` or a custom `authorizeEntry`",
         );
       }
     }
@@ -932,7 +943,9 @@ export class AssembledTransaction<T> {
     // eslint-disable-next-line no-restricted-syntax
     for (const [i, entry] of authEntries.entries()) {
       // workaround for https://github.com/stellar/js-stellar-sdk/issues/1070
-      const credentials = xdr.SorobanCredentials.fromXDR(entry.credentials().toXDR())
+      const credentials = xdr.SorobanCredentials.fromXDR(
+        entry.credentials().toXDR(),
+      );
       if (
         credentials.switch() !==
         xdr.SorobanCredentialsType.sorobanCredentialsAddress()
@@ -956,9 +969,12 @@ export class AssembledTransaction<T> {
       authEntries[i] = await authorizeEntry(
         entry,
         async (preimage) => {
-          const { signedAuthEntry, error } = await sign(preimage.toXDR("base64"), {
-            address,
-          });
+          const { signedAuthEntry, error } = await sign(
+            preimage.toXDR("base64"),
+            {
+              address,
+            },
+          );
           this.handleWalletError(error);
           return Buffer.from(signedAuthEntry, "base64");
         },
@@ -1013,27 +1029,28 @@ export class AssembledTransaction<T> {
       transactionData: SorobanDataBuilder;
     },
     /** The account that is executing the footprint restore operation. If omitted, will use the account from the AssembledTransaction. */
-    account?: Account
+    account?: Account,
   ): Promise<Api.GetTransactionResponse> {
     if (!this.options.signTransaction) {
-      throw new Error("For automatic restore to work you must provide a signTransaction function when initializing your Client");
+      throw new Error(
+        "For automatic restore to work you must provide a signTransaction function when initializing your Client",
+      );
     }
-    account = account ?? await getAccount(this.options, this.server);
+    account = account ?? (await getAccount(this.options, this.server));
     // first try restoring the contract
-    const restoreTx = await AssembledTransaction.buildFootprintRestoreTransaction(
-      { ...this.options },
-      restorePreamble.transactionData,
-      account,
-      restorePreamble.minResourceFee
-    );
+    const restoreTx =
+      await AssembledTransaction.buildFootprintRestoreTransaction(
+        { ...this.options },
+        restorePreamble.transactionData,
+        account,
+        restorePreamble.minResourceFee,
+      );
     const sentTransaction = await restoreTx.signAndSend();
     if (!sentTransaction.getTransactionResponse) {
       throw new AssembledTransaction.Errors.RestorationFailure(
-        `The attempt at automatic restore failed. \n${JSON.stringify(sentTransaction)}`
+        `The attempt at automatic restore failed. \n${JSON.stringify(sentTransaction)}`,
       );
     }
     return sentTransaction.getTransactionResponse;
   }
-
-
 }

--- a/src/contract/sent_transaction.ts
+++ b/src/contract/sent_transaction.ts
@@ -1,8 +1,8 @@
 /* disable max-classes rule, because extending error shouldn't count! */
 /* eslint max-classes-per-file: 0 */
 import type { MethodOptions } from "./types";
-import { Server } from "../rpc"
-import { Api } from "../rpc/api"
+import { Server } from "../rpc";
+import { Api } from "../rpc/api";
 import { withExponentialBackoff } from "./utils";
 import { DEFAULT_TIMEOUT } from "./types";
 import type { AssembledTransaction } from "./assembled_transaction";
@@ -51,14 +51,12 @@ export class SentTransaction<T> {
   public getTransactionResponse?: Api.GetTransactionResponse;
 
   static Errors = {
-    SendFailed: class SendFailedError extends Error { },
-    SendResultOnly: class SendResultOnlyError extends Error { },
-    TransactionStillPending: class TransactionStillPendingError extends Error { },
+    SendFailed: class SendFailedError extends Error {},
+    SendResultOnly: class SendResultOnlyError extends Error {},
+    TransactionStillPending: class TransactionStillPendingError extends Error {},
   };
 
-  constructor(
-    public assembled: AssembledTransaction<T>,
-  ) {
+  constructor(public assembled: AssembledTransaction<T>) {
     this.server = new Server(this.assembled.options.rpcUrl, {
       allowHttp: this.assembled.options.allowHttp ?? false,
     });
@@ -94,7 +92,7 @@ export class SentTransaction<T> {
       );
     }
 
-    if (watcher?.onSubmitted) watcher.onSubmitted(this.sendTransactionResponse)
+    if (watcher?.onSubmitted) watcher.onSubmitted(this.sendTransactionResponse);
 
     const { hash } = this.sendTransactionResponse;
 
@@ -102,9 +100,9 @@ export class SentTransaction<T> {
       this.assembled.options.timeoutInSeconds ?? DEFAULT_TIMEOUT;
     this.getTransactionResponseAll = await withExponentialBackoff(
       async () => {
-        const tx = await this.server.getTransaction(hash)
-        if (watcher?.onProgress) watcher.onProgress(tx)
-        return tx
+        const tx = await this.server.getTransaction(hash);
+        if (watcher?.onProgress) watcher.onProgress(tx);
+        return tx;
       },
       (resp) => resp.status === Api.GetTransactionStatus.NOT_FOUND,
       timeoutInSeconds,
@@ -113,22 +111,21 @@ export class SentTransaction<T> {
     this.getTransactionResponse =
       this.getTransactionResponseAll[this.getTransactionResponseAll.length - 1];
     if (
-      this.getTransactionResponse.status ===
-      Api.GetTransactionStatus.NOT_FOUND
+      this.getTransactionResponse.status === Api.GetTransactionStatus.NOT_FOUND
     ) {
       throw new SentTransaction.Errors.TransactionStillPending(
         `Waited ${timeoutInSeconds} seconds for transaction to complete, but it did not. ` +
-        `Returning anyway. Check the transaction status manually. ` +
-        `Sent transaction: ${JSON.stringify(
-          this.sendTransactionResponse,
-          null,
-          2,
-        )}\n` +
-        `All attempts to get the result: ${JSON.stringify(
-          this.getTransactionResponseAll,
-          null,
-          2,
-        )}`,
+          `Returning anyway. Check the transaction status manually. ` +
+          `Sent transaction: ${JSON.stringify(
+            this.sendTransactionResponse,
+            null,
+            2,
+          )}\n` +
+          `All attempts to get the result: ${JSON.stringify(
+            this.getTransactionResponseAll,
+            null,
+            2,
+          )}`,
       );
     }
 
@@ -175,11 +172,11 @@ export abstract class Watcher {
    * Function to call after transaction has been submitted successfully to
    * the network for processing
    */
-  abstract onSubmitted?(response?: Api.SendTransactionResponse): void
+  abstract onSubmitted?(response?: Api.SendTransactionResponse): void;
 
   /**
    * Function to call every time the submitted transaction's status is
    * checked while awaiting its full inclusion in the ledger
    */
-  abstract onProgress?(response?: Api.GetTransactionResponse): void
+  abstract onProgress?(response?: Api.GetTransactionResponse): void;
 }

--- a/test/e2e/src/test-swap.js
+++ b/test/e2e/src/test-swap.js
@@ -147,14 +147,16 @@ describe("Swap Contract Tests", function () {
     const txRoot = clientRoot.txFromXDR(xdrFromBob);
 
     await txRoot.simulate();
-    const result = await txRoot.signAndSend({ watcher: {
-      onSubmitted: ({ status, hash, latestLedger }) => {
-        console.log({ status, hash, latestLedger });
+    const result = await txRoot.signAndSend({
+      watcher: {
+        onSubmitted: ({ status, hash, latestLedger }) => {
+          console.log({ status, hash, latestLedger });
+        },
+        onProgress: ({ status, txHash, latestLedger }) => {
+          console.log({ status, txHash, latestLedger });
+        },
       },
-      onProgress: ({ status, txHash, latestLedger }) => {
-        console.log({ status, txHash, latestLedger });
-      }
-    }});
+    });
 
     expect(result).to.have.property("sendTransactionResponse");
     expect(result.sendTransactionResponse).to.have.property(

--- a/test/e2e/src/test-swap.js
+++ b/test/e2e/src/test-swap.js
@@ -147,7 +147,14 @@ describe("Swap Contract Tests", function () {
     const txRoot = clientRoot.txFromXDR(xdrFromBob);
 
     await txRoot.simulate();
-    const result = await txRoot.signAndSend();
+    const result = await txRoot.signAndSend({ watcher: {
+      onSubmitted: ({ status, hash, latestLedger }) => {
+        console.log({ status, hash, latestLedger });
+      },
+      onProgress: ({ status, txHash, latestLedger }) => {
+        console.log({ status, txHash, latestLedger });
+      }
+    }});
 
     expect(result).to.have.property("sendTransactionResponse");
     expect(result.sendTransactionResponse).to.have.property(


### PR DESCRIPTION
`AssembledTransaction#signAndSend` now takes a `watcher` argument. This `watcher` is an abstract class with two optional methods:

- `onSubmitted`: called with the return value from the `sendTransaction` call that submits the transaction to the network for processing
- `onProgress`: called with each return value of `getTransaction` that checks on the ongoing status of the transaction

For example, a `watcher` like this:

```ts
await tx.signAndSend({ watcher: {
  onSubmitted: ({ status, hash, latestLedger }) => {
    console.log({ status, hash, latestLedger });
  },
  onProgress: ({ status, txHash, latestLedger }) => {
    console.log({ status, txHash, latestLedger });
  }
}});
```

...will result in output like:

```
{
  status: 'PENDING',
  hash: '8239a5c6a3248966291a202bab2ba393dabc872947b5ee4224921b071850b021',
  latestLedger: 25076
}
{
  status: 'NOT_FOUND',
  txHash: '8239a5c6a3248966291a202bab2ba393dabc872947b5ee4224921b071850b021',
  latestLedger: 25076
}
{
  status: 'SUCCESS',
  txHash: '8239a5c6a3248966291a202bab2ba393dabc872947b5ee4224921b071850b021',
  latestLedger: 25077
}
```