### PR TITLE
Parse new `events` schema more reliably and release rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+
 ## [v14.0.0-rc.3](https://github.com/stellar/js-stellar-sdk/compare/v13.1.0...v14.0.0-rc.3)
 
 ### Fixed
-* Fixes a bug in `Rpc.Server.getTransaction` where the new `events` field was not present.
+* Fixes a bug in `Rpc.Server.getTransaction` where either `transactionEventsXdr` and/or `contractEventsXdr` may not be present in the new `events` field.
 
 
 ## [v14.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v13.1.0...v14.0.0-rc.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+## [v14.0.0-rc.3](https://github.com/stellar/js-stellar-sdk/compare/v13.1.0...v14.0.0-rc.3)
+
+### Fixed
+* Fixes a bug in `Rpc.Server.getTransaction` where the new `events` field was not present.
+
 
 ## [v14.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v13.1.0...v14.0.0-rc.2)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/stellar-sdk",
-  "version": "14.0.0-rc.2",
+  "version": "14.0.0-rc.3",
   "description": "A library for working with the Stellar network, including communication with the Horizon and Soroban RPC servers.",
   "keywords": [
     "stellar"

--- a/src/rpc/api.ts
+++ b/src/rpc/api.ts
@@ -178,7 +178,7 @@ export namespace Api {
     returnValue?: xdr.ScVal;
     diagnosticEventsXdr?: xdr.DiagnosticEvent[];
 
-    events: TransactionEvents;
+    events?: TransactionEvents;
   }
 
   export interface GetTransactionsResponse {

--- a/src/rpc/api.ts
+++ b/src/rpc/api.ts
@@ -139,8 +139,8 @@ export namespace Api {
   }
 
   export interface RawTransactionEvents {
-    transactionEventsXdr: string[];
-    contractEventsXdr: string[][];
+    transactionEventsXdr?: string[];
+    contractEventsXdr?: string[][];
   }
 
   export interface RawTransactionInfo {
@@ -178,7 +178,7 @@ export namespace Api {
     returnValue?: xdr.ScVal;
     diagnosticEventsXdr?: xdr.DiagnosticEvent[];
 
-    events?: TransactionEvents;
+    events: TransactionEvents;
   }
 
   export interface GetTransactionsResponse {

--- a/src/rpc/parsers.ts
+++ b/src/rpc/parsers.ts
@@ -46,14 +46,16 @@ export function parseTransactionInfo(
     envelopeXdr: xdr.TransactionEnvelope.fromXDR(raw.envelopeXdr!, 'base64'),
     resultXdr: xdr.TransactionResult.fromXDR(raw.resultXdr!, 'base64'),
     resultMetaXdr: meta,
-    events: {
-      contractEventsXdr: raw.events?.contractEventsXdr.map(
-        lst => lst.map(e => xdr.ContractEvent.fromXDR(e, "base64"))
-      ) ?? [],
-      transactionEventsXdr: raw.events?.transactionEventsXdr.map(
-        e => xdr.TransactionEvent.fromXDR(e, "base64")
-      ) ?? [],
-    }
+    ...(raw.events !== undefined && {
+      events: {
+        contractEventsXdr: raw.events?.contractEventsXdr.map(
+          lst => lst.map(e => xdr.ContractEvent.fromXDR(e, "base64"))
+        ) ?? [],
+        transactionEventsXdr: raw.events?.transactionEventsXdr.map(
+          e => xdr.TransactionEvent.fromXDR(e, "base64")
+        ) ?? [],
+      }
+    }),
   };
 
   switch (meta.switch()) {

--- a/src/rpc/parsers.ts
+++ b/src/rpc/parsers.ts
@@ -46,16 +46,14 @@ export function parseTransactionInfo(
     envelopeXdr: xdr.TransactionEnvelope.fromXDR(raw.envelopeXdr!, 'base64'),
     resultXdr: xdr.TransactionResult.fromXDR(raw.resultXdr!, 'base64'),
     resultMetaXdr: meta,
-    ...(raw.events !== undefined && {
-      events: {
-        contractEventsXdr: raw.events?.contractEventsXdr.map(
-          lst => lst.map(e => xdr.ContractEvent.fromXDR(e, "base64"))
-        ) ?? [],
-        transactionEventsXdr: raw.events?.transactionEventsXdr.map(
-          e => xdr.TransactionEvent.fromXDR(e, "base64")
-        ) ?? [],
-      }
-    }),
+    events: {
+      contractEventsXdr: (raw.events?.contractEventsXdr ?? []).map(
+        lst => lst.map(e => xdr.ContractEvent.fromXDR(e, "base64"))
+      ),
+      transactionEventsXdr: (raw.events?.transactionEventsXdr ?? []).map(
+        e => xdr.TransactionEvent.fromXDR(e, "base64")
+      ),
+    },
   };
 
   switch (meta.switch()) {


### PR DESCRIPTION
The parsed variant assumed `events.transactionEventsXdr` and `events.contractEventsXdr` would always be present. They will always be present in the parsed SDK response for consistency, however.