### PR TITLE
Stop unpublishing a prior version on every publish run

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Build, Test, and Package
         run: yarn preversion
 
-      - name: Publish npm package to both places
+      - name: Publish npm package
         run: npm publish --access public --provenance


### PR DESCRIPTION
This was needed for a single run and can now be removed.