### PR TITLE
Remove defunct field from Horizon API spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Breaking Changes
+* Removes the defunct `destination_muxed_id_type` field for balance changes.
+
 
 ## [v14.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v13.1.0...v14.0.0-rc.2)
 

--- a/src/horizon/horizon_api.ts
+++ b/src/horizon/horizon_api.ts
@@ -577,8 +577,6 @@ export namespace HorizonApi {
     reserves_received: Reserve[];
   }
 
-  export type MuxedIdType = "uint64" | "string" | "bytes";
-
   export interface BalanceChange {
     asset_type: string;
     asset_code?: string;
@@ -588,7 +586,6 @@ export namespace HorizonApi {
     from: string;
     to: string;
     amount: string;
-    destination_muxed_id_type?: MuxedIdType;
     destination_muxed_id?: string;
   }
 


### PR DESCRIPTION
This field isn't necessary because SAC transfers always emit number-like IDs.