### PR TITLE
Add a method to fetch claimable balance entries by ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Added
-* `rpc.Server` now includes `getAccountEntry`, `getTrustlineEntry`, and `getClaimableBalance` methods to facilitate retrieving those entries without manually constructing the ledger keys ([#1218](https://github.com/stellar/js-stellar-sdk/pull/1218), [#TODO]()).
+* `rpc.Server` now includes `getAccountEntry`, `getTrustlineEntry`, and `getClaimableBalance` methods to facilitate retrieving those entries without manually constructing the ledger keys ([#1218](https://github.com/stellar/js-stellar-sdk/pull/1218), [#1221](https://github.com/stellar/js-stellar-sdk/pull/1221)).
 * `rpc.Server`'s `getSACBalance` now allows retrieving an account ID's balance (`G...`) of an asset within a contract (for example, how much XLM a user holds in a contract, ([#1218](https://github.com/stellar/js-stellar-sdk/pull/1218))).
 * `rpc.Server`'s
 
 ### Fixed
-* Updated `@stellar/stellar-base` to latest patch (see its [release notes](https://github.com/stellar/js-stellar-base/releases/tag/v14.0.1), [TODO]()).
+* Updated `@stellar/stellar-base` to latest patch (see its [release notes](https://github.com/stellar/js-stellar-base/releases/tag/v14.0.1), [#1221](https://github.com/stellar/js-stellar-sdk/pull/1221)).
 
 
 ## [v14.1.1](https://github.com/stellar/js-stellar-sdk/compare/v14.1.0...v14.1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Added
-* `rpc.Server` now includes `getAccountEntry` and `getTrustlineEntry` methods to facilitate retrieving those entries without manually constructing the ledger keys ([#1218](https://github.com/stellar/js-stellar-sdk/pull/1218)).
+* `rpc.Server` now includes `getAccountEntry`, `getTrustlineEntry`, and `getClaimableBalance` methods to facilitate retrieving those entries without manually constructing the ledger keys ([#1218](https://github.com/stellar/js-stellar-sdk/pull/1218), [#TODO]()).
 * `rpc.Server`'s `getSACBalance` now allows retrieving an account ID's balance (`G...`) of an asset within a contract (for example, how much XLM a user holds in a contract, ([#1218](https://github.com/stellar/js-stellar-sdk/pull/1218))).
+* `rpc.Server`'s
 
 ### Fixed
-* Added missing `Asset.toString()` TypeScript definition ([#1218](https://github.com/stellar/js-stellar-sdk/pull/1218)).
+* Updated `@stellar/stellar-base` to latest patch (see its [release notes](https://github.com/stellar/js-stellar-base/releases/tag/v14.0.1), [TODO]()).
 
 
 ## [v14.1.1](https://github.com/stellar/js-stellar-sdk/compare/v14.1.0...v14.1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ A breaking change will get clearly marked in this log.
 
 ### Added
 * `rpc.Server` now includes `getAccountEntry`, `getTrustlineEntry`, and `getClaimableBalance` methods to facilitate retrieving those entries without manually constructing the ledger keys ([#1218](https://github.com/stellar/js-stellar-sdk/pull/1218), [#1221](https://github.com/stellar/js-stellar-sdk/pull/1221)).
-* `rpc.Server`'s `getSACBalance` now allows retrieving an account ID's balance (`G...`) of an asset within a contract (for example, how much XLM a user holds in a contract, ([#1218](https://github.com/stellar/js-stellar-sdk/pull/1218))).
 * `rpc.Server`'s
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "prepare": "yarn build:prod",
     "_build": "yarn build:node:all && yarn build:test && yarn build:browser:all",
     "_babel": "babel --extensions '.ts' --out-dir ${OUTPUT_DIR:-lib} src/",
-    "_nyc": "node $(NODE_ARGS) node_modules/.bin/nyc --nycrc-path config/.nycrc",
+    "_nyc": "node $NODE_ARGS node_modules/.bin/nyc --nycrc-path config/.nycrc",
     "_prettier": "prettier --ignore-path config/.prettierignore --write './test/**/*.js'"
   },
   "husky": {
@@ -217,7 +217,7 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
-    "@stellar/stellar-base": "^14.0.0",
+    "@stellar/stellar-base": "^14.0.1",
     "axios": "^1.8.4",
     "bignumber.js": "^9.3.1",
     "eventsource": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "test": "yarn build:test && yarn test:node && yarn test:integration && yarn test:browser",
     "test:e2e": "./test/e2e/initialize.sh && yarn _nyc mocha --recursive 'test/e2e/src/test-*.js'",
     "test:node": "NODE_OPTIONS=--no-experimental-detect-module yarn _nyc mocha --recursive 'test/unit/**/*.js'",
-    "test:e2e:noeval": "NODE_ARGS='--disable-eval' yarn test:e2e",
+    "test:e2e:noeval": "NODE_OPTIONS=--disallow-code-generation-from-strings yarn test:e2e",
     "test:integration": "yarn _nyc mocha --recursive 'test/integration/**/*.js'",
     "test:browser": "karma start config/karma.conf.js",
     "test:browser:no-axios": "cross-env USE_AXIOS=false yarn build:browser && cross-env USE_AXIOS=false karma start config/karma.conf.js",
@@ -108,7 +108,7 @@
     "prepare": "yarn build:prod",
     "_build": "yarn build:node:all && yarn build:test && yarn build:browser:all",
     "_babel": "babel --extensions '.ts' --out-dir ${OUTPUT_DIR:-lib} src/",
-    "_nyc": "node $NODE_ARGS node_modules/.bin/nyc --nycrc-path config/.nycrc",
+    "_nyc": "node node_modules/.bin/nyc --nycrc-path config/.nycrc",
     "_prettier": "prettier --ignore-path config/.prettierignore --write './test/**/*.js'"
   },
   "husky": {

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -1159,8 +1159,7 @@ export class RpcServer {
    *    entry details if and only if the request returned a valid balance ledger
    *    entry. If it doesn't, the `balanceEntry` field will not exist.
    *
-   * @throws {TypeError} If `address` is not a valid contract ID (C...) or
-   *    ed25519 public key (G...).
+   * @throws {TypeError} If `address` is not a valid contract ID (C...).
    *
    * @see getLedgerEntries
    * @see https://developers.stellar.org/docs/tokens/stellar-asset-contract
@@ -1181,17 +1180,16 @@ export class RpcServer {
    *   "Address has no XLM");
    */
   public async getSACBalance(
-    address: string,
+    address: string | Address,
     sac: Asset,
     networkPassphrase?: string
   ): Promise<Api.BalanceResponse> {
-      if (
-        !StrKey.isValidContract(address) &&
-        !StrKey.isValidEd25519PublicKey(address)
-      ) {
-        throw new TypeError(
-          `expected contract ID or ed25519 public key, got ${address}`
-        );
+      const addressString = (address instanceof Address)
+        ? address.toString()
+        : address;
+
+      if (!StrKey.isValidContract(addressString)) {
+        throw new TypeError(`expected contract ID, got ${addressString}`);
       }
 
       // Call out to RPC if passphrase isn't provided.
@@ -1202,7 +1200,7 @@ export class RpcServer {
       const sacId = sac.contractId(passphrase);
 
       // Rust union enum type with "Balance(ScAddress)" structure
-      const key = nativeToScVal(["Balance", address], {
+      const key = nativeToScVal(["Balance", addressString], {
         type: [ "symbol", "address" ]
       });
 

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -284,7 +284,7 @@ export class RpcServer {
   }
 
   /**
-   * Fetch the full trustline entry for a Stellar account.
+   * Fetch the full claimable balance entry for a Stellar account.
    *
    * @param {string} id   The strkey (`B...`) or hex (`00000000abcde...`) of the
    *    claimable balance to load

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -286,7 +286,8 @@ export class RpcServer {
   /**
    * Fetch the full claimable balance entry for a Stellar account.
    *
-   * @param {string} id   The strkey (`B...`) or hex (`00000000abcde...`) of the
+   * @param {string} id   The strkey (`B...`) or hex (`00000000abcde...`) (both
+   *    IDs with and without the 000... version prefix are accepted) of the
    *    claimable balance to load
    * @returns {Promise<xdr.ClaimableBalanceEntry>} Resolves to the full on-chain
    *    claimable balance entry
@@ -316,6 +317,8 @@ export class RpcServer {
       );
     } else if (id.match(/[a-f0-9]{72}/i)) {
       balanceId = xdr.ClaimableBalanceId.fromXDR(id, "hex")
+    } else if (id.match(/[a-f0-9]{64}/i)) {
+      balanceId = xdr.ClaimableBalanceId.fromXDR(id.padStart(72, '0'), "hex")
     } else {
       throw new TypeError(`expected 72-char hex ID or strkey, not ${id}`)
     }

--- a/test/unit/server/soroban/get_classic_entries_test.js
+++ b/test/unit/server/soroban/get_classic_entries_test.js
@@ -1,0 +1,276 @@
+const { Asset, Keypair, StrKey, xdr, hash } = StellarSdk;
+const { Server, AxiosClient } = StellarSdk.rpc;
+
+function expectLedgerEntryNotFound(axiosMock, ledgerKeyXDR, call, message) {
+  axiosMock
+    .expects("post")
+    .withArgs(serverUrl, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "getLedgerEntries",
+      params: { keys: [ledgerKeyXDR] },
+    })
+    .returns(
+      Promise.resolve({
+        data: {
+          result: {
+            latestLedger: 0,
+            entries: [],
+          },
+        },
+      }),
+    );
+
+  return call()
+    .then(() => Promise.reject(new Error("Expected rejection")))
+    .catch((error) => {
+      expect(error.message).to.equal(message);
+    });
+}
+
+describe("Server#getAccountEntry", function () {
+  beforeEach(function () {
+    this.server = new Server(serverUrl);
+    this.axiosMock = sinon.mock(AxiosClient);
+  });
+
+  afterEach(function () {
+    this.axiosMock.verify();
+    this.axiosMock.restore();
+  });
+
+  const account = "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
+  const accountId = Keypair.fromPublicKey(account).xdrAccountId();
+  const ledgerKey = xdr.LedgerKey.account(
+    new xdr.LedgerKeyAccount({ accountId }),
+  );
+  const accountEntry = new xdr.AccountEntry({
+    accountId,
+    balance: xdr.Int64.fromString("1"),
+    seqNum: xdr.SequenceNumber.fromString("1"),
+    numSubEntries: 0,
+    inflationDest: null,
+    flags: 0,
+    homeDomain: "",
+    thresholds: Buffer.from("AQAAAA==", "base64"),
+    signers: [],
+    ext: new xdr.AccountEntryExt(0),
+  });
+  const ledgerEntry = xdr.LedgerEntryData.account(accountEntry);
+  const ledgerKeyXDR = ledgerKey.toXDR("base64");
+  const ledgerEntryXDR = ledgerEntry.toXDR("base64");
+
+  it("returns the account entry when one is found", function () {
+    this.axiosMock
+      .expects("post")
+      .withArgs(serverUrl, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getLedgerEntries",
+        params: { keys: [ledgerKeyXDR] },
+      })
+      .returns(
+        Promise.resolve({
+          data: {
+            result: {
+              latestLedger: 0,
+              entries: [
+                {
+                  key: ledgerKeyXDR,
+                  xdr: ledgerEntryXDR,
+                },
+              ],
+            },
+          },
+        }),
+      );
+
+    return this.server.getAccountEntry(account).then((entry) => {
+      expect(entry).to.be.instanceof(xdr.AccountEntry);
+      expect(entry.toXDR("base64")).to.equal(accountEntry.toXDR("base64"));
+    });
+  });
+
+  it("throws a helpful error when the account is missing", function () {
+    return expectLedgerEntryNotFound(
+      this.axiosMock,
+      ledgerKeyXDR,
+      () => this.server.getAccountEntry(account),
+      `Account not found: ${account}`,
+    );
+  });
+});
+
+describe("Server#getTrustline", function () {
+  beforeEach(function () {
+    this.server = new Server(serverUrl);
+    this.axiosMock = sinon.mock(AxiosClient);
+  });
+
+  afterEach(function () {
+    this.axiosMock.verify();
+    this.axiosMock.restore();
+  });
+
+  const account = "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
+  const issuer = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+  const asset = new Asset("USDC", issuer);
+  const accountId = Keypair.fromPublicKey(account).xdrAccountId();
+  const trustlineKey = xdr.LedgerKey.trustline(
+    new xdr.LedgerKeyTrustLine({
+      accountId,
+      asset: asset.toTrustLineXDRObject(),
+    }),
+  );
+  const trustlineEntry = new xdr.TrustLineEntry({
+    accountId,
+    asset: asset.toTrustLineXDRObject(),
+    balance: xdr.Int64.fromString("500"),
+    limit: xdr.Int64.fromString("1000"),
+    flags: 1,
+    ext: new xdr.TrustLineEntryExt(0),
+  });
+  const trustlineLedgerEntry = xdr.LedgerEntryData.trustline(trustlineEntry);
+  const trustlineKeyXDR = trustlineKey.toXDR("base64");
+  const trustlineEntryXDR = trustlineLedgerEntry.toXDR("base64");
+
+  it("returns the trustline entry when it exists", function () {
+    this.axiosMock
+      .expects("post")
+      .withArgs(serverUrl, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getLedgerEntries",
+        params: { keys: [trustlineKeyXDR] },
+      })
+      .returns(
+        Promise.resolve({
+          data: {
+            result: {
+              latestLedger: 0,
+              entries: [
+                {
+                  key: trustlineKeyXDR,
+                  xdr: trustlineEntryXDR,
+                },
+              ],
+            },
+          },
+        }),
+      );
+
+    return this.server.getTrustline(account, asset).then((entry) => {
+      expect(entry).to.be.instanceof(xdr.TrustLineEntry);
+      expect(entry.toXDR("base64")).to.equal(trustlineEntry.toXDR("base64"));
+    });
+  });
+
+  it("throws an error when the trustline is missing", function () {
+    return expectLedgerEntryNotFound(
+      this.axiosMock,
+      trustlineKeyXDR,
+      () => this.server.getTrustline(account, asset),
+      `Trustline for ${asset.getCode()}:${asset.getIssuer()} not found for ${account}`,
+    );
+  });
+});
+
+describe("Server#getClaimableBalance", function () {
+  beforeEach(function () {
+    this.server = new Server(serverUrl);
+    this.axiosMock = sinon.mock(AxiosClient);
+  });
+
+  afterEach(function () {
+    this.axiosMock.verify();
+    this.axiosMock.restore();
+  });
+
+  const claimantAccount = "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
+  const balanceIdBytes = hash(Buffer.from("claimable-balance-test"));
+  const balanceId = xdr.ClaimableBalanceId.claimableBalanceIdTypeV0(
+    balanceIdBytes,
+  );
+  const ledgerKey = xdr.LedgerKey.claimableBalance(
+    new xdr.LedgerKeyClaimableBalance({ balanceId }),
+  );
+  const claimant = xdr.Claimant.claimantTypeV0(
+    new xdr.ClaimantV0({
+      destination: Keypair.fromPublicKey(claimantAccount).xdrAccountId(),
+      predicate: xdr.ClaimPredicate.claimPredicateUnconditional(),
+    }),
+  );
+  const claimableBalanceEntry = new xdr.ClaimableBalanceEntry({
+    balanceId,
+    claimants: [claimant],
+    asset: Asset.native().toXDRObject(),
+    amount: xdr.Int64.fromString("200"),
+    ext: new xdr.ClaimableBalanceEntryExt(0),
+  });
+  const ledgerEntry = xdr.LedgerEntryData.claimableBalance(
+    claimableBalanceEntry,
+  );
+  const ledgerKeyXDR = ledgerKey.toXDR("base64");
+  const ledgerEntryXDR = ledgerEntry.toXDR("base64");
+  const balanceIdHex = balanceId.toXDR("hex");
+  const balanceIdStrKey = StrKey.encodeClaimableBalance(
+    Buffer.concat([
+      Buffer.from([balanceId.switch().value]),
+      balanceId.value(),
+    ]),
+  );
+
+  it("returns the claimable balance entry when found", function () {
+    this.axiosMock
+      .expects("post")
+      .withArgs(serverUrl, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getLedgerEntries",
+        params: { keys: [ledgerKeyXDR] },
+      })
+      .returns(
+        Promise.resolve({
+          data: {
+            result: {
+              latestLedger: 0,
+              entries: [
+                {
+                  key: ledgerKeyXDR,
+                  xdr: ledgerEntryXDR,
+                },
+              ],
+            },
+          },
+        }),
+      );
+
+    return this.server
+      .getClaimableBalance(balanceIdStrKey)
+      .then((entry) => {
+        expect(entry).to.be.instanceof(xdr.ClaimableBalanceEntry);
+        expect(entry.toXDR("base64")).to.equal(
+          claimableBalanceEntry.toXDR("base64"),
+        );
+      });
+  });
+
+  it("throws an error when the claimable balance does not exist", function () {
+    return expectLedgerEntryNotFound(
+      this.axiosMock,
+      ledgerKeyXDR,
+      () => this.server.getClaimableBalance(balanceIdHex),
+      `Claimable balance ${balanceIdHex} not found`,
+    );
+  });
+
+  it("rejects when provided id is neither strkey nor hex", function () {
+    return this.server
+      .getClaimableBalance("not-a-valid-balance-id")
+      .then(() => Promise.reject(new Error("Expected rejection")))
+      .catch((error) => {
+        expect(error).to.be.instanceof(TypeError);
+        expect(error.message).to.match(/expected 72-char hex ID or strkey/i);
+      });
+  });
+});

--- a/test/unit/server/soroban/get_classic_entries_test.js
+++ b/test/unit/server/soroban/get_classic_entries_test.js
@@ -186,11 +186,11 @@ describe("Server#getClaimableBalance", function () {
     this.axiosMock.restore();
   });
 
-  const claimantAccount = "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
+  const claimantAccount =
+    "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
   const balanceIdBytes = hash(Buffer.from("claimable-balance-test"));
-  const balanceId = xdr.ClaimableBalanceId.claimableBalanceIdTypeV0(
-    balanceIdBytes,
-  );
+  const balanceId =
+    xdr.ClaimableBalanceId.claimableBalanceIdTypeV0(balanceIdBytes);
   const ledgerKey = xdr.LedgerKey.claimableBalance(
     new xdr.LedgerKeyClaimableBalance({ balanceId }),
   );
@@ -214,10 +214,7 @@ describe("Server#getClaimableBalance", function () {
   const ledgerEntryXDR = ledgerEntry.toXDR("base64");
   const balanceIdHex = balanceId.toXDR("hex");
   const balanceIdStrKey = StrKey.encodeClaimableBalance(
-    Buffer.concat([
-      Buffer.from([balanceId.switch().value]),
-      balanceId.value(),
-    ]),
+    Buffer.concat([Buffer.from([balanceId.switch().value]), balanceId.value()]),
   );
 
   it("returns the claimable balance entry when found", function () {
@@ -245,14 +242,12 @@ describe("Server#getClaimableBalance", function () {
         }),
       );
 
-    return this.server
-      .getClaimableBalance(balanceIdStrKey)
-      .then((entry) => {
-        expect(entry).to.be.instanceof(xdr.ClaimableBalanceEntry);
-        expect(entry.toXDR("base64")).to.equal(
-          claimableBalanceEntry.toXDR("base64"),
-        );
-      });
+    return this.server.getClaimableBalance(balanceIdStrKey).then((entry) => {
+      expect(entry).to.be.instanceof(xdr.ClaimableBalanceEntry);
+      expect(entry.toXDR("base64")).to.equal(
+        claimableBalanceEntry.toXDR("base64"),
+      );
+    });
   });
 
   it("throws an error when the claimable balance does not exist", function () {

--- a/test/unit/server/soroban/get_contract_balance_test.js
+++ b/test/unit/server/soroban/get_contract_balance_test.js
@@ -1,7 +1,7 @@
 const { Address, Keypair, xdr, nativeToScVal, hash } = StellarSdk;
 const { Server, AxiosClient, Durability } = StellarSdk.rpc;
 
-describe("Server#getContractBalance", function () {
+describe("Server#getSACBalance", function () {
   beforeEach(function () {
     this.server = new Server(serverUrl);
     this.axiosMock = sinon.mock(AxiosClient);

--- a/test/unit/server/soroban/get_contract_balance_test.js
+++ b/test/unit/server/soroban/get_contract_balance_test.js
@@ -33,10 +33,10 @@ describe("Server#getSACBalance", function () {
     },
   );
 
-  function buildBalanceArtifacts(holder) {
+  function buildBalanceArtifacts() {
     const key = xdr.ScVal.scvVec([
       nativeToScVal("Balance", { type: "symbol" }),
-      nativeToScVal(holder, { type: "address" }),
+      nativeToScVal(contract, { type: "address" }),
     ]);
 
     const entry = xdr.LedgerEntryData.contractData(
@@ -60,8 +60,8 @@ describe("Server#getSACBalance", function () {
     return { entry, ledgerKey };
   }
 
-  function buildMockResult(that, holder = contract) {
-    const { entry, ledgerKey } = buildBalanceArtifacts(holder);
+  function buildMockResult(that) {
+    const { entry, ledgerKey } = buildBalanceArtifacts();
     let result = {
       latestLedger: 1000,
       entries: [
@@ -105,23 +105,6 @@ describe("Server#getSACBalance", function () {
       .catch((err) => done(err));
   });
 
-  it("returns the correct balance entry for accounts", function (done) {
-    const account = Keypair.random().publicKey();
-    buildMockResult(this, account);
-
-    this.server
-      .getSACBalance(account, token, StellarSdk.Networks.TESTNET)
-      .then((response) => {
-        expect(response.latestLedger).to.equal(1000);
-        expect(response.balanceEntry).to.not.be.undefined;
-        expect(response.balanceEntry.amount).to.equal("1000000000000");
-        expect(response.balanceEntry.authorized).to.be.true;
-        expect(response.balanceEntry.clawback).to.be.false;
-        done();
-      })
-      .catch((err) => done(err));
-  });
-
   it("infers the network passphrase", function (done) {
     buildMockResult(this);
 
@@ -154,6 +137,18 @@ describe("Server#getSACBalance", function () {
         done();
       })
       .catch((err) => done(err));
+  });
+
+  it("throws on account addresses", function (done) {
+    const account = Keypair.random().publicKey();
+
+    this.server
+      .getSACBalance(account, token)
+      .then(() => done(new Error("Error didn't occur")))
+      .catch((err) => {
+        expect(err).to.match(/TypeError/);
+        done();
+      });
   });
 
   it("throws on invalid addresses", function (done) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,10 +1269,10 @@
   resolved "https://registry.yarnpkg.com/@stellar/js-xdr/-/js-xdr-3.1.2.tgz#db7611135cf21e989602fd72f513c3bed621bc74"
   integrity sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==
 
-"@stellar/stellar-base@^14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@stellar/stellar-base/-/stellar-base-14.0.0.tgz#ec57a67f97da8b62c343453acac1c1a0886ae1aa"
-  integrity sha512-CM84WNbj1GoB4FSWof4In60I6+m5ja0jbUFGKFmpYxabbgiU3Nmf29k9ZM9rkFwdyApgG2kFrB5WEwwoOHSmVA==
+"@stellar/stellar-base@^14.0.1":
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/@stellar/stellar-base/-/stellar-base-14.0.1.tgz#a1286a44da50ce903e6df8f4ab3a27df42212b49"
+  integrity sha512-mI6Kjh9hGWDA1APawQTtCbR7702dNT/8Te1uuRFPqqdoAKBk3WpXOQI3ZSZO+5olW7BSHpmVG5KBPZpIpQxIvw==
   dependencies:
     "@noble/curves" "^1.9.6"
     "@stellar/js-xdr" "^3.1.2"


### PR DESCRIPTION
* Adds a new RPC method where `id` can be strkey (`B...`) or hex (e.g. [this](https://horizon.stellar.org/claimable_balances/00000000178826fbfe339e1f5c53417c6fedfe2c05e8bec14303143ec46b38981b09c3f9/)).
```typescript
function getClaimableBalance(id: string): Promise<xdr.ClaimableBalanceEntry>
```
* Add docs & tests for the new ledger entry fetch methods introduced in #1218 
* Bump `stellar-base`