### PR TITLE
Fix npm publishing

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -34,4 +34,4 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish npm package to both places
-        run: yarn publish --access public --provenance
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Why
The improvement to use npm's trusted publishing in #1321 does not work with yarn classic.

## What
Replace yarn publish with npm publish. Output should be identical as the yarn command is running npm underneath.