### PR TITLE
fix(client#MethodOptions): add overrideable params

### DIFF
--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -133,18 +133,16 @@ export type SignAuthEntry = (
  */
 export type ClientOptions = {
   /**
-   * The public key of the account that will send this transaction. You can
-   * override this for specific methods later, like
-   * [signAndSend]{@link module:contract.AssembledTransaction#signAndSend} and
-   * [signAuthEntries]{@link module:contract.AssembledTransaction#signAuthEntries}.
+   * The public key of the source account for this transaction. You can
+   * override this for specific methods later; see {@link MethodOptions}.
    */
   publicKey?: string;
   /**
    * A function to sign the transaction using the private key corresponding to
    * the given `publicKey`. You do not need to provide this, for read-only
-   * calls, which only need to be simulated. If you do not need to sign and
-   * send, there is no need to provide this. If you do not provide it during
-   * initialization, you can provide it later when you call
+   * calls, which only need to be simulated. If you do not provide it during
+   * initialization, you can provide it later, either when you initialize a
+   * method (see {@link MethodOptions}) or when you call
    * {@link module:contract.AssembledTransaction#signAndSend signAndSend}.
    *
    * Matches signature of `signTransaction` from Freighter.
@@ -155,7 +153,8 @@ export type ClientOptions = {
    * private key corresponding to the provided `publicKey`. This is only needed
    * for multi-auth transactions, in which one transaction is signed by
    * multiple parties. If you do not provide it during initialization, you can
-   * provide it later when you call {@link module:contract.AssembledTransaction#signAuthEntries signAuthEntries}.
+   * provide it later either when you initialize a method (see {@link MethodOptions})
+   * or when you call {@link module:contract.AssembledTransaction#signAuthEntries signAuthEntries}.
    *
    * Matches signature of `signAuthEntry` from Freighter.
    */
@@ -236,6 +235,34 @@ export type MethodOptions = {
    * @default false
    */
   restore?: boolean;
+
+  /**
+   * The public key of the source account for this transaction.
+   *
+   * Default: the one provided to the {@link Client} in {@link ClientOptions}
+   */
+  publicKey?: string;
+  /**
+   * A function to sign the transaction using the private key corresponding to
+   * the given `publicKey`. You do not need to provide this, for read-only
+   * calls, which only need to be simulated.
+   *
+   * Matches signature of `signTransaction` from Freighter.
+   *
+   * Default: the one provided to the {@link Client} in {@link ClientOptions}
+   */
+  signTransaction?: SignTransaction;
+  /**
+   * A function to sign a specific auth entry for a transaction, using the
+   * private key corresponding to the provided `publicKey`. This is only needed
+   * for multi-auth transactions, in which one transaction is signed by
+   * multiple parties.
+   *
+   * Matches signature of `signAuthEntry` from Freighter.
+   *
+   * Default: the one provided to the {@link Client} in {@link ClientOptions}
+   */
+  signAuthEntry?: SignAuthEntry;
 };
 
 export type AssembledTransactionOptions<T = string> = MethodOptions &


### PR DESCRIPTION
This supercedes #1283, adding `publicKey`, `signTransaction`, and `signAuthEntry` as optional parameters on `MethodOptions`. This is actually the type of each method added to a Client ([[1]]), and needs to allow overriding these settings.

This will allow us to fix the generated TS Bindings and specify `MethodOptions` as the `options` type, rather than `AssembledTransactionOptions`, which causes errors since these settings (as well as `contractId`) are all **required**, but should not be required for Client methods.

  [1]: https://github.com/theahaco/js-stellar-sdk/blob/f1f81f7870affb444c1d2a289c1a272f01410346/src/contract/client.ts#L27