### PR TITLE
update stellar-base dependency and release v14.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+## [v14.3.2](https://github.com/stellar/js-stellar-sdk/compare/v14.3.1...v14.3.2)
+
 ### Added
 * `AssembledTransaction.sign()` throws an error if `publicKey` was not provided when instantiated ([#1269](https://github.com/stellar/js-stellar-sdk/pull/1269)).
-
 
 ## [v14.3.1](https://github.com/stellar/js-stellar-sdk/compare/v14.3.0...v14.3.1)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/stellar-sdk",
-  "version": "14.3.1",
+  "version": "14.3.2",
   "description": "A library for working with the Stellar network, including communication with the Horizon and Soroban RPC servers.",
   "keywords": [
     "stellar"
@@ -188,13 +188,13 @@
     "taffydb": "^2.7.3",
     "terser-webpack-plugin": "^5.3.14",
     "ts-node": "^10.9.2",
-    "typescript": "5.6.3",    
+    "typescript": "5.6.3",
     "vitest": "^3.2.4",
     "webpack": "^5.102.1",
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
-    "@stellar/stellar-base": "^14.0.1",
+    "@stellar/stellar-base": "^14.0.2",
     "axios": "^1.12.2",
     "bignumber.js": "^9.3.1",
     "eventsource": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1625,10 +1625,10 @@
   resolved "https://registry.yarnpkg.com/@stellar/js-xdr/-/js-xdr-3.1.2.tgz#db7611135cf21e989602fd72f513c3bed621bc74"
   integrity sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==
 
-"@stellar/stellar-base@^14.0.1":
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/@stellar/stellar-base/-/stellar-base-14.0.1.tgz#a1286a44da50ce903e6df8f4ab3a27df42212b49"
-  integrity sha512-mI6Kjh9hGWDA1APawQTtCbR7702dNT/8Te1uuRFPqqdoAKBk3WpXOQI3ZSZO+5olW7BSHpmVG5KBPZpIpQxIvw==
+"@stellar/stellar-base@^14.0.2":
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/@stellar/stellar-base/-/stellar-base-14.0.2.tgz#c53368dfcde566a8464258f7b5e8c6988720f380"
+  integrity sha512-2/zQLw3kwHOn4jka7pZDwu24++MDvW0gthuPINF2gCNl7V8LwjmkLTuZ/eUMJjwfo6uDpujgrCkSy9JFrgdVzg==
   dependencies:
     "@noble/curves" "^1.9.6"
     "@stellar/js-xdr" "^3.1.2"


### PR DESCRIPTION
- Adds a fail early error for `AssembledTransaction.sign()` when a publicKey was not provided
- Fixes bug in misplaced `urijs`  in `dev-dependencies` instead of `dependencies` 
- updated js-stellar-base to v14.0.2