### PR TITLE
chore: add sep45 fields in stellar TOML interface

### DIFF
--- a/src/stellartoml/index.ts
+++ b/src/stellartoml/index.ts
@@ -103,7 +103,7 @@ export namespace Api {
   }
   export type Url = string;
   export type PublicKey = string;
-  export type ContractAddress = string;
+  export type ContractId = string;
   export type ISODateTime = string;
   export interface Documentation {
     ORG_NAME?: string;
@@ -193,7 +193,7 @@ export namespace Api {
     KYC_SERVER?: Url;
     WEB_AUTH_ENDPOINT?: Url;
     WEB_AUTH_FOR_CONTRACTS_ENDPOINT?: Url;
-    WEB_AUTH_CONTRACT_ID?: ContractAddress;
+    WEB_AUTH_CONTRACT_ID?: ContractId;
     FEDERATION_SERVER?: Url;
     SIGNING_KEY?: PublicKey;
     HORIZON_URL?: Url;


### PR DESCRIPTION
SEP-1 TOML files now support `WEB_AUTH_FOR_CONTRACTS_ENDPOINT` and `WEB_AUTH_CONTRACT_ID` fields for SEP-45 authentication. This commit adds those two fields to the return type from the `StellarToml.Resolver.resolve(...)` function.