### PR TITLE
Tx builder type regression

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -500,6 +500,328 @@ the `docs/` directory at that ref on GitHub.
 See the [release notes](https://github.com/stellar/js-stellar-sdk/releases) for
 what changed in each release — breaking changes are clearly marked.
 
+# Source: docs/guides/01-protocol-27-soroban-auth.md
+
+# Protocol 27: Soroban authorization migration
+
+Protocol 27 ([CAP-71](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0071.md))
+reworks how Soroban authorization entries are signed. If you let the SDK build
+and sign your entries end to end — `authorizeInvocation()`, or
+`AssembledTransaction.signAuthEntries()` / `contract.Client` — the upgrade is
+mostly transparent and you can skim this guide.
+
+This guide is for the other case: **you hand-craft `SorobanAuthorizationEntry`
+values and/or compute the signature payload yourself.** Those code paths need
+changes, because the bytes you sign are different now.
+
+## What changed, in one paragraph
+
+Before P27, an address credential's signature committed to the network, nonce,
+invocation, and expiration — but **not** to the address being authorized. P27
+adds a new signature payload that **binds the address into the signed bytes**,
+and two new credential types that use it: `SOROBAN_CREDENTIALS_ADDRESS_V2`
+(same shape as the old `ADDRESS`, address-bound payload) and
+`SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES` (an account plus a tree of delegate
+signers, all signing that same shared, address-bound payload). The old
+`SOROBAN_CREDENTIALS_ADDRESS` type and its non-address-bound payload still exist
+for backwards compatibility, but new entries should use `ADDRESS_V2`.
+
+## The three credential types
+
+| Type | Value | Signature payload | Notes |
+|------|-------|-------------------|-------|
+| `SOROBAN_CREDENTIALS_SOURCE_ACCOUNT` | 0 | — (covered by tx envelope) | unchanged |
+| `SOROBAN_CREDENTIALS_ADDRESS` | 1 | `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION` (legacy, **not** address-bound) | still valid; pre-P27 behavior |
+| `SOROBAN_CREDENTIALS_ADDRESS_V2` | 2 | `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS` (**address-bound**) | new default for `authorizeInvocation()` |
+| `SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES` | 3 | `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS` (bound to the **top-level** address) | account + delegate tree |
+
+`ADDRESS_V2` carries exactly the same fields as `ADDRESS`
+(`SorobanAddressCredentials`: address, nonce, `signatureExpirationLedger`,
+signature). The only thing that changes is which preimage you hash and sign.
+
+## The core change: the signature payload is address-bound
+
+This is the part that breaks hand-rolled signers. The payload for `ADDRESS_V2`
+(and `ADDRESS_WITH_DELEGATES`) is a different `HashIdPreimage` variant with an
+extra `address` field, so it hashes to different bytes than the legacy payload.
+
+**Before (legacy `ADDRESS`):**
+
+```js
+import { hash, xdr } from '@stellar/stellar-sdk';
+
+// entry          - the unsigned SorobanAuthorizationEntry to authorize, e.g.
+//                  one returned by `simulateTransaction` or built by hand
+// keypair        - the Keypair that authorizes the invocation
+// validUntil     - ledger sequence the signature is valid until (exclusive)
+// networkPassphrase - e.g. Networks.PUBLIC / Networks.TESTNET
+function signAuthEntry(entry, keypair, validUntil, networkPassphrase) {
+  // pre-P27 entries carry their address credentials on the ADDRESS arm
+  const addressCreds = entry.credentials().address();
+
+  // commit the expiration onto the credentials *before* building the payload,
+  // so the signed hash and the submitted credentials agree on it
+  addressCreds.signatureExpirationLedger(validUntil);
+
+  // legacy payload: commits to network, nonce, invocation, expiration —
+  // but NOT the address being authorized
+  const preimage = xdr.HashIdPreimage.envelopeTypeSorobanAuthorization(
+    new xdr.HashIdPreimageSorobanAuthorization({
+      networkId: hash(Buffer.from(networkPassphrase)),
+      nonce: addressCreds.nonce(),
+      invocation: entry.rootInvocation(),
+      signatureExpirationLedger: validUntil,
+    }),
+  );
+
+  const signature = keypair.sign(hash(preimage.toXDR()));
+
+  // write the signature back onto the credentials (see `encodeSignature` below)
+  addressCreds.signature(encodeSignature(keypair.publicKey(), signature));
+  return entry;
+}
+```
+
+**After (address-bound, for `ADDRESS_V2` / `ADDRESS_WITH_DELEGATES`):**
+
+```js
+import { hash, xdr } from '@stellar/stellar-sdk';
+
+function signAuthEntry(entry, keypair, validUntil, networkPassphrase) {
+  // P27 entries carry the same SorobanAddressCredentials struct, but on the
+  // ADDRESS_V2 arm — read it with `.addressV2()`, not `.address()`
+  const addressCreds = entry.credentials().addressV2();
+
+  addressCreds.signatureExpirationLedger(validUntil);
+
+  // address-bound payload: the WithAddress variant adds an `address` field,
+  // so it hashes to different bytes than the legacy payload above
+  const preimage =
+    xdr.HashIdPreimage.envelopeTypeSorobanAuthorizationWithAddress(
+      new xdr.HashIdPreimageSorobanAuthorizationWithAddress({
+        networkId: hash(Buffer.from(networkPassphrase)),
+        nonce: addressCreds.nonce(),
+        invocation: entry.rootInvocation(),
+        address: addressCreds.address(), // ← NEW: address committed into the payload
+        signatureExpirationLedger: validUntil,
+      }),
+    );
+
+  const signature = keypair.sign(hash(preimage.toXDR()));
+
+  addressCreds.signature(encodeSignature(keypair.publicKey(), signature));
+  return entry;
+}
+```
+
+If you sign the *legacy* payload for an `ADDRESS_V2` entry, the network
+reconstructs the *address-bound* payload from the credentials, the hashes don't
+match, and the entry is rejected.
+
+### Recommended: stop hand-rolling this entirely
+
+If you have a local `Keypair` (or anything with a `.sign(Buffer)` method), all of
+the above — choosing the arm, setting the expiration, building the right payload,
+signing, verifying, and writing the signature back — is exactly what
+`authorizeEntry()` already does. It handles all three credential types, so the
+same call keeps working as you move entries from `ADDRESS` to `ADDRESS_V2`:
+
+```js
+import { authorizeEntry } from '@stellar/stellar-sdk';
+
+const signed = await authorizeEntry(
+  entry,        // any address-based SorobanAuthorizationEntry
+  keypair,      // Keypair, or a SigningCallback (see below)
+  validUntil,   // expiration ledger sequence
+  networkPassphrase,
+);
+```
+
+If your signer lives elsewhere — a hardware wallet, a browser extension, a remote
+signing service — you only need the bytes to sign. Use
+`buildAuthorizationEntryPreimage()`, which picks the correct preimage variant for
+the entry's credential type (legacy for `ADDRESS`, address-bound for `ADDRESS_V2`
+and `ADDRESS_WITH_DELEGATES`):
+
+```js
+import { buildAuthorizationEntryPreimage, hash } from '@stellar/stellar-sdk';
+
+const preimage = buildAuthorizationEntryPreimage(
+  entry,
+  validUntil,
+  networkPassphrase,
+);
+const payload = hash(preimage.toXDR()); // hand these bytes to your external signer
+```
+
+You can also hand the whole thing to `authorizeEntry()` via a `SigningCallback`,
+which receives the `HashIdPreimage` directly so you can inspect what you're
+signing rather than signing a bare hash.
+
+## The signature value itself is unchanged
+
+Only the *payload* changed; the structure you write into the credential's
+`signature` field is exactly as before — an `scvVec` of a map keyed by the
+`public_key` and `signature` symbols. This is the `encodeSignature` helper the
+two examples above call:
+
+```js
+import { nativeToScVal, StrKey, xdr } from '@stellar/stellar-sdk';
+
+// publicKey - the signer's G... address (string)
+// signature - the raw signature over `hash(preimage.toXDR())` (Buffer)
+function encodeSignature(publicKey, signature) {
+  const sigScVal = nativeToScVal(
+    {
+      public_key: StrKey.decodeEd25519PublicKey(publicKey),
+      signature,
+    },
+    {
+      type: {
+        public_key: ['symbol', null],
+        signature: ['symbol', null],
+      },
+    },
+  );
+
+  return xdr.ScVal.scvVec([sigScVal]);
+}
+```
+
+## Reading credentials off an entry
+
+The accessor depends on the arm. If you used to read `credentials().address()`
+unconditionally, that throws on a `V2` entry. Switch on the credential type:
+
+```js
+import { xdr } from '@stellar/stellar-sdk';
+
+function addressCredentials(credentials) {
+  switch (credentials.switch().value) {
+    case xdr.SorobanCredentialsType.sorobanCredentialsAddress().value:
+      return credentials.address();
+    case xdr.SorobanCredentialsType.sorobanCredentialsAddressV2().value:
+      return credentials.addressV2();
+    case xdr.SorobanCredentialsType
+      .sorobanCredentialsAddressWithDelegates().value:
+      return credentials.addressWithDelegates().addressCredentials();
+    default:
+      return null; // source-account credentials carry no address payload
+  }
+}
+```
+
+`SorobanAddressCredentials` is the same struct in all three arms, so once you've
+unwrapped it the `.address()`, `.nonce()`, `.signatureExpirationLedger()`, and
+`.signature()` accessors work identically.
+
+## `authorizeInvocation()` now produces `ADDRESS_V2`
+
+`authorizeInvocation()` builds `SOROBAN_CREDENTIALS_ADDRESS_V2` instead of the
+legacy `SOROBAN_CREDENTIALS_ADDRESS`. The signing is transparent — you still
+pass a `Keypair` or a `SigningCallback` — but two things follow:
+
+- **Read the result with `.addressV2()`**, not `.address()`:
+
+  ```js
+  const entry = await authorizeInvocation({
+    signer,
+    validUntilLedgerSeq,
+    invocation,
+    networkPassphrase,
+    publicKey, // required when `signer` is a callback
+  });
+
+  const addr = entry.credentials().addressV2(); // ← was .address()
+  ```
+
+- **The entries are only valid on protocol 27+.** If you assert on the
+  credential type, or target a pre-P27 network, account for the new type.
+
+If you specifically need a legacy `ADDRESS` entry, build it by hand with
+`xdr.SorobanCredentials.sorobanCredentialsAddress(...)` and sign the legacy
+payload (or just call `buildAuthorizationEntryPreimage()`, which detects the
+`ADDRESS` arm and returns the legacy preimage).
+
+`authorizeEntry()` already handles all three credential types and selects the
+correct payload internally, so existing `authorizeEntry()` call sites keep
+working unchanged.
+
+## New: delegated signing (`ADDRESS_WITH_DELEGATES`)
+
+CAP-71 also adds delegated authorization: an account can authorize an invocation
+through a tree of delegate signers rather than (or in addition to) its own
+signature. Like multisig, which accounts use delegation is client-side policy —
+simulation never emits this variant on its own, so you assemble it.
+
+Two pieces make this work:
+
+1. **`buildWithDelegatesEntry()`** wraps an `ADDRESS`/`ADDRESS_V2` entry into an
+   `ADDRESS_WITH_DELEGATES` entry, attaching the delegate tree. It sorts each
+   delegate array ascending by address and rejects duplicates, as the protocol
+   requires — do not hand-sort.
+2. **`authorizeEntry(..., forAddress)`** signs the shared payload and writes the
+   signature into the node whose address matches `forAddress` (the top-level
+   account or any nested delegate), instead of always the top level.
+
+```js
+import { buildWithDelegatesEntry, authorizeEntry } from '@stellar/stellar-sdk';
+
+// Start from an ADDRESS_V2 entry (e.g. one returned by simulation) and attach
+// the delegate set. The top-level signature defaults to scvVoid, which is valid
+// for an account that authorizes purely through its delegates.
+let entry = buildWithDelegatesEntry({
+  entry: simEntry, // ADDRESS or ADDRESS_V2
+  validUntilLedgerSeq,
+  delegates: [
+    { address: delegateA.publicKey() },
+    {
+      address: delegateB.publicKey(),
+      nestedDelegates: [{ address: delegateC.publicKey() }],
+    },
+  ],
+});
+
+// Every signer signs the SAME payload — bound to the *top-level* address, not
+// their own. `forAddress` just routes each signature into the right node.
+entry = await authorizeEntry(
+  entry, delegateA, validUntilLedgerSeq, networkPassphrase, delegateA.publicKey(),
+);
+entry = await authorizeEntry(
+  entry, delegateB, validUntilLedgerSeq, networkPassphrase, delegateB.publicKey(),
+);
+entry = await authorizeEntry(
+  entry, delegateC, validUntilLedgerSeq, networkPassphrase, delegateC.publicKey(),
+);
+```
+
+Each `authorizeEntry()` call clones the entry it's given, so chaining preserves
+the signatures already written. `forAddress` must match a node actually present
+in the entry, or the call throws.
+
+If you drive signing entirely yourself, build the shared payload once with
+`buildAuthorizationEntryPreimage(entry, ...)` (it's bound to the top-level
+address for every signer), hand the hash to each delegate, and write the
+resulting `scvVec` signature into each delegate node directly. Remember the
+ordering and de-duplication rules per delegate array if you construct the XDR by
+hand.
+
+## Quick checklist
+
+- [ ] Replace any hand-built `envelopeTypeSorobanAuthorization` preimage with
+      `buildAuthorizationEntryPreimage()` (or switch to
+      `envelopeTypeSorobanAuthorizationWithAddress` and include `address`) for
+      `ADDRESS_V2` entries.
+- [ ] Make sure the `signatureExpirationLedger` in the payload matches the value
+      on the credentials you submit.
+- [ ] Update reads of `credentials().address()` to handle the `addressV2()` and
+      `addressWithDelegates()` arms.
+- [ ] Update `authorizeInvocation()` result reads from `.address()` to
+      `.addressV2()`, and confirm you're targeting a protocol 27+ network.
+- [ ] For delegated auth, use `buildWithDelegatesEntry()` +
+      `authorizeEntry(..., forAddress)` rather than building the wrapper XDR by
+      hand.
+
 # Source: docs/reference/core-keys.md
 
 # Core / Keys
@@ -2156,7 +2478,7 @@ number. Account tracks the sequence number as it is used by `TransactionBuilder`
 more information about how accounts work in Stellar.
 
 ```ts
-class Account {
+class Account implements TransactionSource {
   constructor(accountId: string, sequence: string);
   accountId(): string;
   incrementSequenceNumber(): void;
@@ -2164,7 +2486,7 @@ class Account {
 }
 ```
 
-**Source:** [src/base/account.ts:15](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L15)
+**Source:** [src/base/account.ts:16](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L16)
 
 ### `new Account(accountId, sequence)`
 
@@ -2179,7 +2501,7 @@ constructor(accountId: string, sequence: string);
       provide a muxed account address, this will throw; use `MuxedAccount` instead.
 - **`sequence`** — `string` (required) — current sequence number of the account
 
-**Source:** [src/base/account.ts:26](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L26)
+**Source:** [src/base/account.ts:27](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L27)
 
 ### `account.accountId()`
 
@@ -2190,7 +2512,7 @@ Returns Stellar account ID, ex.
 accountId(): string;
 ```
 
-**Source:** [src/base/account.ts:57](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L57)
+**Source:** [src/base/account.ts:58](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L58)
 
 ### `account.incrementSequenceNumber()`
 
@@ -2200,7 +2522,7 @@ Increments sequence number in this object by one.
 incrementSequenceNumber(): void;
 ```
 
-**Source:** [src/base/account.ts:71](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L71)
+**Source:** [src/base/account.ts:72](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L72)
 
 ### `account.sequenceNumber()`
 
@@ -2210,7 +2532,7 @@ Returns sequence number for the account as a string
 sequenceNumber(): string;
 ```
 
-**Source:** [src/base/account.ts:64](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L64)
+**Source:** [src/base/account.ts:65](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L65)
 
 ## AuthClawbackEnabledFlag
 
@@ -2306,7 +2628,7 @@ const BASE_FEE: "100"
 
 - [Fees](https://developers.stellar.org/docs/glossary/fees/)
 
-**Source:** [src/base/transaction_builder.ts:38](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L38)
+**Source:** [src/base/transaction_builder.ts:39](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L39)
 
 ## FeeBumpTransaction
 
@@ -3170,7 +3492,7 @@ instances of an account can collectively modify the sequence number whenever
 a muxed account is used as the source of a `Transaction` with `TransactionBuilder`.
 
 ```ts
-class MuxedAccount {
+class MuxedAccount implements TransactionSource {
   constructor(baseAccount: Account, id: string);
   static fromAddress(mAddress: string, sequenceNum: string): MuxedAccount;
   accountId(): string;
@@ -3188,7 +3510,7 @@ class MuxedAccount {
 
 - https://developers.stellar.org/docs/glossary/muxed-accounts/
 
-**Source:** [src/base/muxed_account.ts:59](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L59)
+**Source:** [src/base/muxed_account.ts:60](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L60)
 
 ### `new MuxedAccount(baseAccount, id)`
 
@@ -3203,7 +3525,7 @@ constructor(baseAccount: Account, id: string);
 - **`id`** — `string` (required) — a stringified uint64 value that represents the ID of the
       muxed account
 
-**Source:** [src/base/muxed_account.ts:71](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L71)
+**Source:** [src/base/muxed_account.ts:72](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L72)
 
 ### `MuxedAccount.fromAddress(mAddress, sequenceNum)`
 
@@ -3219,7 +3541,7 @@ static fromAddress(mAddress: string, sequenceNum: string): MuxedAccount;
 - **`sequenceNum`** — `string` (required) — the sequence number of the underlying `Account`, to use for the underlying base account `MuxedAccount.baseAccount`. If you're using the SDK, you can use
       `server.loadAccount` to fetch this if you don't know it.
 
-**Source:** [src/base/muxed_account.ts:95](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L95)
+**Source:** [src/base/muxed_account.ts:96](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L96)
 
 ### `muxedAccount.accountId()`
 
@@ -3229,7 +3551,7 @@ Returns the M-address representing this account's (G-address, ID).
 accountId(): string;
 ```
 
-**Source:** [src/base/muxed_account.ts:114](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L114)
+**Source:** [src/base/muxed_account.ts:115](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L115)
 
 ### `muxedAccount.baseAccount()`
 
@@ -3240,7 +3562,7 @@ accounts with this Stellar address.
 baseAccount(): Account;
 ```
 
-**Source:** [src/base/muxed_account.ts:107](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L107)
+**Source:** [src/base/muxed_account.ts:108](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L108)
 
 ### `muxedAccount.equals(otherMuxedAccount)`
 
@@ -3254,7 +3576,7 @@ equals(otherMuxedAccount: MuxedAccount): boolean;
 
 - **`otherMuxedAccount`** — `MuxedAccount` (required) — the MuxedAccount to compare against
 
-**Source:** [src/base/muxed_account.ts:170](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L170)
+**Source:** [src/base/muxed_account.ts:171](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L171)
 
 ### `muxedAccount.id()`
 
@@ -3264,7 +3586,7 @@ Returns the uint64 ID of this muxed account as a string.
 id(): string;
 ```
 
-**Source:** [src/base/muxed_account.ts:121](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L121)
+**Source:** [src/base/muxed_account.ts:122](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L122)
 
 ### `muxedAccount.incrementSequenceNumber()`
 
@@ -3274,7 +3596,7 @@ Increments the underlying account's sequence number by one.
 incrementSequenceNumber(): void;
 ```
 
-**Source:** [src/base/muxed_account.ts:153](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L153)
+**Source:** [src/base/muxed_account.ts:154](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L154)
 
 ### `muxedAccount.sequenceNumber()`
 
@@ -3284,7 +3606,7 @@ Returns the stringified sequence number for the underlying account.
 sequenceNumber(): string;
 ```
 
-**Source:** [src/base/muxed_account.ts:146](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L146)
+**Source:** [src/base/muxed_account.ts:147](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L147)
 
 ### `muxedAccount.setId(id)`
 
@@ -3298,7 +3620,7 @@ setId(id: string): MuxedAccount;
 
 - **`id`** — `string` (required) — a stringified uint64 value to set as the new muxed account ID
 
-**Source:** [src/base/muxed_account.ts:130](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L130)
+**Source:** [src/base/muxed_account.ts:131](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L131)
 
 ### `muxedAccount.toXDRObject()`
 
@@ -3309,7 +3631,7 @@ G-address and uint64 ID.
 toXDRObject(): MuxedAccount;
 ```
 
-**Source:** [src/base/muxed_account.ts:161](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L161)
+**Source:** [src/base/muxed_account.ts:162](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L162)
 
 ## Networks
 
@@ -4760,7 +5082,7 @@ interface SorobanFees {
 }
 ```
 
-**Source:** [src/base/transaction_builder.ts:49](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L49)
+**Source:** [src/base/transaction_builder.ts:50](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L50)
 
 ### `sorobanFees.instructions`
 
@@ -4770,7 +5092,7 @@ The number of instructions executed by the transaction.
 instructions: number;
 ```
 
-**Source:** [src/base/transaction_builder.ts:51](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L51)
+**Source:** [src/base/transaction_builder.ts:52](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L52)
 
 ### `sorobanFees.readBytes`
 
@@ -4780,7 +5102,7 @@ The number of bytes read from the ledger by the transaction.
 readBytes: number;
 ```
 
-**Source:** [src/base/transaction_builder.ts:53](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L53)
+**Source:** [src/base/transaction_builder.ts:54](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L54)
 
 ### `sorobanFees.resourceFee`
 
@@ -4790,7 +5112,7 @@ The fee to be paid for the transaction, in stroops.
 resourceFee: bigint;
 ```
 
-**Source:** [src/base/transaction_builder.ts:57](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L57)
+**Source:** [src/base/transaction_builder.ts:58](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L58)
 
 ### `sorobanFees.writeBytes`
 
@@ -4800,7 +5122,7 @@ The number of bytes written to the ledger by the transaction.
 writeBytes: number;
 ```
 
-**Source:** [src/base/transaction_builder.ts:55](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L55)
+**Source:** [src/base/transaction_builder.ts:56](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L56)
 
 ## TimeoutInfinite
 
@@ -4813,7 +5135,7 @@ const TimeoutInfinite: 0
 - - `TransactionBuilder.setTimeout`
  - [Timeout](https://developers.stellar.org/api/resources/transactions/post/)
 
-**Source:** [src/base/transaction_builder.ts:44](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L44)
+**Source:** [src/base/transaction_builder.ts:45](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L45)
 
 ## Transaction
 
@@ -5250,7 +5572,7 @@ transaction.sign(sourceKeypair);
 
 ```ts
 class TransactionBuilder {
-  constructor(sourceAccount: Account | MuxedAccount, opts: TransactionBuilderOptions = ...);
+  constructor(sourceAccount: TransactionSource, opts: TransactionBuilderOptions = ...);
   static buildFeeBumpTransaction(feeSource: string | Keypair, baseFee: string, innerTx: Transaction, networkPassphrase: string): FeeBumpTransaction;
   static cloneFrom(tx: Transaction, opts: Partial<TransactionBuilderOptions> = {}): TransactionBuilder;
   static fromXDR(envelope: string | TransactionEnvelope, networkPassphrase: string): Transaction | FeeBumpTransaction;
@@ -5264,7 +5586,7 @@ class TransactionBuilder {
   networkPassphrase: string | null;
   operations: Operation2<OperationRecord>[];
   sorobanData: SorobanTransactionData | null;
-  source: Account | MuxedAccount;
+  source: TransactionSource;
   timebounds: { maxTime?: string | number | Date; minTime?: string | number | Date } | null;
   addMemo(memo: Memo): TransactionBuilder;
   addOperation(operation: Operation2): TransactionBuilder;
@@ -5286,20 +5608,20 @@ class TransactionBuilder {
 }
 ```
 
-**Source:** [src/base/transaction_builder.ts:152](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L152)
+**Source:** [src/base/transaction_builder.ts:153](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L153)
 
 ### `new TransactionBuilder(sourceAccount, opts)`
 
 ```ts
-constructor(sourceAccount: Account | MuxedAccount, opts: TransactionBuilderOptions = ...);
+constructor(sourceAccount: TransactionSource, opts: TransactionBuilderOptions = ...);
 ```
 
 **Parameters**
 
-- **`sourceAccount`** — `Account | MuxedAccount` (required) — source account for this transaction
+- **`sourceAccount`** — `TransactionSource` (required) — source account for this transaction
 - **`opts`** — `TransactionBuilderOptions` (optional) (default: `...`) — options object (see `TransactionBuilderOptions`)
 
-**Source:** [src/base/transaction_builder.ts:173](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L173)
+**Source:** [src/base/transaction_builder.ts:174](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L174)
 
 ### `TransactionBuilder.buildFeeBumpTransaction(feeSource, baseFee, innerTx, networkPassphrase)`
 
@@ -5333,7 +5655,7 @@ static buildFeeBumpTransaction(feeSource: string | Keypair, baseFee: string, inn
 
 - https://developers.stellar.org/docs/glossary/fee-bumps/#replace-by-fee
 
-**Source:** [src/base/transaction_builder.ts:1091](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1091)
+**Source:** [src/base/transaction_builder.ts:1092](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1092)
 
 ### `TransactionBuilder.cloneFrom(tx, opts)`
 
@@ -5364,7 +5686,7 @@ static cloneFrom(tx: Transaction, opts: Partial<TransactionBuilderOptions> = {})
   
   TODO: This cannot clone `FeeBumpTransaction`s, yet.
 
-**Source:** [src/base/transaction_builder.ts:280](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L280)
+**Source:** [src/base/transaction_builder.ts:281](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L281)
 
 ### `TransactionBuilder.fromXDR(envelope, networkPassphrase)`
 
@@ -5383,7 +5705,7 @@ static fromXDR(envelope: string | TransactionEnvelope, networkPassphrase: string
       Stellar network (e.g. "Public Global Stellar Network ; September
       2015"), see `Networks`.
 
-**Source:** [src/base/transaction_builder.ts:1202](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1202)
+**Source:** [src/base/transaction_builder.ts:1203](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1203)
 
 ### `transactionBuilder.baseFee`
 
@@ -5391,7 +5713,7 @@ static fromXDR(envelope: string | TransactionEnvelope, networkPassphrase: string
 baseFee: string;
 ```
 
-**Source:** [src/base/transaction_builder.ts:155](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L155)
+**Source:** [src/base/transaction_builder.ts:156](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L156)
 
 ### `transactionBuilder.extraSigners`
 
@@ -5399,7 +5721,7 @@ baseFee: string;
 extraSigners: string[] | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:164](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L164)
+**Source:** [src/base/transaction_builder.ts:165](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L165)
 
 ### `transactionBuilder.ledgerbounds`
 
@@ -5407,7 +5729,7 @@ extraSigners: string[] | null;
 ledgerbounds: { maxLedger?: number; minLedger?: number } | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:160](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L160)
+**Source:** [src/base/transaction_builder.ts:161](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L161)
 
 ### `transactionBuilder.memo`
 
@@ -5415,7 +5737,7 @@ ledgerbounds: { maxLedger?: number; minLedger?: number } | null;
 memo: Memo;
 ```
 
-**Source:** [src/base/transaction_builder.ts:165](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L165)
+**Source:** [src/base/transaction_builder.ts:166](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L166)
 
 ### `transactionBuilder.minAccountSequence`
 
@@ -5423,7 +5745,7 @@ memo: Memo;
 minAccountSequence: string | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:161](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L161)
+**Source:** [src/base/transaction_builder.ts:162](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L162)
 
 ### `transactionBuilder.minAccountSequenceAge`
 
@@ -5431,7 +5753,7 @@ minAccountSequence: string | null;
 minAccountSequenceAge: bigint | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:162](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L162)
+**Source:** [src/base/transaction_builder.ts:163](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L163)
 
 ### `transactionBuilder.minAccountSequenceLedgerGap`
 
@@ -5439,7 +5761,7 @@ minAccountSequenceAge: bigint | null;
 minAccountSequenceLedgerGap: number | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:163](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L163)
+**Source:** [src/base/transaction_builder.ts:164](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L164)
 
 ### `transactionBuilder.networkPassphrase`
 
@@ -5447,7 +5769,7 @@ minAccountSequenceLedgerGap: number | null;
 networkPassphrase: string | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:166](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L166)
+**Source:** [src/base/transaction_builder.ts:167](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L167)
 
 ### `transactionBuilder.operations`
 
@@ -5455,7 +5777,7 @@ networkPassphrase: string | null;
 operations: Operation2<OperationRecord>[];
 ```
 
-**Source:** [src/base/transaction_builder.ts:154](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L154)
+**Source:** [src/base/transaction_builder.ts:155](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L155)
 
 ### `transactionBuilder.sorobanData`
 
@@ -5463,15 +5785,15 @@ operations: Operation2<OperationRecord>[];
 sorobanData: SorobanTransactionData | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:167](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L167)
+**Source:** [src/base/transaction_builder.ts:168](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L168)
 
 ### `transactionBuilder.source`
 
 ```ts
-source: Account | MuxedAccount;
+source: TransactionSource;
 ```
 
-**Source:** [src/base/transaction_builder.ts:153](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L153)
+**Source:** [src/base/transaction_builder.ts:154](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L154)
 
 ### `transactionBuilder.timebounds`
 
@@ -5479,7 +5801,7 @@ source: Account | MuxedAccount;
 timebounds: { maxTime?: string | number | Date; minTime?: string | number | Date } | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:156](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L156)
+**Source:** [src/base/transaction_builder.ts:157](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L157)
 
 ### `transactionBuilder.addMemo(memo)`
 
@@ -5493,7 +5815,7 @@ addMemo(memo: Memo): TransactionBuilder;
 
 - **`memo`** — `Memo` (required) — `Memo` object
 
-**Source:** [src/base/transaction_builder.ts:393](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L393)
+**Source:** [src/base/transaction_builder.ts:394](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L394)
 
 ### `transactionBuilder.addOperation(operation)`
 
@@ -5507,7 +5829,7 @@ addOperation(operation: Operation2): TransactionBuilder;
 
 - **`operation`** — `Operation2` (required) — The xdr operation object, use `Operation` static methods.
 
-**Source:** [src/base/transaction_builder.ts:355](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L355)
+**Source:** [src/base/transaction_builder.ts:356](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L356)
 
 ### `transactionBuilder.addOperationAt(operation, index)`
 
@@ -5522,7 +5844,7 @@ addOperationAt(operation: Operation2, index: number): TransactionBuilder;
 - **`operation`** — `Operation2` (required) — The xdr operation object to add, use `Operation` static methods.
 - **`index`** — `number` (required) — The index at which to insert the operation.
 
-**Source:** [src/base/transaction_builder.ts:366](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L366)
+**Source:** [src/base/transaction_builder.ts:367](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L367)
 
 ### `transactionBuilder.addSacTransferOperation(destination, asset, amount, sorobanFees)`
 
@@ -5541,7 +5863,7 @@ addSacTransferOperation(destination: string, asset: Asset, amount: string | bigi
 - **`amount`** — `string | bigint` (required) — the amount of tokens to be transferred in 7 decimals. IE 1 token with 7 decimals of precision would be represented as "1_0000000"
 - **`sorobanFees`** — `SorobanFees` (optional) — optional Soroban fees for the transaction to override the default fees used
 
-**Source:** [src/base/transaction_builder.ts:700](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L700)
+**Source:** [src/base/transaction_builder.ts:701](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L701)
 
 ### `transactionBuilder.build()`
 
@@ -5552,7 +5874,7 @@ number by 1.
 build(): Transaction;
 ```
 
-**Source:** [src/base/transaction_builder.ts:920](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L920)
+**Source:** [src/base/transaction_builder.ts:921](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L921)
 
 ### `transactionBuilder.clearOperationAt(index)`
 
@@ -5566,7 +5888,7 @@ clearOperationAt(index: number): TransactionBuilder;
 
 - **`index`** — `number` (required) — The index of the operation to remove.
 
-**Source:** [src/base/transaction_builder.ts:384](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L384)
+**Source:** [src/base/transaction_builder.ts:385](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L385)
 
 ### `transactionBuilder.clearOperations()`
 
@@ -5576,7 +5898,7 @@ Removes the operations from the builder (useful when cloning).
 clearOperations(): TransactionBuilder;
 ```
 
-**Source:** [src/base/transaction_builder.ts:374](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L374)
+**Source:** [src/base/transaction_builder.ts:375](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L375)
 
 ### `transactionBuilder.hasV2Preconditions()`
 
@@ -5586,7 +5908,7 @@ Checks whether any v2 preconditions have been set on this builder.
 hasV2Preconditions(): boolean;
 ```
 
-**Source:** [src/base/transaction_builder.ts:1059](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1059)
+**Source:** [src/base/transaction_builder.ts:1060](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1060)
 
 ### `transactionBuilder.setExtraSigners(extraSigners)`
 
@@ -5603,7 +5925,7 @@ setExtraSigners(extraSigners: string[]): TransactionBuilder;
 
 - **`extraSigners`** — `string[]` (required) — required extra signers (as `StrKey`s)
 
-**Source:** [src/base/transaction_builder.ts:635](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L635)
+**Source:** [src/base/transaction_builder.ts:636](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L636)
 
 ### `transactionBuilder.setLedgerbounds(minLedger, maxLedger)`
 
@@ -5624,7 +5946,7 @@ setLedgerbounds(minLedger: number, maxLedger: number): TransactionBuilder;
       before. Cannot be negative. If the value is `0`, the transaction is
       valid indefinitely.
 
-**Source:** [src/base/transaction_builder.ts:523](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L523)
+**Source:** [src/base/transaction_builder.ts:524](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L524)
 
 ### `transactionBuilder.setMinAccountSequence(minAccountSequence)`
 
@@ -5648,7 +5970,7 @@ setMinAccountSequence(minAccountSequence: string): TransactionBuilder;
       default), the transaction is valid when `sourceAccount`'s sequence
       number `== tx.seqNum - 1`.
 
-**Source:** [src/base/transaction_builder.ts:560](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L560)
+**Source:** [src/base/transaction_builder.ts:561](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L561)
 
 ### `transactionBuilder.setMinAccountSequenceAge(durationInSeconds)`
 
@@ -5667,7 +5989,7 @@ setMinAccountSequenceAge(durationInSeconds: bigint): TransactionBuilder;
       will become valid. If the value is `0`, the transaction is unrestricted
       by the account sequence age. Cannot be negative.
 
-**Source:** [src/base/transaction_builder.ts:582](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L582)
+**Source:** [src/base/transaction_builder.ts:583](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L583)
 
 ### `transactionBuilder.setMinAccountSequenceLedgerGap(gap)`
 
@@ -5686,7 +6008,7 @@ setMinAccountSequenceLedgerGap(gap: number): TransactionBuilder;
       If the value is `0`, the transaction is unrestricted by the account
       sequence ledger. Cannot be negative.
 
-**Source:** [src/base/transaction_builder.ts:611](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L611)
+**Source:** [src/base/transaction_builder.ts:612](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L612)
 
 ### `transactionBuilder.setNetworkPassphrase(networkPassphrase)`
 
@@ -5701,7 +6023,7 @@ setNetworkPassphrase(networkPassphrase: string): TransactionBuilder;
 - **`networkPassphrase`** — `string` (required) — passphrase of the target Stellar
       network (e.g. "Public Global Stellar Network ; September 2015").
 
-**Source:** [src/base/transaction_builder.ts:661](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L661)
+**Source:** [src/base/transaction_builder.ts:662](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L662)
 
 ### `transactionBuilder.setSorobanData(sorobanData)`
 
@@ -5729,7 +6051,7 @@ setSorobanData(sorobanData: string | SorobanTransactionData): TransactionBuilder
 
 - `SorobanDataBuilder`
 
-**Source:** [src/base/transaction_builder.ts:683](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L683)
+**Source:** [src/base/transaction_builder.ts:684](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L684)
 
 ### `transactionBuilder.setTimebounds(minEpochOrDate, maxEpochOrDate)`
 
@@ -5753,7 +6075,7 @@ setTimebounds(minEpochOrDate: number | Date, maxEpochOrDate: number | Date): Tra
       Can't be negative. If the value is `0`, the transaction is valid
       indefinitely.
 
-**Source:** [src/base/transaction_builder.ts:474](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L474)
+**Source:** [src/base/transaction_builder.ts:475](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L475)
 
 ### `transactionBuilder.setTimeout(timeoutSeconds)`
 
@@ -5793,7 +6115,67 @@ setTimeout(timeoutSeconds: number): TransactionBuilder;
 - - `TimeoutInfinite`
  - https://developers.stellar.org/docs/tutorials/handling-errors/
 
-**Source:** [src/base/transaction_builder.ts:427](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L427)
+**Source:** [src/base/transaction_builder.ts:428](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L428)
+
+## TransactionSource
+
+The contract that `TransactionBuilder` requires of a transaction's
+source account: a way to read the account's address and sequence number, and
+to advance the sequence number in place (the builder calls
+`TransactionSource.incrementSequenceNumber` when it builds a
+transaction).
+
+Both the concrete `Account` and `MuxedAccount` classes implement
+this, as does Horizon's `AccountResponse`. Implement it yourself if you manage
+sequence numbers out-of-band (e.g. a server-side sequence pool) and want to
+pass a custom source to `TransactionBuilder`.
+
+This is intentionally a brand-free structural interface: assignability is by
+shape, not by class identity, so any account-like object that honors the
+contract is accepted.
+
+```ts
+interface TransactionSource {
+  accountId(): string;
+  incrementSequenceNumber(): void;
+  sequenceNumber(): string;
+}
+```
+
+**Source:** [src/base/transaction_source.ts:17](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_source.ts#L17)
+
+### `transactionSource.accountId()`
+
+The source account's address — a `G…` account address or, for a muxed
+source, its `M…` address.
+
+```ts
+accountId(): string;
+```
+
+**Source:** [src/base/transaction_source.ts:22](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_source.ts#L22)
+
+### `transactionSource.incrementSequenceNumber()`
+
+Increments the sequence number in place by one. `TransactionBuilder`
+calls this when building a transaction so that the next transaction built
+from the same source uses the next sequence number.
+
+```ts
+incrementSequenceNumber(): void;
+```
+
+**Source:** [src/base/transaction_source.ts:32](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_source.ts#L32)
+
+### `transactionSource.sequenceNumber()`
+
+The current sequence number, as a string.
+
+```ts
+sequenceNumber(): string;
+```
+
+**Source:** [src/base/transaction_source.ts:25](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_source.ts#L25)
 
 ## TrustLineFlag
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -8,6 +8,7 @@
 ## Guides
 
 - [Versioning & Compatibility](guides/00-versioning)
+- ["Protocol 27: Soroban authorization migration"](guides/01-protocol-27-soroban-auth)
 
 ## Reference
 

--- a/docs/reference/core-transactions.md
+++ b/docs/reference/core-transactions.md
@@ -15,7 +15,7 @@ number. Account tracks the sequence number as it is used by `TransactionBuilder`
 more information about how accounts work in Stellar.
 
 ```ts
-class Account {
+class Account implements TransactionSource {
   constructor(accountId: string, sequence: string);
   accountId(): string;
   incrementSequenceNumber(): void;
@@ -23,7 +23,7 @@ class Account {
 }
 ```
 
-**Source:** [src/base/account.ts:15](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L15)
+**Source:** [src/base/account.ts:16](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L16)
 
 ### `new Account(accountId, sequence)`
 
@@ -38,7 +38,7 @@ constructor(accountId: string, sequence: string);
       provide a muxed account address, this will throw; use `MuxedAccount` instead.
 - **`sequence`** — `string` (required) — current sequence number of the account
 
-**Source:** [src/base/account.ts:26](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L26)
+**Source:** [src/base/account.ts:27](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L27)
 
 ### `account.accountId()`
 
@@ -49,7 +49,7 @@ Returns Stellar account ID, ex.
 accountId(): string;
 ```
 
-**Source:** [src/base/account.ts:57](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L57)
+**Source:** [src/base/account.ts:58](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L58)
 
 ### `account.incrementSequenceNumber()`
 
@@ -59,7 +59,7 @@ Increments sequence number in this object by one.
 incrementSequenceNumber(): void;
 ```
 
-**Source:** [src/base/account.ts:71](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L71)
+**Source:** [src/base/account.ts:72](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L72)
 
 ### `account.sequenceNumber()`
 
@@ -69,7 +69,7 @@ Returns sequence number for the account as a string
 sequenceNumber(): string;
 ```
 
-**Source:** [src/base/account.ts:64](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L64)
+**Source:** [src/base/account.ts:65](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L65)
 
 ## AuthClawbackEnabledFlag
 
@@ -165,7 +165,7 @@ const BASE_FEE: "100"
 
 - [Fees](https://developers.stellar.org/docs/glossary/fees/)
 
-**Source:** [src/base/transaction_builder.ts:38](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L38)
+**Source:** [src/base/transaction_builder.ts:39](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L39)
 
 ## FeeBumpTransaction
 
@@ -1029,7 +1029,7 @@ instances of an account can collectively modify the sequence number whenever
 a muxed account is used as the source of a `Transaction` with `TransactionBuilder`.
 
 ```ts
-class MuxedAccount {
+class MuxedAccount implements TransactionSource {
   constructor(baseAccount: Account, id: string);
   static fromAddress(mAddress: string, sequenceNum: string): MuxedAccount;
   accountId(): string;
@@ -1047,7 +1047,7 @@ class MuxedAccount {
 
 - https://developers.stellar.org/docs/glossary/muxed-accounts/
 
-**Source:** [src/base/muxed_account.ts:59](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L59)
+**Source:** [src/base/muxed_account.ts:60](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L60)
 
 ### `new MuxedAccount(baseAccount, id)`
 
@@ -1062,7 +1062,7 @@ constructor(baseAccount: Account, id: string);
 - **`id`** — `string` (required) — a stringified uint64 value that represents the ID of the
       muxed account
 
-**Source:** [src/base/muxed_account.ts:71](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L71)
+**Source:** [src/base/muxed_account.ts:72](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L72)
 
 ### `MuxedAccount.fromAddress(mAddress, sequenceNum)`
 
@@ -1078,7 +1078,7 @@ static fromAddress(mAddress: string, sequenceNum: string): MuxedAccount;
 - **`sequenceNum`** — `string` (required) — the sequence number of the underlying `Account`, to use for the underlying base account `MuxedAccount.baseAccount`. If you're using the SDK, you can use
       `server.loadAccount` to fetch this if you don't know it.
 
-**Source:** [src/base/muxed_account.ts:95](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L95)
+**Source:** [src/base/muxed_account.ts:96](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L96)
 
 ### `muxedAccount.accountId()`
 
@@ -1088,7 +1088,7 @@ Returns the M-address representing this account's (G-address, ID).
 accountId(): string;
 ```
 
-**Source:** [src/base/muxed_account.ts:114](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L114)
+**Source:** [src/base/muxed_account.ts:115](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L115)
 
 ### `muxedAccount.baseAccount()`
 
@@ -1099,7 +1099,7 @@ accounts with this Stellar address.
 baseAccount(): Account;
 ```
 
-**Source:** [src/base/muxed_account.ts:107](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L107)
+**Source:** [src/base/muxed_account.ts:108](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L108)
 
 ### `muxedAccount.equals(otherMuxedAccount)`
 
@@ -1113,7 +1113,7 @@ equals(otherMuxedAccount: MuxedAccount): boolean;
 
 - **`otherMuxedAccount`** — `MuxedAccount` (required) — the MuxedAccount to compare against
 
-**Source:** [src/base/muxed_account.ts:170](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L170)
+**Source:** [src/base/muxed_account.ts:171](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L171)
 
 ### `muxedAccount.id()`
 
@@ -1123,7 +1123,7 @@ Returns the uint64 ID of this muxed account as a string.
 id(): string;
 ```
 
-**Source:** [src/base/muxed_account.ts:121](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L121)
+**Source:** [src/base/muxed_account.ts:122](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L122)
 
 ### `muxedAccount.incrementSequenceNumber()`
 
@@ -1133,7 +1133,7 @@ Increments the underlying account's sequence number by one.
 incrementSequenceNumber(): void;
 ```
 
-**Source:** [src/base/muxed_account.ts:153](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L153)
+**Source:** [src/base/muxed_account.ts:154](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L154)
 
 ### `muxedAccount.sequenceNumber()`
 
@@ -1143,7 +1143,7 @@ Returns the stringified sequence number for the underlying account.
 sequenceNumber(): string;
 ```
 
-**Source:** [src/base/muxed_account.ts:146](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L146)
+**Source:** [src/base/muxed_account.ts:147](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L147)
 
 ### `muxedAccount.setId(id)`
 
@@ -1157,7 +1157,7 @@ setId(id: string): MuxedAccount;
 
 - **`id`** — `string` (required) — a stringified uint64 value to set as the new muxed account ID
 
-**Source:** [src/base/muxed_account.ts:130](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L130)
+**Source:** [src/base/muxed_account.ts:131](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L131)
 
 ### `muxedAccount.toXDRObject()`
 
@@ -1168,7 +1168,7 @@ G-address and uint64 ID.
 toXDRObject(): MuxedAccount;
 ```
 
-**Source:** [src/base/muxed_account.ts:161](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L161)
+**Source:** [src/base/muxed_account.ts:162](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L162)
 
 ## Networks
 
@@ -2619,7 +2619,7 @@ interface SorobanFees {
 }
 ```
 
-**Source:** [src/base/transaction_builder.ts:49](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L49)
+**Source:** [src/base/transaction_builder.ts:50](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L50)
 
 ### `sorobanFees.instructions`
 
@@ -2629,7 +2629,7 @@ The number of instructions executed by the transaction.
 instructions: number;
 ```
 
-**Source:** [src/base/transaction_builder.ts:51](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L51)
+**Source:** [src/base/transaction_builder.ts:52](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L52)
 
 ### `sorobanFees.readBytes`
 
@@ -2639,7 +2639,7 @@ The number of bytes read from the ledger by the transaction.
 readBytes: number;
 ```
 
-**Source:** [src/base/transaction_builder.ts:53](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L53)
+**Source:** [src/base/transaction_builder.ts:54](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L54)
 
 ### `sorobanFees.resourceFee`
 
@@ -2649,7 +2649,7 @@ The fee to be paid for the transaction, in stroops.
 resourceFee: bigint;
 ```
 
-**Source:** [src/base/transaction_builder.ts:57](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L57)
+**Source:** [src/base/transaction_builder.ts:58](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L58)
 
 ### `sorobanFees.writeBytes`
 
@@ -2659,7 +2659,7 @@ The number of bytes written to the ledger by the transaction.
 writeBytes: number;
 ```
 
-**Source:** [src/base/transaction_builder.ts:55](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L55)
+**Source:** [src/base/transaction_builder.ts:56](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L56)
 
 ## TimeoutInfinite
 
@@ -2672,7 +2672,7 @@ const TimeoutInfinite: 0
 - - `TransactionBuilder.setTimeout`
  - [Timeout](https://developers.stellar.org/api/resources/transactions/post/)
 
-**Source:** [src/base/transaction_builder.ts:44](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L44)
+**Source:** [src/base/transaction_builder.ts:45](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L45)
 
 ## Transaction
 
@@ -3109,7 +3109,7 @@ transaction.sign(sourceKeypair);
 
 ```ts
 class TransactionBuilder {
-  constructor(sourceAccount: Account | MuxedAccount, opts: TransactionBuilderOptions = ...);
+  constructor(sourceAccount: TransactionSource, opts: TransactionBuilderOptions = ...);
   static buildFeeBumpTransaction(feeSource: string | Keypair, baseFee: string, innerTx: Transaction, networkPassphrase: string): FeeBumpTransaction;
   static cloneFrom(tx: Transaction, opts: Partial<TransactionBuilderOptions> = {}): TransactionBuilder;
   static fromXDR(envelope: string | TransactionEnvelope, networkPassphrase: string): Transaction | FeeBumpTransaction;
@@ -3123,7 +3123,7 @@ class TransactionBuilder {
   networkPassphrase: string | null;
   operations: Operation2<OperationRecord>[];
   sorobanData: SorobanTransactionData | null;
-  source: Account | MuxedAccount;
+  source: TransactionSource;
   timebounds: { maxTime?: string | number | Date; minTime?: string | number | Date } | null;
   addMemo(memo: Memo): TransactionBuilder;
   addOperation(operation: Operation2): TransactionBuilder;
@@ -3145,20 +3145,20 @@ class TransactionBuilder {
 }
 ```
 
-**Source:** [src/base/transaction_builder.ts:152](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L152)
+**Source:** [src/base/transaction_builder.ts:153](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L153)
 
 ### `new TransactionBuilder(sourceAccount, opts)`
 
 ```ts
-constructor(sourceAccount: Account | MuxedAccount, opts: TransactionBuilderOptions = ...);
+constructor(sourceAccount: TransactionSource, opts: TransactionBuilderOptions = ...);
 ```
 
 **Parameters**
 
-- **`sourceAccount`** — `Account | MuxedAccount` (required) — source account for this transaction
+- **`sourceAccount`** — `TransactionSource` (required) — source account for this transaction
 - **`opts`** — `TransactionBuilderOptions` (optional) (default: `...`) — options object (see `TransactionBuilderOptions`)
 
-**Source:** [src/base/transaction_builder.ts:173](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L173)
+**Source:** [src/base/transaction_builder.ts:174](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L174)
 
 ### `TransactionBuilder.buildFeeBumpTransaction(feeSource, baseFee, innerTx, networkPassphrase)`
 
@@ -3192,7 +3192,7 @@ static buildFeeBumpTransaction(feeSource: string | Keypair, baseFee: string, inn
 
 - https://developers.stellar.org/docs/glossary/fee-bumps/#replace-by-fee
 
-**Source:** [src/base/transaction_builder.ts:1091](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1091)
+**Source:** [src/base/transaction_builder.ts:1092](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1092)
 
 ### `TransactionBuilder.cloneFrom(tx, opts)`
 
@@ -3223,7 +3223,7 @@ static cloneFrom(tx: Transaction, opts: Partial<TransactionBuilderOptions> = {})
   
   TODO: This cannot clone `FeeBumpTransaction`s, yet.
 
-**Source:** [src/base/transaction_builder.ts:280](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L280)
+**Source:** [src/base/transaction_builder.ts:281](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L281)
 
 ### `TransactionBuilder.fromXDR(envelope, networkPassphrase)`
 
@@ -3242,7 +3242,7 @@ static fromXDR(envelope: string | TransactionEnvelope, networkPassphrase: string
       Stellar network (e.g. "Public Global Stellar Network ; September
       2015"), see `Networks`.
 
-**Source:** [src/base/transaction_builder.ts:1202](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1202)
+**Source:** [src/base/transaction_builder.ts:1203](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1203)
 
 ### `transactionBuilder.baseFee`
 
@@ -3250,7 +3250,7 @@ static fromXDR(envelope: string | TransactionEnvelope, networkPassphrase: string
 baseFee: string;
 ```
 
-**Source:** [src/base/transaction_builder.ts:155](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L155)
+**Source:** [src/base/transaction_builder.ts:156](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L156)
 
 ### `transactionBuilder.extraSigners`
 
@@ -3258,7 +3258,7 @@ baseFee: string;
 extraSigners: string[] | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:164](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L164)
+**Source:** [src/base/transaction_builder.ts:165](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L165)
 
 ### `transactionBuilder.ledgerbounds`
 
@@ -3266,7 +3266,7 @@ extraSigners: string[] | null;
 ledgerbounds: { maxLedger?: number; minLedger?: number } | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:160](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L160)
+**Source:** [src/base/transaction_builder.ts:161](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L161)
 
 ### `transactionBuilder.memo`
 
@@ -3274,7 +3274,7 @@ ledgerbounds: { maxLedger?: number; minLedger?: number } | null;
 memo: Memo;
 ```
 
-**Source:** [src/base/transaction_builder.ts:165](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L165)
+**Source:** [src/base/transaction_builder.ts:166](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L166)
 
 ### `transactionBuilder.minAccountSequence`
 
@@ -3282,7 +3282,7 @@ memo: Memo;
 minAccountSequence: string | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:161](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L161)
+**Source:** [src/base/transaction_builder.ts:162](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L162)
 
 ### `transactionBuilder.minAccountSequenceAge`
 
@@ -3290,7 +3290,7 @@ minAccountSequence: string | null;
 minAccountSequenceAge: bigint | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:162](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L162)
+**Source:** [src/base/transaction_builder.ts:163](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L163)
 
 ### `transactionBuilder.minAccountSequenceLedgerGap`
 
@@ -3298,7 +3298,7 @@ minAccountSequenceAge: bigint | null;
 minAccountSequenceLedgerGap: number | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:163](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L163)
+**Source:** [src/base/transaction_builder.ts:164](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L164)
 
 ### `transactionBuilder.networkPassphrase`
 
@@ -3306,7 +3306,7 @@ minAccountSequenceLedgerGap: number | null;
 networkPassphrase: string | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:166](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L166)
+**Source:** [src/base/transaction_builder.ts:167](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L167)
 
 ### `transactionBuilder.operations`
 
@@ -3314,7 +3314,7 @@ networkPassphrase: string | null;
 operations: Operation2<OperationRecord>[];
 ```
 
-**Source:** [src/base/transaction_builder.ts:154](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L154)
+**Source:** [src/base/transaction_builder.ts:155](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L155)
 
 ### `transactionBuilder.sorobanData`
 
@@ -3322,15 +3322,15 @@ operations: Operation2<OperationRecord>[];
 sorobanData: SorobanTransactionData | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:167](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L167)
+**Source:** [src/base/transaction_builder.ts:168](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L168)
 
 ### `transactionBuilder.source`
 
 ```ts
-source: Account | MuxedAccount;
+source: TransactionSource;
 ```
 
-**Source:** [src/base/transaction_builder.ts:153](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L153)
+**Source:** [src/base/transaction_builder.ts:154](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L154)
 
 ### `transactionBuilder.timebounds`
 
@@ -3338,7 +3338,7 @@ source: Account | MuxedAccount;
 timebounds: { maxTime?: string | number | Date; minTime?: string | number | Date } | null;
 ```
 
-**Source:** [src/base/transaction_builder.ts:156](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L156)
+**Source:** [src/base/transaction_builder.ts:157](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L157)
 
 ### `transactionBuilder.addMemo(memo)`
 
@@ -3352,7 +3352,7 @@ addMemo(memo: Memo): TransactionBuilder;
 
 - **`memo`** — `Memo` (required) — `Memo` object
 
-**Source:** [src/base/transaction_builder.ts:393](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L393)
+**Source:** [src/base/transaction_builder.ts:394](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L394)
 
 ### `transactionBuilder.addOperation(operation)`
 
@@ -3366,7 +3366,7 @@ addOperation(operation: Operation2): TransactionBuilder;
 
 - **`operation`** — `Operation2` (required) — The xdr operation object, use `Operation` static methods.
 
-**Source:** [src/base/transaction_builder.ts:355](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L355)
+**Source:** [src/base/transaction_builder.ts:356](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L356)
 
 ### `transactionBuilder.addOperationAt(operation, index)`
 
@@ -3381,7 +3381,7 @@ addOperationAt(operation: Operation2, index: number): TransactionBuilder;
 - **`operation`** — `Operation2` (required) — The xdr operation object to add, use `Operation` static methods.
 - **`index`** — `number` (required) — The index at which to insert the operation.
 
-**Source:** [src/base/transaction_builder.ts:366](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L366)
+**Source:** [src/base/transaction_builder.ts:367](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L367)
 
 ### `transactionBuilder.addSacTransferOperation(destination, asset, amount, sorobanFees)`
 
@@ -3400,7 +3400,7 @@ addSacTransferOperation(destination: string, asset: Asset, amount: string | bigi
 - **`amount`** — `string | bigint` (required) — the amount of tokens to be transferred in 7 decimals. IE 1 token with 7 decimals of precision would be represented as "1_0000000"
 - **`sorobanFees`** — `SorobanFees` (optional) — optional Soroban fees for the transaction to override the default fees used
 
-**Source:** [src/base/transaction_builder.ts:700](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L700)
+**Source:** [src/base/transaction_builder.ts:701](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L701)
 
 ### `transactionBuilder.build()`
 
@@ -3411,7 +3411,7 @@ number by 1.
 build(): Transaction;
 ```
 
-**Source:** [src/base/transaction_builder.ts:920](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L920)
+**Source:** [src/base/transaction_builder.ts:921](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L921)
 
 ### `transactionBuilder.clearOperationAt(index)`
 
@@ -3425,7 +3425,7 @@ clearOperationAt(index: number): TransactionBuilder;
 
 - **`index`** — `number` (required) — The index of the operation to remove.
 
-**Source:** [src/base/transaction_builder.ts:384](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L384)
+**Source:** [src/base/transaction_builder.ts:385](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L385)
 
 ### `transactionBuilder.clearOperations()`
 
@@ -3435,7 +3435,7 @@ Removes the operations from the builder (useful when cloning).
 clearOperations(): TransactionBuilder;
 ```
 
-**Source:** [src/base/transaction_builder.ts:374](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L374)
+**Source:** [src/base/transaction_builder.ts:375](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L375)
 
 ### `transactionBuilder.hasV2Preconditions()`
 
@@ -3445,7 +3445,7 @@ Checks whether any v2 preconditions have been set on this builder.
 hasV2Preconditions(): boolean;
 ```
 
-**Source:** [src/base/transaction_builder.ts:1059](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1059)
+**Source:** [src/base/transaction_builder.ts:1060](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1060)
 
 ### `transactionBuilder.setExtraSigners(extraSigners)`
 
@@ -3462,7 +3462,7 @@ setExtraSigners(extraSigners: string[]): TransactionBuilder;
 
 - **`extraSigners`** — `string[]` (required) — required extra signers (as `StrKey`s)
 
-**Source:** [src/base/transaction_builder.ts:635](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L635)
+**Source:** [src/base/transaction_builder.ts:636](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L636)
 
 ### `transactionBuilder.setLedgerbounds(minLedger, maxLedger)`
 
@@ -3483,7 +3483,7 @@ setLedgerbounds(minLedger: number, maxLedger: number): TransactionBuilder;
       before. Cannot be negative. If the value is `0`, the transaction is
       valid indefinitely.
 
-**Source:** [src/base/transaction_builder.ts:523](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L523)
+**Source:** [src/base/transaction_builder.ts:524](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L524)
 
 ### `transactionBuilder.setMinAccountSequence(minAccountSequence)`
 
@@ -3507,7 +3507,7 @@ setMinAccountSequence(minAccountSequence: string): TransactionBuilder;
       default), the transaction is valid when `sourceAccount`'s sequence
       number `== tx.seqNum - 1`.
 
-**Source:** [src/base/transaction_builder.ts:560](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L560)
+**Source:** [src/base/transaction_builder.ts:561](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L561)
 
 ### `transactionBuilder.setMinAccountSequenceAge(durationInSeconds)`
 
@@ -3526,7 +3526,7 @@ setMinAccountSequenceAge(durationInSeconds: bigint): TransactionBuilder;
       will become valid. If the value is `0`, the transaction is unrestricted
       by the account sequence age. Cannot be negative.
 
-**Source:** [src/base/transaction_builder.ts:582](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L582)
+**Source:** [src/base/transaction_builder.ts:583](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L583)
 
 ### `transactionBuilder.setMinAccountSequenceLedgerGap(gap)`
 
@@ -3545,7 +3545,7 @@ setMinAccountSequenceLedgerGap(gap: number): TransactionBuilder;
       If the value is `0`, the transaction is unrestricted by the account
       sequence ledger. Cannot be negative.
 
-**Source:** [src/base/transaction_builder.ts:611](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L611)
+**Source:** [src/base/transaction_builder.ts:612](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L612)
 
 ### `transactionBuilder.setNetworkPassphrase(networkPassphrase)`
 
@@ -3560,7 +3560,7 @@ setNetworkPassphrase(networkPassphrase: string): TransactionBuilder;
 - **`networkPassphrase`** — `string` (required) — passphrase of the target Stellar
       network (e.g. "Public Global Stellar Network ; September 2015").
 
-**Source:** [src/base/transaction_builder.ts:661](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L661)
+**Source:** [src/base/transaction_builder.ts:662](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L662)
 
 ### `transactionBuilder.setSorobanData(sorobanData)`
 
@@ -3588,7 +3588,7 @@ setSorobanData(sorobanData: string | SorobanTransactionData): TransactionBuilder
 
 - `SorobanDataBuilder`
 
-**Source:** [src/base/transaction_builder.ts:683](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L683)
+**Source:** [src/base/transaction_builder.ts:684](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L684)
 
 ### `transactionBuilder.setTimebounds(minEpochOrDate, maxEpochOrDate)`
 
@@ -3612,7 +3612,7 @@ setTimebounds(minEpochOrDate: number | Date, maxEpochOrDate: number | Date): Tra
       Can't be negative. If the value is `0`, the transaction is valid
       indefinitely.
 
-**Source:** [src/base/transaction_builder.ts:474](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L474)
+**Source:** [src/base/transaction_builder.ts:475](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L475)
 
 ### `transactionBuilder.setTimeout(timeoutSeconds)`
 
@@ -3652,7 +3652,67 @@ setTimeout(timeoutSeconds: number): TransactionBuilder;
 - - `TimeoutInfinite`
  - https://developers.stellar.org/docs/tutorials/handling-errors/
 
-**Source:** [src/base/transaction_builder.ts:427](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L427)
+**Source:** [src/base/transaction_builder.ts:428](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L428)
+
+## TransactionSource
+
+The contract that `TransactionBuilder` requires of a transaction's
+source account: a way to read the account's address and sequence number, and
+to advance the sequence number in place (the builder calls
+`TransactionSource.incrementSequenceNumber` when it builds a
+transaction).
+
+Both the concrete `Account` and `MuxedAccount` classes implement
+this, as does Horizon's `AccountResponse`. Implement it yourself if you manage
+sequence numbers out-of-band (e.g. a server-side sequence pool) and want to
+pass a custom source to `TransactionBuilder`.
+
+This is intentionally a brand-free structural interface: assignability is by
+shape, not by class identity, so any account-like object that honors the
+contract is accepted.
+
+```ts
+interface TransactionSource {
+  accountId(): string;
+  incrementSequenceNumber(): void;
+  sequenceNumber(): string;
+}
+```
+
+**Source:** [src/base/transaction_source.ts:17](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_source.ts#L17)
+
+### `transactionSource.accountId()`
+
+The source account's address — a `G…` account address or, for a muxed
+source, its `M…` address.
+
+```ts
+accountId(): string;
+```
+
+**Source:** [src/base/transaction_source.ts:22](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_source.ts#L22)
+
+### `transactionSource.incrementSequenceNumber()`
+
+Increments the sequence number in place by one. `TransactionBuilder`
+calls this when building a transaction so that the next transaction built
+from the same source uses the next sequence number.
+
+```ts
+incrementSequenceNumber(): void;
+```
+
+**Source:** [src/base/transaction_source.ts:32](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_source.ts#L32)
+
+### `transactionSource.sequenceNumber()`
+
+The current sequence number, as a string.
+
+```ts
+sequenceNumber(): string;
+```
+
+**Source:** [src/base/transaction_source.ts:25](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_source.ts#L25)
 
 ## TrustLineFlag
 

--- a/src/base/account.ts
+++ b/src/base/account.ts
@@ -2,6 +2,7 @@ import CustomBigNumber from "./util/bignumber.js";
 import type { BigNumber } from "./util/bignumber.js";
 
 import { StrKey } from "./strkey.js";
+import type { TransactionSource } from "./transaction_source.js";
 
 /**
  * Create a new Account object.
@@ -12,7 +13,7 @@ import { StrKey } from "./strkey.js";
  * [Accounts](https://developers.stellar.org/docs/glossary/accounts/) for
  * more information about how accounts work in Stellar.
  */
-export class Account {
+export class Account implements TransactionSource {
   private _accountId: string;
   private sequence: BigNumber;
 

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -51,6 +51,7 @@ export type {
 export * from "./memo.js";
 export { Account } from "./account.js";
 export { MuxedAccount } from "./muxed_account.js";
+export type { TransactionSource } from "./transaction_source.js";
 export { Claimant } from "./claimant.js";
 export { Networks } from "./network.js";
 export { StrKey } from "./strkey.js";

--- a/src/base/muxed_account.ts
+++ b/src/base/muxed_account.ts
@@ -1,6 +1,7 @@
 import xdr from "./xdr.js";
 import { Account } from "./account.js";
 import { StrKey } from "./strkey.js";
+import type { TransactionSource } from "./transaction_source.js";
 import {
   decodeAddressToMuxedAccount,
   encodeMuxedAccountToAddress,
@@ -56,7 +57,7 @@ function validateUint64Id(id: string): void {
  *
  * @see https://developers.stellar.org/docs/glossary/muxed-accounts/
  */
-export class MuxedAccount {
+export class MuxedAccount implements TransactionSource {
   private account: Account;
   private _muxedXdr: xdr.MuxedAccount;
   private _mAddress: string;

--- a/src/base/transaction_builder.ts
+++ b/src/base/transaction_builder.ts
@@ -5,6 +5,7 @@ import xdr from "./xdr.js";
 
 import { Account } from "./account.js";
 import { MuxedAccount } from "./muxed_account.js";
+import type { TransactionSource } from "./transaction_source.js";
 import {
   decodeAddressToMuxedAccount,
   extractBaseAddress,
@@ -150,7 +151,7 @@ export interface TransactionBuilderOptions {
  *
  */
 export class TransactionBuilder {
-  source: Account | MuxedAccount;
+  source: TransactionSource;
   operations: xdr.Operation[];
   baseFee: string;
   timebounds: {
@@ -171,7 +172,7 @@ export class TransactionBuilder {
    * @param opts - options object (see {@link TransactionBuilderOptions})
    */
   constructor(
-    sourceAccount: Account | MuxedAccount,
+    sourceAccount: TransactionSource,
     opts: TransactionBuilderOptions = {} as TransactionBuilderOptions,
   ) {
     if (!sourceAccount) {

--- a/src/base/transaction_source.ts
+++ b/src/base/transaction_source.ts
@@ -1,0 +1,33 @@
+/**
+ * The contract that {@link TransactionBuilder} requires of a transaction's
+ * source account: a way to read the account's address and sequence number, and
+ * to advance the sequence number in place (the builder calls
+ * {@link TransactionSource.incrementSequenceNumber} when it builds a
+ * transaction).
+ *
+ * Both the concrete {@link Account} and {@link MuxedAccount} classes implement
+ * this, as does Horizon's `AccountResponse`. Implement it yourself if you manage
+ * sequence numbers out-of-band (e.g. a server-side sequence pool) and want to
+ * pass a custom source to {@link TransactionBuilder}.
+ *
+ * This is intentionally a brand-free structural interface: assignability is by
+ * shape, not by class identity, so any account-like object that honors the
+ * contract is accepted.
+ */
+export interface TransactionSource {
+  /**
+   * The source account's address — a `G…` account address or, for a muxed
+   * source, its `M…` address.
+   */
+  accountId(): string;
+
+  /** The current sequence number, as a string. */
+  sequenceNumber(): string;
+
+  /**
+   * Increments the sequence number in place by one. {@link TransactionBuilder}
+   * calls this when building a transaction so that the next transaction built
+   * from the same source uses the next sequence number.
+   */
+  incrementSequenceNumber(): void;
+}

--- a/src/horizon/account_response.ts
+++ b/src/horizon/account_response.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:variable-name */
 
 import { Account as BaseAccount } from "../base/index.js";
-import type { TransactionBuilder } from "../base/index.js";
+import type { TransactionBuilder, TransactionSource } from "../base/index.js";
 import { HorizonApi } from "./horizon_api.js";
 import { ServerApi } from "./server_api.js";
 
@@ -18,7 +18,7 @@ import { ServerApi } from "./server_api.js";
  * @param response - Response from horizon account endpoint.
  * @returns AccountResponse instance
  */
-export class AccountResponse {
+export class AccountResponse implements TransactionSource {
   public readonly id!: string;
   public readonly paging_token!: string;
   public readonly account_id!: string;


### PR DESCRIPTION
## What 

- Defines a `TransactionSource` interface with the methods that `TransactionBuilder` requires
- Forces `Account` and `MuxedAccount` to implement this interface to prevent regressions

## Why
The typescript migration of base introduced a type narrowing of the `account` parameter in the TransactionBuilder constructor. This caused a regression in the ability to use Horizon's `AccountResponse` class as an arg to TransactionBuilder. 

fixes #1435 