### PR TITLE
[Modernization] Make fetch default

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Browser Tests
         run: yarn test:browser
 
-      - name: Browser Tests (No Axios)
-        run: yarn test:browser:no-axios
+      - name: Browser Tests (Axios)
+        run: yarn test:browser:axios

--- a/README.md
+++ b/README.md
@@ -82,25 +82,19 @@ If you don't want to use or install Bower, you can copy the packaged JS files fr
 
 ### Custom Installation
 
-You can configure whether or not to build the browser bundle with the axios dependency. In order to turn off the axios dependency, set the USE_AXIOS environment variable to false. You can also turn off the eventsource dependency by setting USE_EVENTSOURCE to false.
+The default bundle uses a native-fetch HTTP client with no axios dependency. If you need the axios transport (for example, to match the behavior of older SDK versions), set the `USE_AXIOS` environment variable to `true` when building. You can also turn off the eventsource dependency by setting `USE_EVENTSOURCE=false`.
 
-#### Build without Axios
+#### Build with Axios
 ```
-npm run build:browser:no-axios
+npm run build:browser:axios
 ```
-This will create `stellar-sdk-no-axios.js` in `dist/`.
+This will create `stellar-sdk-axios.js` in `dist/`. Consumers can also import the axios-backed entry from Node via `@stellar/stellar-sdk/axios`.
 
 #### Build without EventSource
 ```
 npm run build:browser:no-eventsource
 ```
 This will create `stellar-sdk-no-eventsource.js` in `dist/`.
-
-#### Build without Axios and Eventsource
-```
-npm run build:browser:minimal
-```
-This will create `stellar-sdk-minimal.js` in `dist/`.
 
 ## Usage
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const buildConfig = require("./config/build.config");
 const fs = require("fs");
 const packageJson = JSON.parse(fs.readFileSync("./package.json", "utf8"));
@@ -18,11 +19,16 @@ module.exports = function (api) {
   plugins.push([
     "babel-plugin-transform-define",
     {
-      __USE_AXIOS__: buildConfig.useAxios,
       __USE_EVENTSOURCE__: buildConfig.useEventSource,
       __PACKAGE_VERSION__: version,
     },
   ]);
+
+  if (buildConfig.useAxios) {
+    plugins.push(
+      path.resolve(__dirname, "config/babel-plugin-alias-http-client.js"),
+    );
+  }
 
   const config = {
     comments: process.env.NODE_ENV !== "production",

--- a/config/.jsdoc.json
+++ b/config/.jsdoc.json
@@ -12,8 +12,7 @@
     "includePattern": "\\.(js|ts)$",
     "exclude": [
       "js-stellar-base/src/generated",
-      "lib/minimal",
-      "lib/no-axios",
+      "lib/axios",
       "lib/no-eventsource",
       "lib/contract/utils.d.ts"
     ]

--- a/config/babel-plugin-alias-http-client.js
+++ b/config/babel-plugin-alias-http-client.js
@@ -1,0 +1,41 @@
+// Rewrites relative imports of `./http-client` (or `../http-client`, etc.) to
+// `./http-client/axios` so the axios variant of the Node/browser build wires
+// every downstream consumer to the axios re-export without runtime branching.
+// Applied only when USE_AXIOS=true. Paths already pointing inside the
+// http-client directory (e.g. `./http-client/types`, `./http-client/axios`)
+// are left untouched.
+module.exports = function aliasHttpClient() {
+  const isHttpClientIndex = (value) => /(^|\/)http-client$/.test(value);
+  const rewrite = (value) =>
+    isHttpClientIndex(value) ? `${value}/axios` : value;
+
+  return {
+    name: "alias-http-client",
+    visitor: {
+      ImportDeclaration(path) {
+        path.node.source.value = rewrite(path.node.source.value);
+      },
+      ExportAllDeclaration(path) {
+        if (path.node.source) {
+          path.node.source.value = rewrite(path.node.source.value);
+        }
+      },
+      ExportNamedDeclaration(path) {
+        if (path.node.source) {
+          path.node.source.value = rewrite(path.node.source.value);
+        }
+      },
+      CallExpression(path) {
+        const { node } = path;
+        if (
+          node.callee &&
+          node.callee.name === "require" &&
+          node.arguments[0] &&
+          node.arguments[0].type === "StringLiteral"
+        ) {
+          node.arguments[0].value = rewrite(node.arguments[0].value);
+        }
+      },
+    },
+  };
+};

--- a/config/build.config.js
+++ b/config/build.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-    useAxios: process.env.USE_AXIOS !== 'false',
+    useAxios: process.env.USE_AXIOS === 'true',
     useEventSource: process.env.USE_EVENTSOURCE !== 'false',
   };

--- a/config/vitest.config.axios.ts
+++ b/config/vitest.config.axios.ts
@@ -8,11 +8,11 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "lcov"],
-      // This config runs tests against lib/no-axios (USE_AXIOS=false routes
-      // the test harness there). Scope coverage to that build so the report
-      // reflects what's actually under test; the default axios build is
+      // This config runs tests against lib/axios (TRANSPORT=axios routes the
+      // test harness there). Scope coverage to that build so the report
+      // reflects what's actually under test; the default fetch build is
       // covered by vitest.config.ts.
-      include: ["lib/no-axios/**/*.js"],
+      include: ["lib/axios/**/*.js"],
       exclude: [
         "test/**",
         "dist/**",
@@ -34,7 +34,6 @@ export default defineConfig({
   },
 
   define: {
-    __USE_AXIOS__: false,
     __USE_EVENTSOURCE__: true,
     __PACKAGE_VERSION__: JSON.stringify(process.env.npm_package_version),
   },

--- a/config/vitest.config.browser.ts
+++ b/config/vitest.config.browser.ts
@@ -40,7 +40,6 @@ export default defineConfig({
     },
   },
   define: {
-    __USE_AXIOS__: true,
     __USE_EVENTSOURCE__: true,
     __PACKAGE_VERSION__: JSON.stringify(process.env.npm_package_version),
   },

--- a/config/vitest.config.browser.ts
+++ b/config/vitest.config.browser.ts
@@ -4,6 +4,9 @@ import { playwright } from "@vitest/browser-playwright";
 
 export default defineConfig({
   test: {
+    env: {
+      VITE_TRANSPORT: process.env.TRANSPORT || "fetch",
+    },
     globals: true,
     environment: "jsdom",
     coverage: {

--- a/config/vitest.config.e2e.ts
+++ b/config/vitest.config.e2e.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],
       include: ['lib/**/*.js'],
-      exclude: ['test/**', 'dist/**', 'coverage/**', '**/*.d.ts', 'lib/**/*.d.ts', 'lib/minimal', 'lib/no-axios', 'lib/no-eventsource', '**/*/browser.js'],
+      exclude: ['test/**', 'dist/**', 'coverage/**', '**/*.d.ts', 'lib/**/*.d.ts', 'lib/axios', 'lib/no-eventsource', '**/*/browser.js'],
       all: true,
     },
     testTimeout: 120000, // 2 minutes timeout for e2e tests (same as original Mocha config)
@@ -38,7 +38,6 @@ export default defineConfig({
     include: ['axios'],
   },
   define: {
-    __USE_AXIOS__: true,
     __USE_EVENTSOURCE__: true,
     __PACKAGE_VERSION__: JSON.stringify(process.env.npm_package_version),
   },

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],
       include: ['lib/**/*.js'],
-      exclude: ['test/**', 'dist/**', 'coverage/**', '**/*.d.ts', 'lib/**/*.d.ts', 'lib/minimal', 'lib/no-axios', 'lib/no-eventsource', '**/*/browser.js'],
+      exclude: ['test/**', 'dist/**', 'coverage/**', '**/*.d.ts', 'lib/**/*.d.ts', 'lib/axios', 'lib/no-eventsource', '**/*/browser.js'],
       all: true,
     },
     testTimeout: 20000,
@@ -30,7 +30,6 @@ export default defineConfig({
     include: ['axios'],
   },
   define: {
-    __USE_AXIOS__: true,
     __USE_EVENTSOURCE__: true,
     __PACKAGE_VERSION__: JSON.stringify(process.env.npm_package_version),
   },

--- a/config/webpack.config.browser.js
+++ b/config/webpack.config.browser.js
@@ -11,12 +11,21 @@ var buildConfig = require('./build.config');
 const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf8'));
 const version = packageJson.version;
 
+// For the axios variant, the browser entry imports from `src/browser-axios.ts`
+// so the initial `httpClient` re-export resolves to the axios adapter. The
+// NormalModuleReplacementPlugin below then rewrites every downstream relative
+// import of `./http-client` (or `../http-client`) to `./http-client/axios`,
+// so Horizon/rpc/stellartoml/federation all pick up axios in the same bundle.
+const entryPath = buildConfig.useAxios
+  ? path.resolve(__dirname, '../src/browser-axios.ts')
+  : path.resolve(__dirname, '../src/browser.ts');
+
 const config = {
   target: 'web',
   // https://stackoverflow.com/a/34018909
   entry: {
-    'stellar-sdk': path.resolve(__dirname, '../src/browser.ts'),
-    'stellar-sdk.min': path.resolve(__dirname, '../src/browser.ts')
+    'stellar-sdk': entryPath,
+    'stellar-sdk.min': entryPath
   },
   resolve: {
     fallback: {
@@ -36,7 +45,7 @@ const config = {
     filename: (pathData) => {
       let name = pathData.chunk.name;
       let suffix = '';
-      
+
       if (name.endsWith('.min')) {
         name = name.slice(0, -4); // Remove .min
         suffix = '.min.js';
@@ -44,10 +53,9 @@ const config = {
         suffix = '.js';
       }
 
-      if (!buildConfig.useAxios && !buildConfig.useEventSource) name += '-minimal';
-      else if (!buildConfig.useAxios) name += '-no-axios';
+      if (buildConfig.useAxios) name += '-axios';
       else if (!buildConfig.useEventSource) name += '-no-eventsource';
-      
+
       return name + suffix;
     },
     path: path.resolve(__dirname, '../dist')
@@ -95,17 +103,33 @@ const config = {
     new webpack.IgnorePlugin({ resourceRegExp: /sodium-native/ }),
     new NodePolyfillPlugin({
       includeAliases: ['http', 'https'] // others aren't needed
-    
+
     }),
     new webpack.ProvidePlugin({
       Buffer: ['buffer', 'Buffer'],
       // process: 'process/browser.js',
     }),
     new webpack.DefinePlugin({
-      __USE_AXIOS__: JSON.stringify(buildConfig.useAxios),
       __USE_EVENTSOURCE__: JSON.stringify(buildConfig.useEventSource),
       __PACKAGE_VERSION__: JSON.stringify(version),
-    })
+    }),
+    ...(buildConfig.useAxios
+      ? [
+          new webpack.NormalModuleReplacementPlugin(
+            /(^|\/)http-client$/,
+            (resource) => {
+              // `resource.request` is the import specifier as written in the
+              // source file (e.g. "../http-client"). Only rewrite the bare
+              // directory import; `../http-client/axios` and
+              // `../http-client/types` don't match the regex and pass through.
+              resource.request = resource.request.replace(
+                /(^|\/)http-client$/,
+                '$1http-client/axios',
+              );
+            },
+          ),
+        ]
+      : []),
   ],
   watchOptions: {
     ignored: /(node_modules|coverage|lib|dist)/

--- a/package.json
+++ b/package.json
@@ -41,18 +41,18 @@
       "types": "./lib/rpc/index.d.ts",
       "default": "./lib/rpc/index.js"
     },
-    "./no-axios": {
-      "browser": "./dist/stellar-sdk-no-axios.min.js",
-      "types": "./lib/no-axios/index.d.ts",
-      "default": "./lib/no-axios/index.js"
+    "./axios": {
+      "browser": "./dist/stellar-sdk-axios.min.js",
+      "types": "./lib/axios/index.d.ts",
+      "default": "./lib/axios/index.js"
     },
-    "./no-axios/contract": {
-      "types": "./lib/no-axios/contract/index.d.ts",
-      "default": "./lib/no-axios/contract/index.js"
+    "./axios/contract": {
+      "types": "./lib/axios/contract/index.d.ts",
+      "default": "./lib/axios/contract/index.js"
     },
-    "./no-axios/rpc": {
-      "types": "./lib/no-axios/rpc/index.d.ts",
-      "default": "./lib/no-axios/rpc/index.js"
+    "./axios/rpc": {
+      "types": "./lib/axios/rpc/index.d.ts",
+      "default": "./lib/axios/rpc/index.js"
     },
     "./no-eventsource": {
       "browser": "./dist/stellar-sdk-no-eventsource.min.js",
@@ -67,18 +67,9 @@
       "types": "./lib/no-eventsource/rpc/index.d.ts",
       "default": "./lib/no-eventsource/rpc/index.js"
     },
-    "./minimal": {
-      "browser": "./dist/stellar-sdk-minimal.min.js",
-      "types": "./lib/minimal/index.d.ts",
-      "default": "./lib/minimal/index.js"
-    },
-    "./minimal/contract": {
-      "types": "./lib/minimal/contract/index.d.ts",
-      "default": "./lib/minimal/contract/index.js"
-    },
-    "./minimal/rpc": {
-      "types": "./lib/minimal/rpc/index.d.ts",
-      "default": "./lib/minimal/rpc/index.js"
+    "./http-client/axios": {
+      "types": "./lib/http-client/axios.d.ts",
+      "default": "./lib/http-client/axios.js"
     }
   },
   "scripts": {
@@ -86,29 +77,27 @@
     "build": "cross-env NODE_ENV=development yarn _build",
     "build:prod": "cross-env NODE_ENV=production yarn _build",
     "build:node": "yarn _babel && yarn build:ts",
-    "build:node:no-axios": "cross-env OUTPUT_DIR=lib/no-axios USE_AXIOS=false yarn build:node",
+    "build:node:axios": "cross-env OUTPUT_DIR=lib/axios USE_AXIOS=true yarn build:node",
     "build:node:no-eventsource": "cross-env OUTPUT_DIR=lib/no-eventsource USE_EVENTSOURCE=false yarn build:node",
-    "build:node:minimal": "cross-env OUTPUT_DIR=lib/minimal USE_AXIOS=false USE_EVENTSOURCE=false yarn build:node",
-    "build:node:all": "yarn build:node && yarn build:node:no-axios && yarn build:node:no-eventsource && yarn build:node:minimal",
+    "build:node:all": "yarn build:node && yarn build:node:axios && yarn build:node:no-eventsource",
     "clean:temp": "rm -f ./config/tsconfig.tmp.json",
     "build:ts": "node config/set-output-dir.js && tsc -p ./config/tsconfig.tmp.json && yarn clean:temp",
     "build:browser": "webpack -c config/webpack.config.browser.js",
-    "build:browser:no-axios": "cross-env USE_AXIOS=false webpack -c config/webpack.config.browser.js",
+    "build:browser:axios": "cross-env USE_AXIOS=true webpack -c config/webpack.config.browser.js",
     "build:browser:no-eventsource": "cross-env USE_EVENTSOURCE=false webpack -c config/webpack.config.browser.js",
-    "build:browser:minimal": "cross-env USE_AXIOS=false USE_EVENTSOURCE=false webpack -c config/webpack.config.browser.js",
-    "build:browser:all": "yarn build:browser && cross-env no_clean=true yarn build:browser:no-axios && cross-env no_clean=true yarn build:browser:no-eventsource && cross-env no_clean=true yarn build:browser:minimal",
+    "build:browser:all": "yarn build:browser && cross-env no_clean=true yarn build:browser:axios && cross-env no_clean=true yarn build:browser:no-eventsource",
     "build:docs": "cross-env NODE_ENV=docs yarn _babel",
     "clean": "rm -rf lib/ dist/ coverage/ .nyc_output/ jsdoc/ test/e2e/.soroban",
     "docs": "yarn build:docs && jsdoc -c ./config/.jsdoc.json",
-    "test": "yarn test:node && yarn test:node:no-axios && yarn test:integration && yarn test:browser",
-    "test:all": "yarn test:node && yarn test:node:no-axios && yarn test:integration && yarn test:browser && yarn test:e2e",
+    "test": "yarn test:node && yarn test:node:axios && yarn test:integration && yarn test:browser",
+    "test:all": "yarn test:node && yarn test:node:axios && yarn test:integration && yarn test:browser && yarn test:e2e",
     "test:e2e": "./test/e2e/initialize.sh && vitest run --config config/vitest.config.e2e.ts --coverage",
     "test:node": "vitest run test/unit --config config/vitest.config.ts --coverage",
-    "test:node:no-axios": "cross-env USE_AXIOS=false vitest run test/unit --config config/vitest.config.no-axios.ts",
+    "test:node:axios": "cross-env TRANSPORT=axios vitest run test/unit --config config/vitest.config.axios.ts",
     "test:e2e:noeval": "NODE_OPTIONS=--disallow-code-generation-from-strings yarn test:e2e",
     "test:integration": "vitest run test/integration --config config/vitest.config.ts --coverage",
     "test:browser": "yarn build:browser && vitest run --config config/vitest.config.browser.ts test/unit --coverage",
-    "test:browser:no-axios": "cross-env USE_AXIOS=false yarn build:browser && cross-env USE_AXIOS=false vitest run --config config/vitest.config.browser.ts test/unit",
+    "test:browser:axios": "cross-env USE_AXIOS=true yarn build:browser:axios && cross-env TRANSPORT=axios vitest run --config config/vitest.config.browser.ts test/unit",
     "fmt": "yarn _prettier && yarn eslint src/ --fix",
     "preversion": "yarn clean && yarn _prettier && yarn build:prod && yarn test",
     "prepare": "yarn build:prod && yarn setup",

--- a/src/bindings/config.ts
+++ b/src/bindings/config.ts
@@ -1,8 +1,8 @@
 // The SDK version is baked in at build time via babel-plugin-transform-define.
 // Previously this was `import packageJson from "../../package.json"`, which
-// failed at runtime in deeper build outputs (lib/no-axios, lib/minimal) because
-// the relative path `../../package.json` resolved into the output tree rather
-// than the project root.
+// failed at runtime in deeper build outputs (e.g. lib/axios, lib/no-eventsource)
+// because the relative path `../../package.json` resolved into the output tree
+// rather than the project root.
 // eslint-disable-next-line @typescript-eslint/naming-convention
 declare const __PACKAGE_VERSION__: string;
 

--- a/src/browser-axios.ts
+++ b/src/browser-axios.ts
@@ -1,0 +1,9 @@
+/* tslint:disable:no-var-requires */
+/* eslint import/no-import-module-exports: 0 */
+import { httpClient } from "./http-client/axios";
+
+export * from "./index";
+export * as StellarBase from "@stellar/stellar-base";
+export { httpClient };
+
+export default module.exports;

--- a/src/http-client/axios.ts
+++ b/src/http-client/axios.ts
@@ -1,0 +1,6 @@
+// The `axios` HTTP client implementation for the Stellar SDK. This module re-exports the SDK's built-in HTTP client,
+//  but with the `axios` implementation. This allows users to
+// inject the `axios` client without switching bundles (e.g. from `stellar-sdk/axios` to
+// `stellar-sdk`).
+export { axiosClient as httpClient, create } from "./axios-client";
+export * from "./types";

--- a/src/http-client/axios.ts
+++ b/src/http-client/axios.ts
@@ -1,6 +1,6 @@
-// The `axios` HTTP client implementation for the Stellar SDK. This module re-exports the SDK's built-in HTTP client,
-//  but with the `axios` implementation. This allows users to
-// inject the `axios` client without switching bundles (e.g. from `stellar-sdk/axios` to
-// `stellar-sdk`).
+// This file serves as an entry point for the axios-based HTTP client build.
+// It is utilized by the build system to create a separate bundle that uses axios instead of fetch.
+// By re-exporting from the main http-client index, it ensures that all types and the create function are available
+// in the axios build without duplication.
 export { axiosClient as httpClient, create } from "./axios-client";
 export * from "./types";

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -1,24 +1,2 @@
-import { HttpClient, HttpClientRequestConfig } from "./types";
-
-let httpClient: HttpClient;
-
-let create: (config?: HttpClientRequestConfig) => HttpClient;
-
-// Declare a variable that will be set by the entrypoint
-// eslint-disable-next-line @typescript-eslint/naming-convention
-declare const __USE_AXIOS__: boolean;
-
-// Use the variable for the runtime check
-
-if (__USE_AXIOS__) {
-  const axiosModule = require("./axios-client");
-  httpClient = axiosModule.axiosClient;
-  create = axiosModule.create;
-} else {
-  const fetchModule = require("./fetch-client");
-  httpClient = fetchModule.fetchClient;
-  create = fetchModule.create;
-}
-
-export { httpClient, create };
+export { fetchClient as httpClient, create } from "./fetch-client";
 export * from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,10 +41,6 @@ export * from "@stellar/stellar-base";
 
 export default module.exports;
 
-if (typeof (global as any).__USE_AXIOS__ === "undefined") {
-  (global as any).__USE_AXIOS__ = true;
-}
-
 if (typeof (global as any).__USE_EVENTSOURCE__ === "undefined") {
   (global as any).__USE_EVENTSOURCE__ = false;
 }

--- a/src/stellartoml/index.ts
+++ b/src/stellartoml/index.ts
@@ -13,10 +13,6 @@ import { Config } from "../config";
  */
 export const STELLAR_TOML_MAX_SIZE = 100 * 1024;
 
-// axios timeout doesn't catch missing urls, e.g. those with no response
-// so we use the axios cancel token to ensure the timeout
-const CancelToken = httpClient.CancelToken;
-
 /**
  * Resolver allows resolving `stellar.toml` files.
  * @memberof module:StellarToml
@@ -46,6 +42,8 @@ export class Resolver {
     domain: string,
     opts: Api.StellarTomlResolveOptions = {},
   ): Promise<Api.StellarToml> {
+    const { CancelToken } = httpClient;
+
     const allowHttp =
       typeof opts.allowHttp === "undefined"
         ? Config.isAllowHttp()

--- a/test/setup-browser.ts
+++ b/test/setup-browser.ts
@@ -16,13 +16,13 @@ if (typeof global === "undefined") {
 // Make Buffer available globally
 (window as any).Buffer = Buffer;
 
-// Try to load different bundle variants in order of preference
-const bundleVariants = [
-  "stellar-sdk-minimal",
-  "stellar-sdk-no-axios",
-  "stellar-sdk-no-eventsource",
-  "stellar-sdk",
-];
+// Try to load different bundle variants in order of preference. The axios
+// variant is listed first when TRANSPORT=axios is set so that test:browser:axios
+// exercises the axios adapter; otherwise the default fetch bundle is loaded.
+const bundleVariants =
+  typeof process !== "undefined" && process.env?.TRANSPORT === "axios"
+    ? ["stellar-sdk-axios", "stellar-sdk"]
+    : ["stellar-sdk-no-eventsource", "stellar-sdk"];
 
 let bundleLoaded = false;
 let lastError: Error | null = null;

--- a/test/setup-browser.ts
+++ b/test/setup-browser.ts
@@ -19,8 +19,9 @@ if (typeof global === "undefined") {
 // Try to load different bundle variants in order of preference. The axios
 // variant is listed first when TRANSPORT=axios is set so that test:browser:axios
 // exercises the axios adapter; otherwise the default fetch bundle is loaded.
+const transport = import.meta.env.VITE_TRANSPORT;
 const bundleVariants =
-  typeof process !== "undefined" && process.env?.TRANSPORT === "axios"
+  transport === "axios"
     ? ["stellar-sdk-axios", "stellar-sdk"]
     : ["stellar-sdk-no-eventsource", "stellar-sdk"];
 

--- a/test/test-utils/stellar-sdk-import.ts
+++ b/test/test-utils/stellar-sdk-import.ts
@@ -22,15 +22,14 @@ declare global {
   }
 }
 
-// When USE_AXIOS=false is set, Node tests must load the no-axios build so
-// they exercise the fetch path rather than the pre-baked axios build under
-// lib/. Without this redirect, the __USE_AXIOS__ define in vitest config has
-// no effect because the test harness imports pre-compiled JS from lib/.
-// Evaluated lazily so browser bundles (where `process` is undefined) don't
-// crash at module load.
+// When TRANSPORT=axios is set, Node tests must load the axios build so they
+// exercise the axios adapter rather than the default fetch build under lib/.
+// Without this redirect the harness would always import pre-compiled JS from
+// lib/ (fetch-backed) regardless of the env flag. Evaluated lazily so browser
+// bundles (where `process` is undefined) don't crash at module load.
 function getNodeLibPath(): string {
-  return typeof process !== "undefined" && process.env?.USE_AXIOS === "false"
-    ? "../../lib/no-axios"
+  return typeof process !== "undefined" && process.env?.TRANSPORT === "axios"
+    ? "../../lib/axios"
     : "../../lib";
 }
 
@@ -95,9 +94,16 @@ export function getHttpClient() {
     // In browser environment, get httpClient from global StellarSdk
     return (window as any).StellarSdk.httpClient;
   }
-  // In Node.js environment, import directly
+  // In Node.js environment, import directly. The axios lib tree still has a
+  // fetch-backed `http-client/index.js` (the file itself isn't aliased — only
+  // downstream imports of `../http-client` are). So to get the axios client
+  // we must reach for the explicit `http-client/axios` subpath.
+  const subpath =
+    typeof process !== "undefined" && process.env?.TRANSPORT === "axios"
+      ? "/http-client/axios"
+      : "/http-client";
   // eslint-disable-next-line import/no-dynamic-require, global-require
-  const httpClientModule = require(`${getNodeLibPath()}/http-client`);
+  const httpClientModule = require(`${getNodeLibPath()}${subpath}`);
   return httpClientModule.httpClient;
 }
 


### PR DESCRIPTION
## What

- This flips the default http client to fetch and adds an alternative entry point that uses axios. This allows users that find regressions in the fetch implementation or need axios behavior to revert. 
- Removes the dynamic `require` statements to be esm complient
