### PR TITLE
feat: Add missing transactionIndex field in events returned by the RPC

### DIFF
--- a/src/rpc/api.ts
+++ b/src/rpc/api.ts
@@ -236,6 +236,7 @@ export namespace Api {
     ledger: number;
     ledgerClosedAt: string;
     pagingToken: string;
+    transactionIndex: number;
     inSuccessfulContractCall: boolean;
     txHash: string;
   }

--- a/src/rpc/api.ts
+++ b/src/rpc/api.ts
@@ -237,6 +237,7 @@ export namespace Api {
     ledgerClosedAt: string;
     pagingToken: string;
     transactionIndex: number;
+    operationIndex: number;
     inSuccessfulContractCall: boolean;
     txHash: string;
   }


### PR DESCRIPTION
Issue: https://github.com/stellar/js-stellar-sdk/issues/1205

## Description

Add missing `transactionIndex` field in the events returned by the RPC.