### PR TITLE
protocol 27 - V2 credential opt in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Changed
+
+- Soroban auth defaults back to the legacy `SOROBAN_CREDENTIALS_ADDRESS` (V1)
+  credential, with the CAP-71 `SOROBAN_CREDENTIALS_ADDRESS_V2` credential now
+  available behind an opt-in instead of forced on. `ADDRESS_V2` is only valid on
+  networks that have activated CAP-71, so emitting it before activation would
+  fail submission; the opt-in keeps the default safe while letting you exercise
+  V2 against networks that already support it. The default will flip to V2 once
+  the protocol makes it mandatory. ([#1450](https://github.com/stellar/js-stellar-sdk/pull/1450))
+  - `rpc.Server.simulateTransaction` gained a 4th optional argument,
+    `authV2` (default `false`). When `true`, the `authV2` request flag is sent so
+    simulation returns `ADDRESS_V2` auth entries; otherwise the flag is omitted
+    and legacy `ADDRESS` entries are returned.
+  - `authorizeInvocation` gained an optional `authV2` field on its params object
+    (default `false`) selecting between `ADDRESS` and `ADDRESS_V2` credentials.
+  - `contract.Client` / `AssembledTransaction` accept `authV2` in
+    `MethodOptions`, threaded through to simulation.
+
+
 ## v16.0.0-rc.1
 
 There are a few major updates in this release:

--- a/docs/guides/00-migration.md
+++ b/docs/guides/00-migration.md
@@ -381,36 +381,56 @@ If your code reached through the SDK for any of these, declare them yourself now
 Protocol 27 ([CAP-71](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0071.md))
 adds two address-bound Soroban credential types, `AddressV2` and
 `AddressWithDelegates`. This only affects code that signs Soroban authorization
-entries or inspects their credential arms. Depending on the network and RPC
-simulation behavior, authorization entries may contain either the legacy
-`ADDRESS` credential or the newer `ADDRESS_V2` credential. Both are valid for SDK
-signing flows that use the helpers below.
+entries or inspects their credential arms.
+
+By default the SDK still uses the legacy `ADDRESS` credential: simulation is
+asked for `ADDRESS` entries and `authorizeInvocation` builds them. `ADDRESS_V2`
+is only valid on networks that have upgraded to protocol 27, so it is **opt-in** until
+the protocol makes it mandatory (at which point the default flips). Opt in with
+the `authV2` flag — on
+`rpc.Server.simulateTransaction`,
+on `authorizeInvocation`'s params, or via `authV2` in
+[`contract.Client`](/reference/contracts-client/#contractclient) /
+`MethodOptions` — when your target network supports it.
 
 SDK-driven signing ([`contract.Client`](/reference/contracts-client/#contractclient),
 [`basicNodeSigner`](/reference/contracts-client/#contractbasicnodesigner),
 [`authorizeEntry`](/reference/core-soroban-primitives/#authorizeentry),
 [`signAuthEntries`](/reference/contracts-client/#contractassembledtransaction)) is
-forward-compatible with no code change: it signs whichever credential simulation
-returns. The entries below break only code that reads the credential arm or
-builds the signature payload by hand.
+forward-compatible with no code change: it signs whichever credential the entry
+carries, `ADDRESS` or `ADDRESS_V2`. The entries below break only code that reads
+the credential arm or builds the signature payload by hand.
 
 For the full walkthrough of signing Soroban authorization entries, see
 [Authorize a Contract Call](/guides/07-contract-auth/).
 
-### Auth: `authorizeInvocation` now returns `AddressV2`
+### Auth: `authorizeInvocation` takes a params object
 
 [`authorizeInvocation`](/reference/core-soroban-primitives/#authorizeinvocation) now
-takes a single params object and builds `SOROBAN_CREDENTIALS_ADDRESS_V2` entries
-instead of legacy `ADDRESS`. Read the
-result with `.addressV2()`.
+takes a single params object instead of positional arguments. It still builds a
+legacy `SOROBAN_CREDENTIALS_ADDRESS` entry by default, so keep reading the result
+with `.address()`.
 
-```ts del={1-4} ins={5-8}
+```ts del={1-4} ins={5-7}
 const entry = await authorizeInvocation(
   signer, validUntilLedgerSeq, invocation, publicKey, networkPassphrase,
 )
-const addr = entry.credentials().address()
 const entry = await authorizeInvocation({
   signer, validUntilLedgerSeq, invocation, networkPassphrase, publicKey,
+})
+const addr = entry.credentials().address()
+```
+
+To build a CAP-71 `ADDRESS_V2` entry instead, pass `authV2: true` and read the
+result with `.addressV2()`. Only do this on networks that have upgraded to protocol 27.
+
+```ts ins={6}
+const entry = await authorizeInvocation({
+  signer,
+  validUntilLedgerSeq,
+  invocation,
+  networkPassphrase,
+  authV2: true,
 })
 const addr = entry.credentials().addressV2()
 ```
@@ -470,15 +490,6 @@ wrapper with
 and rejects duplicates, as the protocol requires), then route each signer's
 signature with `forAddress`. Every signer signs the same payload, bound to the
 top-level address.
-
-### Auth: closed export surface
-
-The auth module's wildcard re-export was replaced with an explicit allow-list. The
-package root now exports exactly `authorizeEntry`, `authorizeInvocation`,
-`buildAuthorizationEntryPreimage`, `buildWithDelegatesEntry`, and the types
-`SigningCallback`, `AuthorizeInvocationParams`, `DelegateSignature`,
-`BuildWithDelegatesParams`. Anything else imported from the auth module (notably
-`getAddressCredentials`, now internal) no longer resolves.
 
 ### Earlier 15.x deprecation: `BalanceResponse.revocable`
 

--- a/docs/guides/00-migration.md
+++ b/docs/guides/00-migration.md
@@ -386,7 +386,7 @@ entries or inspects their credential arms.
 By default the SDK still uses the legacy `ADDRESS` credential: simulation is
 asked for `ADDRESS` entries and `authorizeInvocation` builds them. `ADDRESS_V2`
 is only valid on networks that have upgraded to protocol 27, so it is **opt-in** until
-the protocol makes it mandatory (at which point the default flips). Opt in with
+ protocol 28 makes it mandatory (at which point the default flips). Opt in with
 the `authV2` flag — on
 `rpc.Server.simulateTransaction`,
 on `authorizeInvocation`'s params, or via `authV2` in

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -423,7 +423,7 @@ returns `false`, then you need to call `signAndSend` on this transaction.
 readonly isReadCall: boolean;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:1089](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1089)
+**Source:** [src/contract/assembled_transaction.ts:1094](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1094)
 
 ### `assembledTransaction.result`
 
@@ -431,7 +431,7 @@ readonly isReadCall: boolean;
 readonly result: T;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:738](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L738)
+**Source:** [src/contract/assembled_transaction.ts:743](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L743)
 
 ### `assembledTransaction.simulationData`
 
@@ -439,7 +439,7 @@ readonly result: T;
 readonly simulationData: { result: SimulateHostFunctionResult; transactionData: SorobanTransactionData };
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:695](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L695)
+**Source:** [src/contract/assembled_transaction.ts:700](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L700)
 
 ### `assembledTransaction.needsNonInvokerSigningBy(__namedParameters)`
 
@@ -469,7 +469,7 @@ needsNonInvokerSigningBy(__namedParameters: { includeAlreadySigned?: boolean } =
 
 - **`__namedParameters`** — `{ includeAlreadySigned?: boolean }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:924](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L924)
+**Source:** [src/contract/assembled_transaction.ts:929](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L929)
 
 ### `assembledTransaction.restoreFootprint(restorePreamble, account)`
 
@@ -504,7 +504,7 @@ Client initialization.
 - - Throws a custom error if the
 restore transaction fails, providing the details of the failure.
 
-**Source:** [src/contract/assembled_transaction.ts:1118](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1118)
+**Source:** [src/contract/assembled_transaction.ts:1123](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1123)
 
 ### `assembledTransaction.send(watcher)`
 
@@ -521,7 +521,7 @@ send(watcher?: Watcher): Promise<SentTransaction<T>>;
 
 - **`watcher`** — `Watcher` (optional)
 
-**Source:** [src/contract/assembled_transaction.ts:853](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L853)
+**Source:** [src/contract/assembled_transaction.ts:858](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L858)
 
 ### `assembledTransaction.sign(__namedParameters)`
 
@@ -536,7 +536,7 @@ sign(__namedParameters: { force?: boolean; signTransaction?: SignTransaction } =
 
 - **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransaction }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:766](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L766)
+**Source:** [src/contract/assembled_transaction.ts:771](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L771)
 
 ### `assembledTransaction.signAndSend(__namedParameters)`
 
@@ -555,7 +555,7 @@ signAndSend(__namedParameters: { force?: boolean; signTransaction?: SignTransact
 
 - **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransaction; watcher?: Watcher }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:871](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L871)
+**Source:** [src/contract/assembled_transaction.ts:876](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L876)
 
 ### `assembledTransaction.signAuthEntries(__namedParameters)`
 
@@ -582,7 +582,7 @@ signAuthEntries(__namedParameters: { address?: string; authorizeEntry?: (entry: 
 
 - **`__namedParameters`** — `{ address?: string; authorizeEntry?: (entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string) => Promise<SorobanAuthorizationEntry>; expiration?: number | Promise<number>; signAuthEntry?: SignAuthEntry }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:985](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L985)
+**Source:** [src/contract/assembled_transaction.ts:990](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L990)
 
 ### `assembledTransaction.simulate(__namedParameters)`
 
@@ -791,7 +791,7 @@ _before_ transaction signing.
 const DEFAULT_TIMEOUT: number
 ```
 
-**Source:** [src/contract/types.ts:292](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L292)
+**Source:** [src/contract/types.ts:302](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L302)
 
 ## contract.NULL_ACCOUNT
 
@@ -801,7 +801,7 @@ An impossible account on the Stellar network
 const NULL_ACCOUNT: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
 ```
 
-**Source:** [src/contract/types.ts:298](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L298)
+**Source:** [src/contract/types.ts:308](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L308)
 
 ## contract.SentTransaction
 
@@ -1341,7 +1341,7 @@ basicNodeSigner(keypair: Keypair, networkPassphrase: string): { signAuthEntry: S
 type AssembledTransactionOptions<T = string> = MethodOptions & ClientOptions & { address?: string; args?: any[]; method: string; parseResultXdr: (xdr: xdr.ScVal) => T; submit?: boolean; submitUrl?: string }
 ```
 
-**Source:** [src/contract/types.ts:260](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L260)
+**Source:** [src/contract/types.ts:270](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L270)
 
 ### contract.ClientOptions
 
@@ -1392,7 +1392,7 @@ message: string;
 Options for a smart contract method invocation.
 
 ```ts
-type MethodOptions = { fee?: string; publicKey?: string; restore?: boolean; signAuthEntry?: SignAuthEntry; signTransaction?: SignTransaction; simulate?: boolean; timeoutInSeconds?: number }
+type MethodOptions = { authV2?: boolean; fee?: string; publicKey?: string; restore?: boolean; signAuthEntry?: SignAuthEntry; signTransaction?: SignTransaction; simulate?: boolean; timeoutInSeconds?: number }
 ```
 
 **Source:** [src/contract/types.ts:203](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L203)

--- a/docs/reference/core-soroban-primitives.md
+++ b/docs/reference/core-soroban-primitives.md
@@ -708,15 +708,48 @@ function multiPartyAuth(
 
 ## authorizeInvocation
 
+This builds an entry from scratch, allowing you to express authorization as a
+function of:
+  - a particular identity (i.e. signing `Keypair` or other signer)
+  - approving the execution of an invocation tree (i.e. a simulation-acquired
+    `xdr.SorobanAuthorizedInvocation` or otherwise built)
+  - on a particular network (uniquely identified by its passphrase, see
+    `Networks`)
+  - until a particular ledger sequence is reached.
+
+This is in contrast to `authorizeEntry`, which signs an existing entry.
+
 ```ts
 authorizeInvocation(params: AuthorizeInvocationParams): Promise<SorobanAuthorizationEntry>
 ```
 
 **Parameters**
 
-- **`params`** — `AuthorizeInvocationParams` (required)
+- **`params`** — `AuthorizeInvocationParams` (required) — the parameters for building and signing the authorization
+    - `signer`: either a `Keypair` instance (or anything with a
+     `.sign(buf): Buffer-like` method) or a function which takes a payload (a
+     `xdr.HashIdPreimageSorobanAuthorization` instance) input and returns
+     the signature of the hash of the raw payload bytes (where the signing key
+     should correspond to the address in the `entry`)
+    - `validUntilLedgerSeq`: the (exclusive) future ledger sequence
+     number until which this authorization entry should be valid (if
+     `currentLedgerSeq==validUntilLedgerSeq`, this is expired)
+    - `invocation`: the invocation tree that we're authorizing
+     (likely, this comes from transaction simulation)
+    - `networkPassphrase`: the network passphrase is incorporated into
+     the signature (see `Networks` for options)
+    - `publicKey`: the public identity of the signer (when providing a
+     `Keypair` to `signer`, this can be omitted, as it just uses
+     `Keypair.publicKey`)
+    - `authV2`: build `SOROBAN_CREDENTIALS_ADDRESS_V2` (CAP-71) credentials
+     rather than the legacy `SOROBAN_CREDENTIALS_ADDRESS`. Defaults to `false`;
+     only enable it for networks that have activated CAP-71.
 
-**Source:** [src/base/auth.ts:280](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L280)
+**See also**
+
+- authorizeEntry
+
+**Source:** [src/base/auth.ts:291](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L291)
 
 ## buildAuthorizationEntryPreimage
 
@@ -751,7 +784,7 @@ buildAuthorizationEntryPreimage(entry: SorobanAuthorizationEntry, validUntilLedg
 - `Error` if `entry` carries source-account or otherwise non-address
    credentials
 
-**Source:** [src/base/auth.ts:340](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L340)
+**Source:** [src/base/auth.ts:357](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L357)
 
 ## buildInvocationTree
 
@@ -840,7 +873,7 @@ buildWithDelegatesEntry(params: BuildWithDelegatesParams): SorobanAuthorizationE
 - `Error` if `entry` is not an `ADDRESS`/`ADDRESS_V2` entry, or if any
    delegates array contains a duplicate address.
 
-**Source:** [src/base/auth.ts:450](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L450)
+**Source:** [src/base/auth.ts:467](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L467)
 
 ## humanizeEvents
 
@@ -1090,19 +1123,9 @@ walkInvocationTree(root: SorobanAuthorizedInvocation, callback: InvocationWalker
 
 ### AuthorizeInvocationParams
 
-This builds an entry from scratch, allowing you to express authorization as a
-function of:
-  - a particular identity (i.e. signing `Keypair` or other signer)
-  - approving the execution of an invocation tree (i.e. a simulation-acquired
-    `xdr.SorobanAuthorizedInvocation` or otherwise built)
-  - on a particular network (uniquely identified by its passphrase, see
-    `Networks`)
-  - until a particular ledger sequence is reached.
-
-This is in contrast to `authorizeEntry`, which signs an existing entry.
-
 ```ts
 interface AuthorizeInvocationParams {
+  authV2?: boolean;
   invocation: SorobanAuthorizedInvocation;
   networkPassphrase: string;
   publicKey?: string;
@@ -1111,11 +1134,21 @@ interface AuthorizeInvocationParams {
 }
 ```
 
-**See also**
+**Source:** [src/base/auth.ts:241](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L241)
 
-- authorizeEntry
+#### `authorizeInvocationParams.authV2`
 
-**Source:** [src/base/auth.ts:272](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L272)
+Build `SOROBAN_CREDENTIALS_ADDRESS_V2` (CAP-71) credentials instead of the
+legacy `SOROBAN_CREDENTIALS_ADDRESS`. V2 credentials bind the address into
+the signed payload but are only valid on networks that have activated
+CAP-71, so leave this off until the activation vote passes for your target
+network. The default flips to `true` once V2 becomes mandatory.
+
+```ts
+authV2?: boolean;
+```
+
+**Source:** [src/base/auth.ts:255](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L255)
 
 #### `authorizeInvocationParams.invocation`
 
@@ -1123,7 +1156,7 @@ interface AuthorizeInvocationParams {
 invocation: SorobanAuthorizedInvocation;
 ```
 
-**Source:** [src/base/auth.ts:275](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L275)
+**Source:** [src/base/auth.ts:244](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L244)
 
 #### `authorizeInvocationParams.networkPassphrase`
 
@@ -1131,7 +1164,7 @@ invocation: SorobanAuthorizedInvocation;
 networkPassphrase: string;
 ```
 
-**Source:** [src/base/auth.ts:276](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L276)
+**Source:** [src/base/auth.ts:245](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L245)
 
 #### `authorizeInvocationParams.publicKey`
 
@@ -1139,7 +1172,7 @@ networkPassphrase: string;
 publicKey?: string;
 ```
 
-**Source:** [src/base/auth.ts:277](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L277)
+**Source:** [src/base/auth.ts:246](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L246)
 
 #### `authorizeInvocationParams.signer`
 
@@ -1147,7 +1180,7 @@ publicKey?: string;
 signer: Keypair | SigningCallback;
 ```
 
-**Source:** [src/base/auth.ts:273](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L273)
+**Source:** [src/base/auth.ts:242](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L242)
 
 #### `authorizeInvocationParams.validUntilLedgerSeq`
 
@@ -1155,7 +1188,7 @@ signer: Keypair | SigningCallback;
 validUntilLedgerSeq: number;
 ```
 
-**Source:** [src/base/auth.ts:274](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L274)
+**Source:** [src/base/auth.ts:243](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L243)
 
 ### BuildWithDelegatesParams
 
@@ -1170,7 +1203,7 @@ interface BuildWithDelegatesParams {
 }
 ```
 
-**Source:** [src/base/auth.ts:408](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L408)
+**Source:** [src/base/auth.ts:425](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L425)
 
 #### `buildWithDelegatesParams.delegates`
 
@@ -1180,7 +1213,7 @@ the delegate signers to attach.
 delegates: DelegateSignature[];
 ```
 
-**Source:** [src/base/auth.ts:418](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L418)
+**Source:** [src/base/auth.ts:435](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L435)
 
 #### `buildWithDelegatesParams.entry`
 
@@ -1192,7 +1225,7 @@ simulation — whose address credentials should be wrapped.
 entry: SorobanAuthorizationEntry;
 ```
 
-**Source:** [src/base/auth.ts:414](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L414)
+**Source:** [src/base/auth.ts:431](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L431)
 
 #### `buildWithDelegatesParams.signature`
 
@@ -1203,7 +1236,7 @@ for accounts that authorize purely via delegated signers (CAP-71-01).
 signature?: ScVal;
 ```
 
-**Source:** [src/base/auth.ts:423](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L423)
+**Source:** [src/base/auth.ts:440](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L440)
 
 #### `buildWithDelegatesParams.validUntilLedgerSeq`
 
@@ -1213,7 +1246,7 @@ the expiration ledger sequence stored on the top-level credentials.
 validUntilLedgerSeq: number;
 ```
 
-**Source:** [src/base/auth.ts:416](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L416)
+**Source:** [src/base/auth.ts:433](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L433)
 
 ### CreateInvocation
 
@@ -1273,7 +1306,7 @@ interface DelegateSignature {
 }
 ```
 
-**Source:** [src/base/auth.ts:394](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L394)
+**Source:** [src/base/auth.ts:411](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L411)
 
 #### `delegateSignature.address`
 
@@ -1283,7 +1316,7 @@ the delegate's address (`G…` account or `C…` contract).
 address: string;
 ```
 
-**Source:** [src/base/auth.ts:396](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L396)
+**Source:** [src/base/auth.ts:413](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L413)
 
 #### `delegateSignature.nestedDelegates`
 
@@ -1293,7 +1326,7 @@ signers this delegate in turn delegates to (recursive).
 nestedDelegates?: DelegateSignature[];
 ```
 
-**Source:** [src/base/auth.ts:404](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L404)
+**Source:** [src/base/auth.ts:421](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L421)
 
 #### `delegateSignature.signature`
 
@@ -1305,7 +1338,7 @@ as `forAddress`) or by editing the entry directly.
 signature?: ScVal;
 ```
 
-**Source:** [src/base/auth.ts:402](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L402)
+**Source:** [src/base/auth.ts:419](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L419)
 
 ### ExecuteInvocation
 

--- a/docs/reference/network-rpc.md
+++ b/docs/reference/network-rpc.md
@@ -110,7 +110,7 @@ class Server {
   _getTransaction(hash: string): Promise<RawGetTransactionResponse>;
   _getTransactions(request: GetTransactionsRequest): Promise<RawGetTransactionsResponse>;
   _sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<RawSendTransactionResponse>;
-  _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode): Promise<RawSimulateTransactionResponse>;
+  _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, authV2: boolean = false): Promise<RawSimulateTransactionResponse>;
   fundAddress(address: string, friendbotUrl?: string): Promise<GetSuccessfulTransactionResponse>;
   getAccount(address: string): Promise<Account>;
   getAccountEntry(address: string): Promise<AccountEntry>;
@@ -136,7 +136,7 @@ class Server {
   prepareTransaction(tx: Transaction | FeeBumpTransaction): Promise<Transaction>;
   requestAirdrop(address: string | Pick<Account, "accountId">, friendbotUrl?: string): Promise<Account>;
   sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<SendTransactionResponse>;
-  simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode): Promise<SimulateTransactionResponse>;
+  simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, authV2: boolean = false): Promise<SimulateTransactionResponse>;
 }
 ```
 
@@ -233,7 +233,7 @@ _getLedgers(request: GetLedgersRequest): Promise<RawGetLedgersResponse>;
 
 - **`request`** — `GetLedgersRequest` (required)
 
-**Source:** [src/rpc/server.ts:1558](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1558)
+**Source:** [src/rpc/server.ts:1569](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1569)
 
 ### `server._getTransaction(hash)`
 
@@ -269,12 +269,12 @@ _sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<RawSend
 
 - **`transaction`** — `Transaction | FeeBumpTransaction` (required)
 
-**Source:** [src/rpc/server.ts:1194](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1194)
+**Source:** [src/rpc/server.ts:1205](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1205)
 
-### `server._simulateTransaction(transaction, addlResources, authMode)`
+### `server._simulateTransaction(transaction, addlResources, authMode, authV2)`
 
 ```ts
-_simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode): Promise<RawSimulateTransactionResponse>;
+_simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, authV2: boolean = false): Promise<RawSimulateTransactionResponse>;
 ```
 
 **Parameters**
@@ -282,8 +282,9 @@ _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResource
 - **`transaction`** — `Transaction | FeeBumpTransaction` (required)
 - **`addlResources`** — `ResourceLeeway` (optional)
 - **`authMode`** — `SimulationAuthMode` (optional)
+- **`authV2`** — `boolean` (optional) (default: `false`)
 
-**Source:** [src/rpc/server.ts:1041](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1041)
+**Source:** [src/rpc/server.ts:1047](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1047)
 
 ### `server.fundAddress(address, friendbotUrl)`
 
@@ -336,7 +337,7 @@ console.log("Contract funded! Hash:", tx.txHash);
 
 - `Friendbot docs`
 
-**Source:** [src/rpc/server.ts:1317](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1317)
+**Source:** [src/rpc/server.ts:1328](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1328)
 
 ### `server.getAccount(address)`
 
@@ -689,7 +690,7 @@ the fee stats
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getFeeStats
 
-**Source:** [src/rpc/server.ts:1363](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1363)
+**Source:** [src/rpc/server.ts:1374](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1374)
 
 ### `server.getHealth()`
 
@@ -875,7 +876,7 @@ const nextPage = await server.getLedgers({
 
 - `getLedgers docs`
 
-**Source:** [src/rpc/server.ts:1542](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1542)
+**Source:** [src/rpc/server.ts:1553](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1553)
 
 ### `server.getNetwork()`
 
@@ -963,7 +964,7 @@ console.log(
 - - getLedgerEntries
  - https://developers.stellar.org/docs/tokens/stellar-asset-contract
 
-**Source:** [src/rpc/server.ts:1427](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1427)
+**Source:** [src/rpc/server.ts:1438](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1438)
 
 ### `server.getTransaction(hash)`
 
@@ -1094,7 +1095,7 @@ the version info
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getVersionInfo
 
-**Source:** [src/rpc/server.ts:1377](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1377)
+**Source:** [src/rpc/server.ts:1388](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1388)
 
 ### `server.pollTransaction(hash, opts)`
 
@@ -1223,7 +1224,7 @@ server.sendTransaction(transaction).then(result => {
 - - module:rpc.assembleTransaction
  - `simulateTransaction docs`
 
-**Source:** [src/rpc/server.ts:1133](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1133)
+**Source:** [src/rpc/server.ts:1144](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1144)
 
 ### `server.requestAirdrop(address, friendbotUrl)`
 
@@ -1273,7 +1274,7 @@ server
 - - `Friendbot docs`
  - `Friendbot.Api.Response`
 
-**Source:** [src/rpc/server.ts:1239](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1239)
+**Source:** [src/rpc/server.ts:1250](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1250)
 
 ### `server.sendTransaction(transaction)`
 
@@ -1334,15 +1335,15 @@ server.sendTransaction(transaction).then((result) => {
 - - `transaction docs`
  - `sendTransaction docs`
 
-**Source:** [src/rpc/server.ts:1188](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1188)
+**Source:** [src/rpc/server.ts:1199](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1199)
 
-### `server.simulateTransaction(tx, addlResources, authMode)`
+### `server.simulateTransaction(tx, addlResources, authMode, authV2)`
 
 Submit a trial contract invocation to get back return values, expected
 ledger footprint, expected authorizations, and expected costs.
 
 ```ts
-simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode): Promise<SimulateTransactionResponse>;
+simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, authV2: boolean = false): Promise<SimulateTransactionResponse>;
 ```
 
 **Parameters**
@@ -1359,6 +1360,11 @@ simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: Resour
      auth mode to use for simulation: `enforce` for enforcement mode,
      `record` for recording mode, or `record_allow_nonroot` for recording
      mode that allows non-root authorization
+- **`authV2`** — `boolean` (optional) (default: `false`) — (optional) request `SOROBAN_CREDENTIALS_ADDRESS_V2`
+     (CAP-71) auth credentials from simulation instead of the legacy
+     `SOROBAN_CREDENTIALS_ADDRESS`. Defaults to `false`; only enable it for
+     networks that have activated CAP-71, as V2 credentials are otherwise
+     rejected.
 
 **Returns**
 
@@ -1400,7 +1406,7 @@ server.simulateTransaction(transaction).then((sim) => {
  - module:rpc.Server#prepareTransaction
  - module:rpc.assembleTransaction
 
-**Source:** [src/rpc/server.ts:1031](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1031)
+**Source:** [src/rpc/server.ts:1036](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1036)
 
 ## rpc.assembleTransaction
 

--- a/src/base/auth.ts
+++ b/src/base/auth.ts
@@ -238,6 +238,22 @@ export async function authorizeEntry(
   return clone;
 }
 
+export interface AuthorizeInvocationParams {
+  signer: Keypair | SigningCallback;
+  validUntilLedgerSeq: number;
+  invocation: xdr.SorobanAuthorizedInvocation;
+  networkPassphrase: string;
+  publicKey?: string;
+  /**
+   * Build `SOROBAN_CREDENTIALS_ADDRESS_V2` (CAP-71) credentials instead of the
+   * legacy `SOROBAN_CREDENTIALS_ADDRESS`. V2 credentials bind the address into
+   * the signed payload but are only valid on networks that have activated
+   * CAP-71, so leave this off until the activation vote passes for your target
+   * network. The default flips to `true` once V2 becomes mandatory.
+   * @defaultValue false
+   */
+  authV2?: boolean;
+}
 /**
  * This builds an entry from scratch, allowing you to express authorization as a
  * function of:
@@ -266,17 +282,12 @@ export async function authorizeEntry(
  *   - `publicKey`: the public identity of the signer (when providing a
  *    {@link Keypair} to `signer`, this can be omitted, as it just uses
  *    {@link Keypair.publicKey})
+ *   - `authV2`: build `SOROBAN_CREDENTIALS_ADDRESS_V2` (CAP-71) credentials
+ *    rather than the legacy `SOROBAN_CREDENTIALS_ADDRESS`. Defaults to `false`;
+ *    only enable it for networks that have activated CAP-71.
  *
  * @see authorizeEntry
  */
-export interface AuthorizeInvocationParams {
-  signer: Keypair | SigningCallback;
-  validUntilLedgerSeq: number;
-  invocation: xdr.SorobanAuthorizedInvocation;
-  networkPassphrase: string;
-  publicKey?: string;
-}
-
 export function authorizeInvocation(
   params: AuthorizeInvocationParams,
 ): Promise<xdr.SorobanAuthorizationEntry> {
@@ -286,6 +297,7 @@ export function authorizeInvocation(
     invocation,
     networkPassphrase,
     publicKey = "",
+    authV2 = false,
   } = params;
   // We use keypairs as a source of randomness for the nonce to avoid mucking
   // with any crypto dependencies. Note that this just has to be random and
@@ -299,16 +311,21 @@ export function authorizeInvocation(
     throw new Error(`authorizeInvocation requires publicKey parameter`);
   }
 
+  // V1 and V2 carry the identical SorobanAddressCredentials payload; only the
+  // credential union arm differs. authorizeEntry picks the matching signature
+  // preimage (legacy vs. address-bound) off whichever arm we build here.
+  const addressCredentials = new xdr.SorobanAddressCredentials({
+    address: new Address(pk).toScAddress(),
+    nonce,
+    signatureExpirationLedger: 0, // replaced
+    signature: xdr.ScVal.scvVec([]), // replaced
+  });
+
   const entry = new xdr.SorobanAuthorizationEntry({
     rootInvocation: invocation,
-    credentials: xdr.SorobanCredentials.sorobanCredentialsAddressV2(
-      new xdr.SorobanAddressCredentials({
-        address: new Address(pk).toScAddress(),
-        nonce,
-        signatureExpirationLedger: 0, // replaced
-        signature: xdr.ScVal.scvVec([]), // replaced
-      }),
-    ),
+    credentials: authV2
+      ? xdr.SorobanCredentials.sorobanCredentialsAddressV2(addressCredentials)
+      : xdr.SorobanCredentials.sorobanCredentialsAddress(addressCredentials),
   });
 
   return authorizeEntry(entry, signer, validUntilLedgerSeq, networkPassphrase);

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -654,7 +654,12 @@ export class AssembledTransaction<T> {
     // need to force re-calculation of simulationData for new simulation
     delete this.simulationResult;
     delete this.simulationTransactionData;
-    this.simulation = await this.server.simulateTransaction(this.built);
+    this.simulation = await this.server.simulateTransaction(
+      this.built,
+      undefined,
+      undefined,
+      this.options.authV2,
+    );
 
     if (restore && Api.isSimulationRestore(this.simulation)) {
       const account = await getAccount(this.options, this.server);

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -229,6 +229,16 @@ export type MethodOptions = {
   restore?: boolean;
 
   /**
+   * Request `SOROBAN_CREDENTIALS_ADDRESS_V2` (CAP-71) auth credentials from
+   * simulation instead of the legacy `SOROBAN_CREDENTIALS_ADDRESS`. V2
+   * credentials are only valid on networks that have activated CAP-71, so leave
+   * this off until the activation vote passes for your target network. The
+   * default flips to `true` once V2 becomes mandatory.
+   * @defaultValue false
+   */
+  authV2?: boolean;
+
+  /**
    * The public key of the source account for this transaction.
    *
    * Default: the one provided to the {@link Client} in {@link ClientOptions}

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -988,6 +988,11 @@ export class RpcServer {
    *    auth mode to use for simulation: `enforce` for enforcement mode,
    *    `record` for recording mode, or `record_allow_nonroot` for recording
    *    mode that allows non-root authorization
+   * @param authV2 - (optional) request `SOROBAN_CREDENTIALS_ADDRESS_V2`
+   *    (CAP-71) auth credentials from simulation instead of the legacy
+   *    `SOROBAN_CREDENTIALS_ADDRESS`. Defaults to `false`; only enable it for
+   *    networks that have activated CAP-71, as V2 credentials are otherwise
+   *    rejected.
    *
    * @returns An object with the
    *    cost, footprint, result/auth requirements (if applicable), and error of
@@ -1032,8 +1037,9 @@ export class RpcServer {
     tx: Transaction | FeeBumpTransaction,
     addlResources?: RpcServer.ResourceLeeway,
     authMode?: Api.SimulationAuthMode,
+    authV2: boolean = false,
   ): Promise<Api.SimulateTransactionResponse> {
-    return this._simulateTransaction(tx, addlResources, authMode).then(
+    return this._simulateTransaction(tx, addlResources, authMode, authV2).then(
       parseRawSimulation,
     );
   }
@@ -1042,6 +1048,7 @@ export class RpcServer {
     transaction: Transaction | FeeBumpTransaction,
     addlResources?: RpcServer.ResourceLeeway,
     authMode?: Api.SimulationAuthMode,
+    authV2: boolean = false,
   ): Promise<Api.RawSimulateTransactionResponse> {
     return jsonrpc.postObject(
       this.httpClient,
@@ -1055,6 +1062,10 @@ export class RpcServer {
             instructionLeeway: addlResources.cpuInstructions,
           },
         }),
+        // CAP-71: only request ADDRESS_V2 auth credentials when explicitly
+        // opted in. They are rejected by networks that have not activated
+        // CAP-71, so default to omitting the flag (legacy ADDRESS credentials).
+        ...(authV2 && { authV2: true }),
       },
     );
   }

--- a/test/unit/base/auth.test.ts
+++ b/test/unit/base/auth.test.ts
@@ -548,8 +548,12 @@ describe("building authorization entries", () => {
         authEntry.rootInvocation().toXDR(),
       );
 
-      // authorizeInvocation builds SOROBAN_CREDENTIALS_ADDRESS_V2 entries
-      const signedAddr = signedEntry.credentials().addressV2();
+      // authorizeInvocation defaults to legacy SOROBAN_CREDENTIALS_ADDRESS
+      // entries (CAP-71 V2 is opt-in via `authV2`).
+      expect(signedEntry.credentials().switch().name).toBe(
+        "sorobanCredentialsAddress",
+      );
+      const signedAddr = signedEntry.credentials().address();
       expect(signedAddr.signatureExpirationLedger()).toBe(10);
 
       const addrStr = Address.fromScAddress(signedAddr.address()).toString();
@@ -571,6 +575,28 @@ describe("building authorization entries", () => {
         publicKey: kp.publicKey(),
       });
 
+      expect(signedEntry.credentials().switch().name).toBe(
+        "sorobanCredentialsAddress",
+      );
+      const signedAddr = signedEntry.credentials().address();
+      expect(signedAddr.signatureExpirationLedger()).toBe(10);
+
+      const addrStr = Address.fromScAddress(signedAddr.address()).toString();
+      expect(addrStr).toBe(kp.publicKey());
+    });
+
+    it("builds SOROBAN_CREDENTIALS_ADDRESS_V2 entries when authV2 is set", async () => {
+      const signedEntry = await authorizeInvocation({
+        signer: kp,
+        validUntilLedgerSeq: 10,
+        invocation: authEntry.rootInvocation(),
+        networkPassphrase: Networks.TESTNET,
+        authV2: true,
+      });
+
+      expect(signedEntry.credentials().switch().name).toBe(
+        "sorobanCredentialsAddressV2",
+      );
       const signedAddr = signedEntry.credentials().addressV2();
       expect(signedAddr.signatureExpirationLedger()).toBe(10);
 
@@ -620,7 +646,7 @@ describe("building authorization entries", () => {
         invocation: authEntry.rootInvocation(),
         networkPassphrase: Networks.TESTNET,
       });
-      expect(entry.credentials().addressV2().nonce().toBigInt()).toBe(
+      expect(entry.credentials().address().nonce().toBigInt()).toBe(
         4294967296n,
       ); // 2^32
     });
@@ -633,7 +659,7 @@ describe("building authorization entries", () => {
         invocation: authEntry.rootInvocation(),
         networkPassphrase: Networks.TESTNET,
       });
-      expect(entry.credentials().addressV2().nonce().toBigInt()).toBe(-1n);
+      expect(entry.credentials().address().nonce().toBigInt()).toBe(-1n);
     });
 
     it("high bit set produces Int64 minimum value", async () => {
@@ -644,7 +670,7 @@ describe("building authorization entries", () => {
         invocation: authEntry.rootInvocation(),
         networkPassphrase: Networks.TESTNET,
       });
-      expect(entry.credentials().addressV2().nonce().toBigInt()).toBe(
+      expect(entry.credentials().address().nonce().toBigInt()).toBe(
         -9223372036854775808n,
       ); // -(2^63), Int64 minimum
     });
@@ -657,7 +683,7 @@ describe("building authorization entries", () => {
         invocation: authEntry.rootInvocation(),
         networkPassphrase: Networks.TESTNET,
       });
-      expect(entry.credentials().addressV2().nonce().toBigInt()).toBe(0n);
+      expect(entry.credentials().address().nonce().toBigInt()).toBe(0n);
     });
 
     it("throws if fewer than 8 bytes are available", () => {

--- a/test/unit/server/soroban/simulate_transaction.test.ts
+++ b/test/unit/server/soroban/simulate_transaction.test.ts
@@ -138,8 +138,8 @@ function buildAuthEntry(address: any) {
     invocation: root,
     networkPassphrase,
   }).then((entry: any) => {
-    // authorizeInvocation builds SOROBAN_CREDENTIALS_ADDRESS_V2 entries
-    entry.credentials().addressV2().nonce(new xdr.Int64(0xdeadbeef));
+    // authorizeInvocation defaults to legacy SOROBAN_CREDENTIALS_ADDRESS entries
+    entry.credentials().address().nonce(new xdr.Int64(0xdeadbeef));
     return authorizeEntry(entry, kp, 1, networkPassphrase); // overwrites signature w/ above nonce
   });
 }
@@ -435,6 +435,36 @@ describe("Server#simulateTransaction", () => {
         transaction: blob,
         resourceConfig: { instructionLeeway: 100 },
         authMode: undefined,
+      },
+    });
+  });
+
+  it("omits authV2 by default and requests it when opted in", async () => {
+    const mockResponse = { data: { id: 1, result: simulationResponse } };
+    mockPost.mockResolvedValue(mockResponse);
+
+    // default: no authV2 field on the wire (legacy ADDRESS credentials)
+    await server.simulateTransaction(transaction);
+    expect(mockPost).toHaveBeenLastCalledWith(serverUrl, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "simulateTransaction",
+      params: {
+        transaction: blob,
+        authMode: undefined,
+      },
+    });
+
+    // opt-in: authV2: true requests CAP-71 ADDRESS_V2 credentials
+    await server.simulateTransaction(transaction, undefined, undefined, true);
+    expect(mockPost).toHaveBeenLastCalledWith(serverUrl, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "simulateTransaction",
+      params: {
+        transaction: blob,
+        authMode: undefined,
+        authV2: true,
       },
     });
   });


### PR DESCRIPTION
## What

  Soroban auth now defaults to the legacy `SOROBAN_CREDENTIALS_ADDRESS` (V1) credential, with CAP-71 `SOROBAN_CREDENTIALS_ADDRESS_V2` available behind an opt-in instead of forced on. Three opt-in points, all defaulting to `false`:

  - **`rpc.Server.simulateTransaction`** gains a 4th optional arg, `authV2`. The `authV2` request flag is now omitted from the JSON-RPC
  body unless set, so simulation returns legacy `ADDRESS` entries by default and `ADDRESS_V2` only when opted in. (Previously `authV2:
  true` was hardcoded.)
  - **`authorizeInvocation`** gains an `authV2` field on its params object, selecting between building `ADDRESS` and `ADDRESS_V2`
  credentials. (Previously it always built `ADDRESS_V2`.)
  - **`MethodOptions.authV2`** is threaded through `AssembledTransaction.simulate()`, so high-level `contract.Client` users can opt in
  too — not just direct RPC callers.

  The V2 *signing/handling* path is unchanged: `authorizeEntry` and `buildAuthorizationEntryPreimage` already select the correct (legacy vs. address-bound) preimage off whichever credential the entry carries, so the SDK still consumes V2 transparently. Only *emission* is gated.

  Includes test updates (default-path assertions flipped to V1, new `authV2: true` coverage, and a simulate request-body test), a CHANGELOG entry, and migration-guide + regenerated reference-doc updates.

  ## Why

 p27 adds the ability to submit `ADDRESS_V2`; p28 makes it mandatory. But V2 credentials are not valid on-network until p27 activates, so anything the SDK emits as V2 before activation fails submission. The branch currently forces V2 everywhere with no escape hatch, which means users on any not-yet-activated network — and testnet/futurenet/mainnet activate at different times — would hit failed submissions without a way to fall back.

  Defaulting to V1 keeps the SDK valid on every network regardless of activation state and matches upstream's posture (RPC simulation and the sibling SDKs default to V1 with V2 opt-in); a client shouldn't emit a stricter default than its own upstream. The opt-in still lets early adopters exercise V2 against networks that already support it.

  The default will flip to V2 at p28 when it becomes mandatory — a mechanical change (flip the two defaults; the opt-in params stay so anyone on a pre-p28 network can pin to V1 during the transition)