### PR TITLE
Fix: string to muxed account Spec encoding

### DIFF
--- a/src/contract/spec.ts
+++ b/src/contract/spec.ts
@@ -73,6 +73,7 @@ function stringToScVal(str: string, ty: xdr.ScSpecType): xdr.ScVal {
     case xdr.ScSpecType.scSpecTypeSymbol().value:
       return xdr.ScVal.scvSymbol(str);
     case xdr.ScSpecType.scSpecTypeAddress().value:
+    case xdr.ScSpecType.scSpecTypeMuxedAddress().value:
       return Address.fromString(str).toScVal();
     case xdr.ScSpecType.scSpecTypeU64().value:
       return new XdrLargeInt("u64", str).toScVal();


### PR DESCRIPTION
Addresses the bug in which a building an AssembledTransaction that that receives a string value that is later converted to a MuxedAddress would fail because the type is not properly detected and would fall back to the default switch branch, failing

```typescript
throw new TypeError(`invalid type ${ty.name} specified for string value`);
```

### How to reproduce:

Create an AssembledTransaction for the SAC `transfer` function with a muxed account address as the `to` argument.

An error with the following stack trace on would be thrown

```
Error building transaction TypeError: invalid type scSpecTypeMuxedAddress specified for string value
    at stringToScVal ((...)/.pnpm/@stellar+stellar-sdk@14.3.1/node_modules/@stellar/stellar-sdk/lib/contract/spec.js:108:13)
    at g.nativeToScVal ((...)/.pnpm/@stellar+stellar-sdk@14.3.1/node_modules/@stellar/stellar-sdk/lib/contract/spec.js:702:18)
    at g.nativeToScVal (webpack-internal:///(api)/../../libraries/blockchain/stellar-contracts/dist/chunk-TBRJQU75.js:26:370)
    at (...)/.pnpm/@stellar+stellar-sdk@14.3.1/node_modules/@stellar/stellar-sdk/lib/contract/spec.js:514:22
    at Array.map (<anonymous>)
    at g.funcArgsToScVals ((...)/.pnpm/@stellar+stellar-sdk@14.3.1/node_modules/@stellar/stellar-sdk/lib/contract/spec.js:513:26)
    at B.assembleTransaction [as transfer] ((...)/.pnpm/@stellar+stellar-sdk@14.3.1/node_modules/@stellar/stellar-sdk/lib/contract/client.js:104:30)
(...)
```

This change fixes it