### PR TITLE
docs: use HTTPS for bower.io link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can use a CDN:
 <script src="https://cdnjs.cloudflare.com/ajax/libs/stellar-sdk/{version}/stellar-sdk.js"></script>
 ```
 
-Note that this method relies on using a third party to host the JS library. This may not be entirely secure. You can self-host it via [Bower](http://bower.io):
+Note that this method relies on using a third party to host the JS library. This may not be entirely secure. You can self-host it via [Bower](https://bower.io):
 
 ```shell
 bower install @stellar/stellar-sdk


### PR DESCRIPTION
Just a tiny docs clean-up: switch bower.io link to HTTPS in README.\n\nThanks for maintaining this project — happy to tweak anything you prefer.\n\nSigned-off-by: nayan patel <74853694+nickrockbaba5@users.noreply.github.com>