### PR TITLE
Fix getTransactions api

### DIFF
--- a/src/rpc/api.ts
+++ b/src/rpc/api.ts
@@ -130,12 +130,16 @@ export namespace Api {
 
   export type GetTransactionsRequest = {
     startLedger: number;
-    cursor?: never;
-    limit?: number;
+    pagination?: {
+      cursor?: never;
+      limit?: number;
+    };
   } | {
     startLedger?: never;
-    cursor: string;
-    limit?: number;
+    pagination: {
+      cursor: string;
+      limit?: number;
+    };
   };
 
   export interface RawTransactionInfo {


### PR DESCRIPTION
according to https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getTransactions startLedger and cursor args are mutually exclusive. My colleague found it so credit for him @szatanjl.