### PR TITLE
remove postinstall script and run setup in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
   },
   "scripts": {
     "setup": "git config blame.ignoreRevsFile .git-blame-ignore-revs",
-    "postinstall": "yarn setup || true",
     "build": "cross-env NODE_ENV=development yarn _build",
     "build:prod": "cross-env NODE_ENV=production yarn _build",
     "build:node": "yarn _babel && yarn build:ts",
@@ -107,7 +106,7 @@
     "test:browser:no-axios": "cross-env USE_AXIOS=false yarn build:browser && cross-env USE_AXIOS=false vitest run --config config/vitest.config.browser.ts test/unit",
     "fmt": "yarn _prettier && yarn eslint src/ --fix",
     "preversion": "yarn clean && yarn _prettier && yarn build:prod && yarn test",
-    "prepare": "yarn build:prod",
+    "prepare": "yarn build:prod && yarn setup",
     "_build": "yarn build:node:all && yarn build:browser:all",
     "_babel": "babel --extensions '.ts' --out-dir ${OUTPUT_DIR:-lib} src/",
     "_nyc": "node node_modules/.bin/nyc --nycrc-path config/.nycrc",


### PR DESCRIPTION
This pr addresses a bug reported in [discord (https://discord.com/channels/897514728459468821/1082043429053276190/1446310534314987632)

- The Windows environment does not allow for `|| true`
- Removes postinstall script all together as it is not the appropriate place to run the setup script
- Moves the setup script inside the prepare script
