### PR TITLE
fix friendbot url in requestAirdrop documentation

### DIFF
--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -1098,7 +1098,7 @@ export class RpcServer {
    *    off" if it already exists)
    * @throws If Friendbot is not configured on this network or request failure
    *
-   * @see {@link https://developers.stellar.org/docs/learn/networks#friendbot | Friendbot docs}
+   * @see {@link https://developers.stellar.org/docs/learn/fundamentals/networks#friendbot | Friendbot docs}
    * @see {@link module:Friendbot.Api.Response}
    *
    * @example


### PR DESCRIPTION
Noticed recently this was pointing to an outdated URL. I've made stellar/stellar-docs#1816 to handle any redirects that are needed, but also wanted to supply a fix at the source.

Fixes stellar/stellar-docs#1729