### PR TITLE
AssembledTransaction null publicKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Added
+* `AssembledTransaction.sign()` throws an error if `publicKey` was not provided when instantiated ([#1269](https://github.com/stellar/js-stellar-sdk/pull/1269)).
+
 
 ## [v14.3.1](https://github.com/stellar/js-stellar-sdk/compare/v14.3.0...v14.3.1)
 

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -693,6 +693,12 @@ export class AssembledTransaction<T> {
       );
     }
 
+    if (!this.options.publicKey) {
+      throw new AssembledTransaction.Errors.FakeAccount(
+        "This transaction was constructed using a default account. Provide a valid publicKey in the AssembledTransactionOptions.",
+      );
+    }
+
     // filter out contracts, as these are dealt with via cross contract calls
     const sigsNeeded = this.needsNonInvokerSigningBy().filter(
       (id) => !id.startsWith("C"),

--- a/test/unit/server/soroban/assembled_transaction.test.ts
+++ b/test/unit/server/soroban/assembled_transaction.test.ts
@@ -11,7 +11,7 @@ const restoreTxnData = StellarSdk.SorobanDataBuilder.fromXDR(
   "AAAAAAAAAAAAAAAEAAAABgAAAAHZ4Y4l0GNoS97QH0fa5Jbbm61Ou3t9McQ09l7wREKJYwAAAA8AAAAJUEVSU19DTlQxAAAAAAAAAQAAAAYAAAAB2eGOJdBjaEve0B9H2uSW25utTrt7fTHENPZe8ERCiWMAAAAPAAAACVBFUlNfQ05UMgAAAAAAAAEAAAAGAAAAAdnhjiXQY2hL3tAfR9rkltubrU67e30xxDT2XvBEQoljAAAAFAAAAAEAAAAH+BoQswzzGTKRzrdC6axxKaM4qnyDP8wgQv8Id3S4pbsAAAAAAAAGNAAABjQAAAAAAADNoQ==",
 );
 
-describe("AssembledTransaction.buildFootprintRestoreTransaction", () => {
+describe("AssembledTransaction", () => {
   let mockPost: any;
   let server: any;
   const keypair = Keypair.random();
@@ -38,7 +38,7 @@ describe("AssembledTransaction.buildFootprintRestoreTransaction", () => {
     vi.clearAllMocks();
   });
 
-  it("makes expected RPC calls", async () => {
+  it("buildFootprintRestoreTransaction makes expected RPC calls", async () => {
     const simulateTransactionResponse = {
       transactionData: restoreTxnData,
       minResourceFee: "52641",
@@ -117,34 +117,6 @@ describe("AssembledTransaction.buildFootprintRestoreTransaction", () => {
       }),
     );
     expect(mockPost).toHaveBeenCalledTimes(3);
-  });
-});
-
-describe("AssembledTransaction", () => {
-  let mockPost: any;
-  let server: any;
-  const keypair = Keypair.random();
-  const contractId = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
-  const networkPassphrase = "Standalone Network ; February 2017";
-  const wallet = contract.basicNodeSigner(keypair, networkPassphrase);
-  let options: any; // Declare but don't initialize
-
-  beforeEach(() => {
-    server = new Server(serverUrl);
-    mockPost = vi.spyOn(server.httpClient, "post");
-    options = {
-      networkPassphrase,
-      contractId,
-      rpcUrl: serverUrl,
-      allowHttp: true,
-      publicKey: keypair.publicKey(),
-      server,
-      ...wallet,
-    };
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
   });
 
   it("throws an error if signing transaction without providing a public key", async () => {


### PR DESCRIPTION
Addresses issue #1059 by throwing a 'FakeAccount' error if a user attempts to sign an `AssembledTransaction` that they did not provide a publicKey for when instantiating
