### PR TITLE
Lint cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ config/tsconfig.tmp.json
 
 # scratch: per-guide tests, never shipped
 test-guides/
+.vuln-hunt/

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -791,7 +791,7 @@ _before_ transaction signing.
 const DEFAULT_TIMEOUT: number
 ```
 
-**Source:** [src/contract/types.ts:302](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L302)
+**Source:** [src/contract/types.ts:303](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L303)
 
 ## contract.NULL_ACCOUNT
 
@@ -801,7 +801,7 @@ An impossible account on the Stellar network
 const NULL_ACCOUNT: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
 ```
 
-**Source:** [src/contract/types.ts:308](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L308)
+**Source:** [src/contract/types.ts:309](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L309)
 
 ## contract.SentTransaction
 
@@ -1341,7 +1341,7 @@ basicNodeSigner(keypair: Keypair, networkPassphrase: string): { signAuthEntry: S
 type AssembledTransactionOptions<T = string> = MethodOptions & ClientOptions & { address?: string; args?: any[]; method: string; parseResultXdr: (xdr: xdr.ScVal) => T; submit?: boolean; submitUrl?: string }
 ```
 
-**Source:** [src/contract/types.ts:270](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L270)
+**Source:** [src/contract/types.ts:271](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L271)
 
 ### contract.ClientOptions
 

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -791,7 +791,7 @@ _before_ transaction signing.
 const DEFAULT_TIMEOUT: number
 ```
 
-**Source:** [src/contract/types.ts:292](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L292)
+**Source:** [src/contract/types.ts:293](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L293)
 
 ## contract.NULL_ACCOUNT
 
@@ -801,7 +801,7 @@ An impossible account on the Stellar network
 const NULL_ACCOUNT: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
 ```
 
-**Source:** [src/contract/types.ts:298](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L298)
+**Source:** [src/contract/types.ts:299](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L299)
 
 ## contract.SentTransaction
 
@@ -1341,7 +1341,7 @@ basicNodeSigner(keypair: Keypair, networkPassphrase: string): { signAuthEntry: S
 type AssembledTransactionOptions<T = string> = MethodOptions & ClientOptions & { address?: string; args?: any[]; method: string; parseResultXdr: (xdr: xdr.ScVal) => T; submit?: boolean; submitUrl?: string }
 ```
 
-**Source:** [src/contract/types.ts:260](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L260)
+**Source:** [src/contract/types.ts:261](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L261)
 
 ### contract.ClientOptions
 
@@ -1351,7 +1351,7 @@ Options for a smart contract client.
 type ClientOptions = { allowHttp?: boolean; contractId: string; errorTypes?: Record<number, { message: string }>; headers?: Record<string, string>; networkPassphrase: string; publicKey?: string; rpcUrl: string; server?: Server; signAuthEntry?: SignAuthEntry; signTransaction?: SignTransaction }
 ```
 
-**Source:** [src/contract/types.ts:127](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L127)
+**Source:** [src/contract/types.ts:128](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L128)
 
 ### contract.Duration
 
@@ -1361,7 +1361,7 @@ An unsigned 64-bit integer.
 type Duration = bigint
 ```
 
-**Source:** [src/contract/types.ts:53](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L53)
+**Source:** [src/contract/types.ts:54](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L54)
 
 ### contract.ErrorMessage
 
@@ -1395,7 +1395,7 @@ Options for a smart contract method invocation.
 type MethodOptions = { fee?: string; publicKey?: string; restore?: boolean; signAuthEntry?: SignAuthEntry; signTransaction?: SignTransaction; simulate?: boolean; timeoutInSeconds?: number }
 ```
 
-**Source:** [src/contract/types.ts:203](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L203)
+**Source:** [src/contract/types.ts:204](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L204)
 
 ### contract.Option
 
@@ -1403,7 +1403,7 @@ type MethodOptions = { fee?: string; publicKey?: string; restore?: boolean; sign
 type Option<T> = T | undefined
 ```
 
-**Source:** [src/contract/types.ts:41](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L41)
+**Source:** [src/contract/types.ts:42](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L42)
 
 ### contract.Result
 
@@ -1492,7 +1492,7 @@ It returns a signed hash of the same authorization entry and the signer address 
 type SignAuthEntry = (authEntry: string, opts?: { address?: string; networkPassphrase?: string }) => Promise<{ signedAuthEntry: string; signerAddress?: string } & { error?: WalletError }>
 ```
 
-**Source:** [src/contract/types.ts:111](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L111)
+**Source:** [src/contract/types.ts:112](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L112)
 
 ### contract.SignTransaction
 
@@ -1506,7 +1506,7 @@ and the signer address back to the requester.
 type SignTransaction = (xdr: string, opts?: { address?: string; networkPassphrase?: string; submit?: boolean; submitUrl?: string }) => Promise<{ signedTxXdr: string; signerAddress?: string } & { error?: WalletError }>
 ```
 
-**Source:** [src/contract/types.ts:82](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L82)
+**Source:** [src/contract/types.ts:83](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L83)
 
 ### contract.Timepoint
 
@@ -1516,7 +1516,7 @@ An unsigned 64-bit integer.
 type Timepoint = bigint
 ```
 
-**Source:** [src/contract/types.ts:49](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L49)
+**Source:** [src/contract/types.ts:50](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L50)
 
 ### contract.Tx
 
@@ -1526,7 +1526,7 @@ A "regular" transaction, as opposed to a FeeBumpTransaction.
 type Tx = Transaction
 ```
 
-**Source:** [src/contract/types.ts:58](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L58)
+**Source:** [src/contract/types.ts:59](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L59)
 
 ### contract.Typepoint
 
@@ -1536,7 +1536,7 @@ type Tx = Transaction
 type Typepoint = bigint
 ```
 
-**Source:** [src/contract/types.ts:45](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L45)
+**Source:** [src/contract/types.ts:46](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L46)
 
 ### contract.Union
 
@@ -1575,7 +1575,7 @@ interface WalletError {
 }
 ```
 
-**Source:** [src/contract/types.ts:60](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L60)
+**Source:** [src/contract/types.ts:61](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L61)
 
 #### `walletError.code`
 
@@ -1583,7 +1583,7 @@ interface WalletError {
 code: number;
 ```
 
-**Source:** [src/contract/types.ts:62](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L62)
+**Source:** [src/contract/types.ts:63](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L63)
 
 #### `walletError.ext`
 
@@ -1591,7 +1591,7 @@ code: number;
 ext?: string[];
 ```
 
-**Source:** [src/contract/types.ts:63](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L63)
+**Source:** [src/contract/types.ts:64](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L64)
 
 #### `walletError.message`
 
@@ -1599,7 +1599,7 @@ ext?: string[];
 message: string;
 ```
 
-**Source:** [src/contract/types.ts:61](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L61)
+**Source:** [src/contract/types.ts:62](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L62)
 
 ### contract.XDR_BASE64
 
@@ -1607,7 +1607,7 @@ message: string;
 type XDR_BASE64 = string
 ```
 
-**Source:** [src/contract/types.ts:8](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L8)
+**Source:** [src/contract/types.ts:9](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L9)
 
 ### contract.i128
 
@@ -1617,7 +1617,7 @@ A signed 128-bit integer.
 type i128 = bigint
 ```
 
-**Source:** [src/contract/types.ts:32](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L32)
+**Source:** [src/contract/types.ts:33](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L33)
 
 ### contract.i256
 
@@ -1627,7 +1627,7 @@ A signed 256-bit integer.
 type i256 = bigint
 ```
 
-**Source:** [src/contract/types.ts:40](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L40)
+**Source:** [src/contract/types.ts:41](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L41)
 
 ### contract.i32
 
@@ -1637,7 +1637,7 @@ A signed 32-bit integer.
 type i32 = number
 ```
 
-**Source:** [src/contract/types.ts:16](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L16)
+**Source:** [src/contract/types.ts:17](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L17)
 
 ### contract.i64
 
@@ -1647,7 +1647,7 @@ A signed 64-bit integer.
 type i64 = bigint
 ```
 
-**Source:** [src/contract/types.ts:24](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L24)
+**Source:** [src/contract/types.ts:25](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L25)
 
 ### contract.u128
 
@@ -1657,7 +1657,7 @@ An unsigned 128-bit integer.
 type u128 = bigint
 ```
 
-**Source:** [src/contract/types.ts:28](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L28)
+**Source:** [src/contract/types.ts:29](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L29)
 
 ### contract.u256
 
@@ -1667,7 +1667,7 @@ An unsigned 256-bit integer.
 type u256 = bigint
 ```
 
-**Source:** [src/contract/types.ts:36](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L36)
+**Source:** [src/contract/types.ts:37](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L37)
 
 ### contract.u32
 
@@ -1677,7 +1677,7 @@ An unsigned 32-bit integer.
 type u32 = number
 ```
 
-**Source:** [src/contract/types.ts:12](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L12)
+**Source:** [src/contract/types.ts:13](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L13)
 
 ### contract.u64
 
@@ -1687,4 +1687,4 @@ An unsigned 64-bit integer.
 type u64 = bigint
 ```
 
-**Source:** [src/contract/types.ts:20](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L20)
+**Source:** [src/contract/types.ts:21](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L21)

--- a/docs/reference/network-horizon.md
+++ b/docs/reference/network-horizon.md
@@ -337,7 +337,7 @@ const SERVER_TIME_MAP: Record<string, ServerTime>
 }
 ```
 
-**Source:** [src/horizon/horizon_axios_client.ts:33](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_axios_client.ts#L33)
+**Source:** [src/horizon/horizon_axios_client.ts:32](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_axios_client.ts#L32)
 
 ## Horizon.Server
 
@@ -1215,7 +1215,7 @@ The UNIX timestamp (in seconds, not milliseconds)
 representing the current time on that server, or `null` if we don't have
 a record of that time.
 
-**Source:** [src/horizon/horizon_axios_client.ts:96](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_axios_client.ts#L96)
+**Source:** [src/horizon/horizon_axios_client.ts:95](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_axios_client.ts#L95)
 
 ## Types
 
@@ -1810,7 +1810,7 @@ interface BalanceChange {
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:556](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L556)
+**Source:** [src/horizon/horizon_api.ts:557](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L557)
 
 #### `balanceChange.amount`
 
@@ -1818,7 +1818,7 @@ interface BalanceChange {
 amount: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:564](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L564)
+**Source:** [src/horizon/horizon_api.ts:565](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L565)
 
 #### `balanceChange.asset_code`
 
@@ -1826,7 +1826,7 @@ amount: string;
 asset_code?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:558](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L558)
+**Source:** [src/horizon/horizon_api.ts:559](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L559)
 
 #### `balanceChange.asset_issuer`
 
@@ -1834,7 +1834,7 @@ asset_code?: string;
 asset_issuer?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:559](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L559)
+**Source:** [src/horizon/horizon_api.ts:560](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L560)
 
 #### `balanceChange.asset_type`
 
@@ -1842,7 +1842,7 @@ asset_issuer?: string;
 asset_type: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:557](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L557)
+**Source:** [src/horizon/horizon_api.ts:558](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L558)
 
 #### `balanceChange.destination_muxed_id`
 
@@ -1850,7 +1850,7 @@ asset_type: string;
 destination_muxed_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:565](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L565)
+**Source:** [src/horizon/horizon_api.ts:566](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L566)
 
 #### `balanceChange.from`
 
@@ -1858,7 +1858,7 @@ destination_muxed_id?: string;
 from: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:562](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L562)
+**Source:** [src/horizon/horizon_api.ts:563](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L563)
 
 #### `balanceChange.to`
 
@@ -1866,7 +1866,7 @@ from: string;
 to: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:563](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L563)
+**Source:** [src/horizon/horizon_api.ts:564](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L564)
 
 #### `balanceChange.type`
 
@@ -1874,7 +1874,7 @@ to: string;
 type: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:561](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L561)
+**Source:** [src/horizon/horizon_api.ts:562](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L562)
 
 ### Horizon.HorizonApi.BalanceLine
 
@@ -2261,7 +2261,7 @@ interface BeginSponsoringFutureReservesOperationResponse extends BaseOperationRe
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:470](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L470)
+**Source:** [src/horizon/horizon_api.ts:471](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L471)
 
 #### `beginSponsoringFutureReservesOperationResponse._links`
 
@@ -2309,7 +2309,7 @@ source_account: string;
 sponsored_id: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:474](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L474)
+**Source:** [src/horizon/horizon_api.ts:475](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L475)
 
 #### `beginSponsoringFutureReservesOperationResponse.transaction_hash`
 
@@ -2360,7 +2360,7 @@ interface BumpFootprintExpirationOperationResponse extends BaseOperationResponse
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:582](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L582)
+**Source:** [src/horizon/horizon_api.ts:583](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L583)
 
 #### `bumpFootprintExpirationOperationResponse._links`
 
@@ -2392,7 +2392,7 @@ id: string;
 ledgers_to_expire: number;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:586](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L586)
+**Source:** [src/horizon/horizon_api.ts:587](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L587)
 
 #### `bumpFootprintExpirationOperationResponse.paging_token`
 
@@ -2459,7 +2459,7 @@ interface BumpSequenceOperationResponse extends BaseOperationResponse<OperationR
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:433](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L433)
+**Source:** [src/horizon/horizon_api.ts:434](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L434)
 
 #### `bumpSequenceOperationResponse._links`
 
@@ -2475,7 +2475,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 bump_to: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:437](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L437)
+**Source:** [src/horizon/horizon_api.ts:438](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L438)
 
 #### `bumpSequenceOperationResponse.created_at`
 
@@ -2712,7 +2712,7 @@ interface ClaimClaimableBalanceOperationResponse extends BaseOperationResponse<O
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:462](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L462)
+**Source:** [src/horizon/horizon_api.ts:463](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L463)
 
 #### `claimClaimableBalanceOperationResponse._links`
 
@@ -2728,7 +2728,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 balance_id: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:466](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L466)
+**Source:** [src/horizon/horizon_api.ts:467](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L467)
 
 #### `claimClaimableBalanceOperationResponse.claimant`
 
@@ -2736,7 +2736,7 @@ balance_id: string;
 claimant: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:467](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L467)
+**Source:** [src/horizon/horizon_api.ts:468](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L468)
 
 #### `claimClaimableBalanceOperationResponse.created_at`
 
@@ -2811,7 +2811,7 @@ interface Claimant {
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:447](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L447)
+**Source:** [src/horizon/horizon_api.ts:448](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L448)
 
 #### `claimant.destination`
 
@@ -2819,7 +2819,7 @@ interface Claimant {
 destination: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:448](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L448)
+**Source:** [src/horizon/horizon_api.ts:449](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L449)
 
 #### `claimant.predicate`
 
@@ -2827,7 +2827,7 @@ destination: string;
 predicate: Predicate;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:449](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L449)
+**Source:** [src/horizon/horizon_api.ts:450](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L450)
 
 ### Horizon.HorizonApi.ClawbackClaimableBalanceOperationResponse
 
@@ -2846,7 +2846,7 @@ interface ClawbackClaimableBalanceOperationResponse extends BaseOperationRespons
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:511](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L511)
+**Source:** [src/horizon/horizon_api.ts:512](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L512)
 
 #### `clawbackClaimableBalanceOperationResponse._links`
 
@@ -2862,7 +2862,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 balance_id: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:515](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L515)
+**Source:** [src/horizon/horizon_api.ts:516](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L516)
 
 #### `clawbackClaimableBalanceOperationResponse.created_at`
 
@@ -2949,7 +2949,7 @@ interface ClawbackOperationResponse extends BaseOperationResponse<OperationRespo
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:500](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L500)
+**Source:** [src/horizon/horizon_api.ts:501](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L501)
 
 #### `clawbackOperationResponse._links`
 
@@ -2965,7 +2965,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 amount: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:508](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L508)
+**Source:** [src/horizon/horizon_api.ts:509](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L509)
 
 #### `clawbackOperationResponse.asset_code`
 
@@ -2973,7 +2973,7 @@ amount: string;
 asset_code: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:505](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L505)
+**Source:** [src/horizon/horizon_api.ts:506](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L506)
 
 #### `clawbackOperationResponse.asset_issuer`
 
@@ -2981,7 +2981,7 @@ asset_code: string;
 asset_issuer: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:506](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L506)
+**Source:** [src/horizon/horizon_api.ts:507](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L507)
 
 #### `clawbackOperationResponse.asset_type`
 
@@ -2989,7 +2989,7 @@ asset_issuer: string;
 asset_type: AssetType;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:504](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L504)
+**Source:** [src/horizon/horizon_api.ts:505](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L505)
 
 #### `clawbackOperationResponse.created_at`
 
@@ -3005,7 +3005,7 @@ created_at: string;
 from: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:507](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L507)
+**Source:** [src/horizon/horizon_api.ts:508](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L508)
 
 #### `clawbackOperationResponse.id`
 
@@ -3200,7 +3200,7 @@ interface CreateClaimableBalanceOperationResponse extends BaseOperationResponse<
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:452](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L452)
+**Source:** [src/horizon/horizon_api.ts:453](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L453)
 
 #### `createClaimableBalanceOperationResponse._links`
 
@@ -3216,7 +3216,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 amount: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:457](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L457)
+**Source:** [src/horizon/horizon_api.ts:458](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L458)
 
 #### `createClaimableBalanceOperationResponse.asset`
 
@@ -3224,7 +3224,7 @@ amount: string;
 asset: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:456](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L456)
+**Source:** [src/horizon/horizon_api.ts:457](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L457)
 
 #### `createClaimableBalanceOperationResponse.claimants`
 
@@ -3232,7 +3232,7 @@ asset: string;
 claimants: Claimant[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:459](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L459)
+**Source:** [src/horizon/horizon_api.ts:460](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L460)
 
 #### `createClaimableBalanceOperationResponse.created_at`
 
@@ -3272,7 +3272,7 @@ source_account: string;
 sponsor: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:458](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L458)
+**Source:** [src/horizon/horizon_api.ts:459](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L459)
 
 #### `createClaimableBalanceOperationResponse.transaction_hash`
 
@@ -3330,7 +3330,7 @@ interface DepositLiquidityOperationResponse extends BaseOperationResponse<Operat
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:533](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L533)
+**Source:** [src/horizon/horizon_api.ts:534](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L534)
 
 #### `depositLiquidityOperationResponse._links`
 
@@ -3362,7 +3362,7 @@ id: string;
 liquidity_pool_id: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:537](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L537)
+**Source:** [src/horizon/horizon_api.ts:538](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L538)
 
 #### `depositLiquidityOperationResponse.max_price`
 
@@ -3370,7 +3370,7 @@ liquidity_pool_id: string;
 max_price: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:541](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L541)
+**Source:** [src/horizon/horizon_api.ts:542](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L542)
 
 #### `depositLiquidityOperationResponse.max_price_r`
 
@@ -3378,7 +3378,7 @@ max_price: string;
 max_price_r: PriceRShorthand;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:542](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L542)
+**Source:** [src/horizon/horizon_api.ts:543](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L543)
 
 #### `depositLiquidityOperationResponse.min_price`
 
@@ -3386,7 +3386,7 @@ max_price_r: PriceRShorthand;
 min_price: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:539](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L539)
+**Source:** [src/horizon/horizon_api.ts:540](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L540)
 
 #### `depositLiquidityOperationResponse.min_price_r`
 
@@ -3394,7 +3394,7 @@ min_price: string;
 min_price_r: PriceRShorthand;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:540](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L540)
+**Source:** [src/horizon/horizon_api.ts:541](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L541)
 
 #### `depositLiquidityOperationResponse.paging_token`
 
@@ -3410,7 +3410,7 @@ paging_token: string;
 reserves_deposited: Reserve[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:543](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L543)
+**Source:** [src/horizon/horizon_api.ts:544](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L544)
 
 #### `depositLiquidityOperationResponse.reserves_max`
 
@@ -3418,7 +3418,7 @@ reserves_deposited: Reserve[];
 reserves_max: Reserve[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:538](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L538)
+**Source:** [src/horizon/horizon_api.ts:539](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L539)
 
 #### `depositLiquidityOperationResponse.shares_received`
 
@@ -3426,7 +3426,7 @@ reserves_max: Reserve[];
 shares_received: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:544](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L544)
+**Source:** [src/horizon/horizon_api.ts:545](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L545)
 
 #### `depositLiquidityOperationResponse.source_account`
 
@@ -3485,7 +3485,7 @@ interface EndSponsoringFutureReservesOperationResponse extends BaseOperationResp
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:477](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L477)
+**Source:** [src/horizon/horizon_api.ts:478](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L478)
 
 #### `endSponsoringFutureReservesOperationResponse._links`
 
@@ -3501,7 +3501,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 begin_sponsor: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:481](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L481)
+**Source:** [src/horizon/horizon_api.ts:482](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L482)
 
 #### `endSponsoringFutureReservesOperationResponse.created_at`
 
@@ -3573,7 +3573,7 @@ type_i: endSponsoringFutureReserves;
 type ErrorResponseData = ErrorResponseData.RateLimitExceeded | ErrorResponseData.InternalServerError | ErrorResponseData.TransactionFailed
 ```
 
-**Source:** [src/horizon/horizon_api.ts:630](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L630)
+**Source:** [src/horizon/horizon_api.ts:633](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L633)
 
 ### Horizon.HorizonApi.ErrorResponseData.Base
 
@@ -3587,7 +3587,7 @@ interface Base {
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:636](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L636)
+**Source:** [src/horizon/horizon_api.ts:639](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L639)
 
 #### `base.details`
 
@@ -3595,7 +3595,7 @@ interface Base {
 details: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:640](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L640)
+**Source:** [src/horizon/horizon_api.ts:643](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L643)
 
 #### `base.instance`
 
@@ -3603,7 +3603,7 @@ details: string;
 instance: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:641](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L641)
+**Source:** [src/horizon/horizon_api.ts:644](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L644)
 
 #### `base.status`
 
@@ -3611,7 +3611,7 @@ instance: string;
 status: number;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:637](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L637)
+**Source:** [src/horizon/horizon_api.ts:640](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L640)
 
 #### `base.title`
 
@@ -3619,7 +3619,7 @@ status: number;
 title: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:638](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L638)
+**Source:** [src/horizon/horizon_api.ts:641](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L641)
 
 #### `base.type`
 
@@ -3627,7 +3627,7 @@ title: string;
 type: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:639](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L639)
+**Source:** [src/horizon/horizon_api.ts:642](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L642)
 
 ### Horizon.HorizonApi.ErrorResponseData.InternalServerError
 
@@ -3641,7 +3641,7 @@ interface InternalServerError extends Base {
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:648](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L648)
+**Source:** [src/horizon/horizon_api.ts:651](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L651)
 
 #### `internalServerError.details`
 
@@ -3649,7 +3649,7 @@ interface InternalServerError extends Base {
 details: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:640](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L640)
+**Source:** [src/horizon/horizon_api.ts:643](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L643)
 
 #### `internalServerError.instance`
 
@@ -3657,7 +3657,7 @@ details: string;
 instance: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:641](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L641)
+**Source:** [src/horizon/horizon_api.ts:644](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L644)
 
 #### `internalServerError.status`
 
@@ -3665,7 +3665,7 @@ instance: string;
 status: 500;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:649](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L649)
+**Source:** [src/horizon/horizon_api.ts:652](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L652)
 
 #### `internalServerError.title`
 
@@ -3673,7 +3673,7 @@ status: 500;
 title: "Internal Server Error";
 ```
 
-**Source:** [src/horizon/horizon_api.ts:650](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L650)
+**Source:** [src/horizon/horizon_api.ts:653](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L653)
 
 #### `internalServerError.type`
 
@@ -3681,7 +3681,7 @@ title: "Internal Server Error";
 type: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:639](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L639)
+**Source:** [src/horizon/horizon_api.ts:642](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L642)
 
 ### Horizon.HorizonApi.ErrorResponseData.RateLimitExceeded
 
@@ -3695,7 +3695,7 @@ interface RateLimitExceeded extends Base {
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:644](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L644)
+**Source:** [src/horizon/horizon_api.ts:647](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L647)
 
 #### `rateLimitExceeded.details`
 
@@ -3703,7 +3703,7 @@ interface RateLimitExceeded extends Base {
 details: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:640](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L640)
+**Source:** [src/horizon/horizon_api.ts:643](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L643)
 
 #### `rateLimitExceeded.instance`
 
@@ -3711,7 +3711,7 @@ details: string;
 instance: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:641](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L641)
+**Source:** [src/horizon/horizon_api.ts:644](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L644)
 
 #### `rateLimitExceeded.status`
 
@@ -3719,7 +3719,7 @@ instance: string;
 status: 429;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:645](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L645)
+**Source:** [src/horizon/horizon_api.ts:648](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L648)
 
 #### `rateLimitExceeded.title`
 
@@ -3727,7 +3727,7 @@ status: 429;
 title: "Rate Limit Exceeded";
 ```
 
-**Source:** [src/horizon/horizon_api.ts:646](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L646)
+**Source:** [src/horizon/horizon_api.ts:649](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L649)
 
 #### `rateLimitExceeded.type`
 
@@ -3735,7 +3735,7 @@ title: "Rate Limit Exceeded";
 type: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:639](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L639)
+**Source:** [src/horizon/horizon_api.ts:642](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L642)
 
 ### Horizon.HorizonApi.ErrorResponseData.TransactionFailed
 
@@ -3750,7 +3750,7 @@ interface TransactionFailed extends Base {
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:652](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L652)
+**Source:** [src/horizon/horizon_api.ts:655](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L655)
 
 #### `transactionFailed.details`
 
@@ -3758,7 +3758,7 @@ interface TransactionFailed extends Base {
 details: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:640](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L640)
+**Source:** [src/horizon/horizon_api.ts:643](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L643)
 
 #### `transactionFailed.extras`
 
@@ -3766,7 +3766,7 @@ details: string;
 extras: TransactionFailedExtras;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:655](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L655)
+**Source:** [src/horizon/horizon_api.ts:658](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L658)
 
 #### `transactionFailed.instance`
 
@@ -3774,7 +3774,7 @@ extras: TransactionFailedExtras;
 instance: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:641](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L641)
+**Source:** [src/horizon/horizon_api.ts:644](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L644)
 
 #### `transactionFailed.status`
 
@@ -3782,7 +3782,7 @@ instance: string;
 status: 400;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:653](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L653)
+**Source:** [src/horizon/horizon_api.ts:656](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L656)
 
 #### `transactionFailed.title`
 
@@ -3790,7 +3790,7 @@ status: 400;
 title: "Transaction Failed";
 ```
 
-**Source:** [src/horizon/horizon_api.ts:654](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L654)
+**Source:** [src/horizon/horizon_api.ts:657](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L657)
 
 #### `transactionFailed.type`
 
@@ -3798,7 +3798,7 @@ title: "Transaction Failed";
 type: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:639](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L639)
+**Source:** [src/horizon/horizon_api.ts:642](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L642)
 
 ### Horizon.HorizonApi.FeeBumpTransactionResponse
 
@@ -3848,7 +3848,7 @@ interface FeeDistribution {
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:606](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L606)
+**Source:** [src/horizon/horizon_api.ts:609](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L609)
 
 #### `feeDistribution.max`
 
@@ -3856,7 +3856,7 @@ interface FeeDistribution {
 max: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:607](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L607)
+**Source:** [src/horizon/horizon_api.ts:610](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L610)
 
 #### `feeDistribution.min`
 
@@ -3864,7 +3864,7 @@ max: string;
 min: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:608](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L608)
+**Source:** [src/horizon/horizon_api.ts:611](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L611)
 
 #### `feeDistribution.mode`
 
@@ -3872,7 +3872,7 @@ min: string;
 mode: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:609](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L609)
+**Source:** [src/horizon/horizon_api.ts:612](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L612)
 
 #### `feeDistribution.p10`
 
@@ -3880,7 +3880,7 @@ mode: string;
 p10: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:610](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L610)
+**Source:** [src/horizon/horizon_api.ts:613](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L613)
 
 #### `feeDistribution.p20`
 
@@ -3888,7 +3888,7 @@ p10: string;
 p20: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:611](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L611)
+**Source:** [src/horizon/horizon_api.ts:614](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L614)
 
 #### `feeDistribution.p30`
 
@@ -3896,7 +3896,7 @@ p20: string;
 p30: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:612](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L612)
+**Source:** [src/horizon/horizon_api.ts:615](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L615)
 
 #### `feeDistribution.p40`
 
@@ -3904,7 +3904,7 @@ p30: string;
 p40: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:613](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L613)
+**Source:** [src/horizon/horizon_api.ts:616](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L616)
 
 #### `feeDistribution.p50`
 
@@ -3912,7 +3912,7 @@ p40: string;
 p50: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:614](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L614)
+**Source:** [src/horizon/horizon_api.ts:617](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L617)
 
 #### `feeDistribution.p60`
 
@@ -3920,7 +3920,7 @@ p50: string;
 p60: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:615](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L615)
+**Source:** [src/horizon/horizon_api.ts:618](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L618)
 
 #### `feeDistribution.p70`
 
@@ -3928,7 +3928,7 @@ p60: string;
 p70: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:616](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L616)
+**Source:** [src/horizon/horizon_api.ts:619](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L619)
 
 #### `feeDistribution.p80`
 
@@ -3936,7 +3936,7 @@ p70: string;
 p80: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:617](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L617)
+**Source:** [src/horizon/horizon_api.ts:620](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L620)
 
 #### `feeDistribution.p90`
 
@@ -3944,7 +3944,7 @@ p80: string;
 p90: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:618](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L618)
+**Source:** [src/horizon/horizon_api.ts:621](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L621)
 
 #### `feeDistribution.p95`
 
@@ -3952,7 +3952,7 @@ p90: string;
 p95: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:619](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L619)
+**Source:** [src/horizon/horizon_api.ts:622](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L622)
 
 #### `feeDistribution.p99`
 
@@ -3960,7 +3960,7 @@ p95: string;
 p99: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:620](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L620)
+**Source:** [src/horizon/horizon_api.ts:623](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L623)
 
 ### Horizon.HorizonApi.FeeStatsResponse
 
@@ -3974,7 +3974,7 @@ interface FeeStatsResponse {
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:622](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L622)
+**Source:** [src/horizon/horizon_api.ts:625](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L625)
 
 #### `feeStatsResponse.fee_charged`
 
@@ -3982,7 +3982,7 @@ interface FeeStatsResponse {
 fee_charged: FeeDistribution;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:626](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L626)
+**Source:** [src/horizon/horizon_api.ts:629](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L629)
 
 #### `feeStatsResponse.last_ledger`
 
@@ -3990,7 +3990,7 @@ fee_charged: FeeDistribution;
 last_ledger: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:623](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L623)
+**Source:** [src/horizon/horizon_api.ts:626](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L626)
 
 #### `feeStatsResponse.last_ledger_base_fee`
 
@@ -3998,7 +3998,7 @@ last_ledger: string;
 last_ledger_base_fee: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:624](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L624)
+**Source:** [src/horizon/horizon_api.ts:627](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L627)
 
 #### `feeStatsResponse.ledger_capacity_usage`
 
@@ -4006,7 +4006,7 @@ last_ledger_base_fee: string;
 ledger_capacity_usage: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:625](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L625)
+**Source:** [src/horizon/horizon_api.ts:628](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L628)
 
 #### `feeStatsResponse.max_fee`
 
@@ -4014,7 +4014,7 @@ ledger_capacity_usage: string;
 max_fee: FeeDistribution;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:627](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L627)
+**Source:** [src/horizon/horizon_api.ts:630](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L630)
 
 ### Horizon.HorizonApi.Flags
 
@@ -4077,7 +4077,7 @@ interface InflationOperationResponse extends BaseOperationResponse<OperationResp
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:422](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L422)
+**Source:** [src/horizon/horizon_api.ts:423](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L423)
 
 #### `inflationOperationResponse._links`
 
@@ -4208,7 +4208,7 @@ interface InvokeHostFunctionOperationResponse extends BaseOperationResponse<Oper
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:568](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L568)
+**Source:** [src/horizon/horizon_api.ts:569](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L569)
 
 #### `invokeHostFunctionOperationResponse._links`
 
@@ -4224,7 +4224,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 address: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:577](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L577)
+**Source:** [src/horizon/horizon_api.ts:578](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L578)
 
 #### `invokeHostFunctionOperationResponse.asset_balance_changes`
 
@@ -4232,7 +4232,7 @@ address: string;
 asset_balance_changes: BalanceChange[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:579](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L579)
+**Source:** [src/horizon/horizon_api.ts:580](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L580)
 
 #### `invokeHostFunctionOperationResponse.created_at`
 
@@ -4248,7 +4248,7 @@ created_at: string;
 function: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:572](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L572)
+**Source:** [src/horizon/horizon_api.ts:573](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L573)
 
 #### `invokeHostFunctionOperationResponse.id`
 
@@ -4272,7 +4272,7 @@ paging_token: string;
 parameters: { type: string; value: string }[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:573](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L573)
+**Source:** [src/horizon/horizon_api.ts:574](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L574)
 
 #### `invokeHostFunctionOperationResponse.salt`
 
@@ -4280,7 +4280,7 @@ parameters: { type: string; value: string }[];
 salt: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:578](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L578)
+**Source:** [src/horizon/horizon_api.ts:579](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L579)
 
 #### `invokeHostFunctionOperationResponse.source_account`
 
@@ -4348,7 +4348,7 @@ interface ManageDataOperationResponse extends BaseOperationResponse<OperationRes
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:426](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L426)
+**Source:** [src/horizon/horizon_api.ts:427](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L427)
 
 #### `manageDataOperationResponse._links`
 
@@ -4380,7 +4380,7 @@ id: string;
 name: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:430](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L430)
+**Source:** [src/horizon/horizon_api.ts:431](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L431)
 
 #### `manageDataOperationResponse.paging_token`
 
@@ -4436,7 +4436,7 @@ type_i: manageData;
 value: Buffer;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:431](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L431)
+**Source:** [src/horizon/horizon_api.ts:432](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L432)
 
 ### Horizon.HorizonApi.ManageOfferOperationResponse
 
@@ -5384,7 +5384,7 @@ interface Predicate {
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:439](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L439)
+**Source:** [src/horizon/horizon_api.ts:440](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L440)
 
 #### `predicate.abs_before`
 
@@ -5392,7 +5392,7 @@ interface Predicate {
 abs_before?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:443](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L443)
+**Source:** [src/horizon/horizon_api.ts:444](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L444)
 
 #### `predicate.and`
 
@@ -5400,7 +5400,7 @@ abs_before?: string;
 and?: Predicate[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:440](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L440)
+**Source:** [src/horizon/horizon_api.ts:441](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L441)
 
 #### `predicate.not`
 
@@ -5408,7 +5408,7 @@ and?: Predicate[];
 not?: Predicate;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:442](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L442)
+**Source:** [src/horizon/horizon_api.ts:443](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L443)
 
 #### `predicate.or`
 
@@ -5416,7 +5416,7 @@ not?: Predicate;
 or?: Predicate[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:441](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L441)
+**Source:** [src/horizon/horizon_api.ts:442](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L442)
 
 #### `predicate.rel_before`
 
@@ -5424,7 +5424,7 @@ or?: Predicate[];
 rel_before?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:444](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L444)
+**Source:** [src/horizon/horizon_api.ts:445](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L445)
 
 ### Horizon.HorizonApi.PriceR
 
@@ -5489,7 +5489,7 @@ interface Reserve {
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:529](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L529)
+**Source:** [src/horizon/horizon_api.ts:530](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L530)
 
 #### `reserve.amount`
 
@@ -5497,7 +5497,7 @@ interface Reserve {
 amount: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:531](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L531)
+**Source:** [src/horizon/horizon_api.ts:532](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L532)
 
 #### `reserve.asset`
 
@@ -5505,7 +5505,7 @@ amount: string;
 asset: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:530](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L530)
+**Source:** [src/horizon/horizon_api.ts:531](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L531)
 
 ### Horizon.HorizonApi.ResponseCollection
 
@@ -5516,7 +5516,7 @@ interface ResponseCollection<T extends BaseResponse = BaseResponse> {
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:594](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L594)
+**Source:** [src/horizon/horizon_api.ts:596](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L596)
 
 #### `responseCollection._embedded`
 
@@ -5524,7 +5524,7 @@ interface ResponseCollection<T extends BaseResponse = BaseResponse> {
 _embedded: { records: T[] };
 ```
 
-**Source:** [src/horizon/horizon_api.ts:600](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L600)
+**Source:** [src/horizon/horizon_api.ts:602](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L602)
 
 #### `responseCollection._links`
 
@@ -5532,7 +5532,7 @@ _embedded: { records: T[] };
 _links: { next: ResponseLink; prev: ResponseLink; self: ResponseLink };
 ```
 
-**Source:** [src/horizon/horizon_api.ts:595](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L595)
+**Source:** [src/horizon/horizon_api.ts:597](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L597)
 
 ### Horizon.HorizonApi.ResponseLink
 
@@ -5577,7 +5577,7 @@ interface RestoreFootprintOperationResponse extends BaseOperationResponse<Operat
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:589](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L589)
+**Source:** [src/horizon/horizon_api.ts:591](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L591)
 
 #### `restoreFootprintOperationResponse._links`
 
@@ -5677,7 +5677,7 @@ interface RevokeSponsorshipOperationResponse extends BaseOperationResponse<Opera
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:484](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L484)
+**Source:** [src/horizon/horizon_api.ts:485](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L485)
 
 #### `revokeSponsorshipOperationResponse._links`
 
@@ -5693,7 +5693,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 account_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:488](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L488)
+**Source:** [src/horizon/horizon_api.ts:489](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L489)
 
 #### `revokeSponsorshipOperationResponse.claimable_balance_id`
 
@@ -5701,7 +5701,7 @@ account_id?: string;
 claimable_balance_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:489](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L489)
+**Source:** [src/horizon/horizon_api.ts:490](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L490)
 
 #### `revokeSponsorshipOperationResponse.created_at`
 
@@ -5717,7 +5717,7 @@ created_at: string;
 data_account_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:490](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L490)
+**Source:** [src/horizon/horizon_api.ts:491](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L491)
 
 #### `revokeSponsorshipOperationResponse.data_name`
 
@@ -5725,7 +5725,7 @@ data_account_id?: string;
 data_name?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:491](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L491)
+**Source:** [src/horizon/horizon_api.ts:492](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L492)
 
 #### `revokeSponsorshipOperationResponse.id`
 
@@ -5741,7 +5741,7 @@ id: string;
 offer_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:492](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L492)
+**Source:** [src/horizon/horizon_api.ts:493](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L493)
 
 #### `revokeSponsorshipOperationResponse.paging_token`
 
@@ -5757,7 +5757,7 @@ paging_token: string;
 signer_account_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:496](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L496)
+**Source:** [src/horizon/horizon_api.ts:497](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L497)
 
 #### `revokeSponsorshipOperationResponse.signer_key`
 
@@ -5765,7 +5765,7 @@ signer_account_id?: string;
 signer_key?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:497](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L497)
+**Source:** [src/horizon/horizon_api.ts:498](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L498)
 
 #### `revokeSponsorshipOperationResponse.source_account`
 
@@ -5797,7 +5797,7 @@ transaction_successful: boolean;
 trustline_account_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:493](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L493)
+**Source:** [src/horizon/horizon_api.ts:494](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L494)
 
 #### `revokeSponsorshipOperationResponse.trustline_asset`
 
@@ -5805,7 +5805,7 @@ trustline_account_id?: string;
 trustline_asset?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:494](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L494)
+**Source:** [src/horizon/horizon_api.ts:495](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L495)
 
 #### `revokeSponsorshipOperationResponse.trustline_liquidity_pool_id`
 
@@ -5813,7 +5813,7 @@ trustline_asset?: string;
 trustline_liquidity_pool_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:495](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L495)
+**Source:** [src/horizon/horizon_api.ts:496](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L496)
 
 #### `revokeSponsorshipOperationResponse.type`
 
@@ -5849,7 +5849,7 @@ interface RootResponse {
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:686](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L686)
+**Source:** [src/horizon/horizon_api.ts:689](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L689)
 
 #### `rootResponse.core_latest_ledger`
 
@@ -5857,7 +5857,7 @@ interface RootResponse {
 core_latest_ledger: number;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:693](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L693)
+**Source:** [src/horizon/horizon_api.ts:696](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L696)
 
 #### `rootResponse.core_supported_protocol_version`
 
@@ -5865,7 +5865,7 @@ core_latest_ledger: number;
 core_supported_protocol_version: number;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:697](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L697)
+**Source:** [src/horizon/horizon_api.ts:700](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L700)
 
 #### `rootResponse.core_version`
 
@@ -5873,7 +5873,7 @@ core_supported_protocol_version: number;
 core_version: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:688](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L688)
+**Source:** [src/horizon/horizon_api.ts:691](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L691)
 
 #### `rootResponse.current_protocol_version`
 
@@ -5881,7 +5881,7 @@ core_version: string;
 current_protocol_version: number;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:695](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L695)
+**Source:** [src/horizon/horizon_api.ts:698](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L698)
 
 #### `rootResponse.history_elder_ledger`
 
@@ -5889,7 +5889,7 @@ current_protocol_version: number;
 history_elder_ledger: number;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:692](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L692)
+**Source:** [src/horizon/horizon_api.ts:695](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L695)
 
 #### `rootResponse.history_latest_ledger`
 
@@ -5897,7 +5897,7 @@ history_elder_ledger: number;
 history_latest_ledger: number;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:690](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L690)
+**Source:** [src/horizon/horizon_api.ts:693](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L693)
 
 #### `rootResponse.history_latest_ledger_closed_at`
 
@@ -5905,7 +5905,7 @@ history_latest_ledger: number;
 history_latest_ledger_closed_at: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:691](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L691)
+**Source:** [src/horizon/horizon_api.ts:694](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L694)
 
 #### `rootResponse.horizon_version`
 
@@ -5913,7 +5913,7 @@ history_latest_ledger_closed_at: string;
 horizon_version: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:687](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L687)
+**Source:** [src/horizon/horizon_api.ts:690](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L690)
 
 #### `rootResponse.ingest_latest_ledger`
 
@@ -5921,7 +5921,7 @@ horizon_version: string;
 ingest_latest_ledger: number;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:689](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L689)
+**Source:** [src/horizon/horizon_api.ts:692](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L692)
 
 #### `rootResponse.network_passphrase`
 
@@ -5929,7 +5929,7 @@ ingest_latest_ledger: number;
 network_passphrase: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:694](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L694)
+**Source:** [src/horizon/horizon_api.ts:697](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L697)
 
 #### `rootResponse.supported_protocol_version`
 
@@ -5937,7 +5937,7 @@ network_passphrase: string;
 supported_protocol_version: number;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:696](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L696)
+**Source:** [src/horizon/horizon_api.ts:699](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L699)
 
 ### Horizon.HorizonApi.SetOptionsOperationResponse
 
@@ -6150,7 +6150,7 @@ interface SetTrustLineFlagsOperationResponse extends BaseOperationResponse<Opera
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:518](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L518)
+**Source:** [src/horizon/horizon_api.ts:519](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L519)
 
 #### `setTrustLineFlagsOperationResponse._links`
 
@@ -6166,7 +6166,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 asset_code: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:523](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L523)
+**Source:** [src/horizon/horizon_api.ts:524](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L524)
 
 #### `setTrustLineFlagsOperationResponse.asset_issuer`
 
@@ -6174,7 +6174,7 @@ asset_code: string;
 asset_issuer: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:524](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L524)
+**Source:** [src/horizon/horizon_api.ts:525](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L525)
 
 #### `setTrustLineFlagsOperationResponse.asset_type`
 
@@ -6182,7 +6182,7 @@ asset_issuer: string;
 asset_type: AssetType;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:522](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L522)
+**Source:** [src/horizon/horizon_api.ts:523](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L523)
 
 #### `setTrustLineFlagsOperationResponse.clear_flags`
 
@@ -6190,7 +6190,7 @@ asset_type: AssetType;
 clear_flags: (1 | 2 | 4)[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:527](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L527)
+**Source:** [src/horizon/horizon_api.ts:528](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L528)
 
 #### `setTrustLineFlagsOperationResponse.created_at`
 
@@ -6222,7 +6222,7 @@ paging_token: string;
 set_flags: (1 | 2 | 4)[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:526](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L526)
+**Source:** [src/horizon/horizon_api.ts:527](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L527)
 
 #### `setTrustLineFlagsOperationResponse.source_account`
 
@@ -6254,7 +6254,7 @@ transaction_successful: boolean;
 trustor: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:525](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L525)
+**Source:** [src/horizon/horizon_api.ts:526](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L526)
 
 #### `setTrustLineFlagsOperationResponse.type`
 
@@ -6390,7 +6390,7 @@ interface TransactionFailedExtras {
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:677](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L677)
+**Source:** [src/horizon/horizon_api.ts:680](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L680)
 
 #### `transactionFailedExtras.envelope_xdr`
 
@@ -6398,7 +6398,7 @@ interface TransactionFailedExtras {
 envelope_xdr: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:678](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L678)
+**Source:** [src/horizon/horizon_api.ts:681](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L681)
 
 #### `transactionFailedExtras.result_codes`
 
@@ -6406,7 +6406,7 @@ envelope_xdr: string;
 result_codes: { operations: string[]; transaction: TransactionFailedResultCodes };
 ```
 
-**Source:** [src/horizon/horizon_api.ts:679](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L679)
+**Source:** [src/horizon/horizon_api.ts:682](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L682)
 
 #### `transactionFailedExtras.result_xdr`
 
@@ -6414,7 +6414,7 @@ result_codes: { operations: string[]; transaction: TransactionFailedResultCodes 
 result_xdr: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:683](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L683)
+**Source:** [src/horizon/horizon_api.ts:686](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L686)
 
 ### Horizon.HorizonApi.TransactionFailedResultCodes
 
@@ -6422,7 +6422,7 @@ result_xdr: string;
 enum TransactionFailedResultCodes
 ```
 
-**Source:** [src/horizon/horizon_api.ts:659](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L659)
+**Source:** [src/horizon/horizon_api.ts:662](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L662)
 
 ### Horizon.HorizonApi.TransactionPreconditions
 
@@ -6721,7 +6721,7 @@ interface TransactionResponseCollection extends ResponseCollection<TransactionRe
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:604](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L604)
+**Source:** [src/horizon/horizon_api.ts:607](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L607)
 
 #### `transactionResponseCollection._embedded`
 
@@ -6729,7 +6729,7 @@ interface TransactionResponseCollection extends ResponseCollection<TransactionRe
 _embedded: { records: TransactionResponse[] };
 ```
 
-**Source:** [src/horizon/horizon_api.ts:600](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L600)
+**Source:** [src/horizon/horizon_api.ts:602](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L602)
 
 #### `transactionResponseCollection._links`
 
@@ -6737,7 +6737,7 @@ _embedded: { records: TransactionResponse[] };
 _links: { next: ResponseLink; prev: ResponseLink; self: ResponseLink };
 ```
 
-**Source:** [src/horizon/horizon_api.ts:595](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L595)
+**Source:** [src/horizon/horizon_api.ts:597](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L597)
 
 ### Horizon.HorizonApi.WithdrawLiquidityOperationResponse
 
@@ -6759,7 +6759,7 @@ interface WithdrawLiquidityOperationResponse extends BaseOperationResponse<Opera
 }
 ```
 
-**Source:** [src/horizon/horizon_api.ts:546](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L546)
+**Source:** [src/horizon/horizon_api.ts:547](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L547)
 
 #### `withdrawLiquidityOperationResponse._links`
 
@@ -6791,7 +6791,7 @@ id: string;
 liquidity_pool_id: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:550](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L550)
+**Source:** [src/horizon/horizon_api.ts:551](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L551)
 
 #### `withdrawLiquidityOperationResponse.paging_token`
 
@@ -6807,7 +6807,7 @@ paging_token: string;
 reserves_min: Reserve[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:551](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L551)
+**Source:** [src/horizon/horizon_api.ts:552](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L552)
 
 #### `withdrawLiquidityOperationResponse.reserves_received`
 
@@ -6815,7 +6815,7 @@ reserves_min: Reserve[];
 reserves_received: Reserve[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:553](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L553)
+**Source:** [src/horizon/horizon_api.ts:554](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L554)
 
 #### `withdrawLiquidityOperationResponse.shares`
 
@@ -6823,7 +6823,7 @@ reserves_received: Reserve[];
 shares: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:552](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L552)
+**Source:** [src/horizon/horizon_api.ts:553](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L553)
 
 #### `withdrawLiquidityOperationResponse.source_account`
 
@@ -7817,7 +7817,7 @@ source_account: string;
 sponsored_id: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:474](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L474)
+**Source:** [src/horizon/horizon_api.ts:475](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L475)
 
 #### `beginSponsoringFutureReservesOperationRecord.succeeds`
 
@@ -7929,7 +7929,7 @@ id: string;
 ledgers_to_expire: number;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:586](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L586)
+**Source:** [src/horizon/horizon_api.ts:587](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L587)
 
 #### `bumpFootprintExpirationOperationRecord.paging_token`
 
@@ -8049,7 +8049,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 bump_to: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:437](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L437)
+**Source:** [src/horizon/horizon_api.ts:438](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L438)
 
 #### `bumpSequenceOperationRecord.created_at`
 
@@ -8444,7 +8444,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 balance_id: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:466](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L466)
+**Source:** [src/horizon/horizon_api.ts:467](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L467)
 
 #### `claimClaimableBalanceOperationRecord.claimant`
 
@@ -8452,7 +8452,7 @@ balance_id: string;
 claimant: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:467](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L467)
+**Source:** [src/horizon/horizon_api.ts:468](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L468)
 
 #### `claimClaimableBalanceOperationRecord.created_at`
 
@@ -8677,7 +8677,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 balance_id: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:515](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L515)
+**Source:** [src/horizon/horizon_api.ts:516](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L516)
 
 #### `clawbackClaimableBalanceOperationRecord.created_at`
 
@@ -8825,7 +8825,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 amount: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:508](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L508)
+**Source:** [src/horizon/horizon_api.ts:509](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L509)
 
 #### `clawbackOperationRecord.asset_code`
 
@@ -8833,7 +8833,7 @@ amount: string;
 asset_code: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:505](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L505)
+**Source:** [src/horizon/horizon_api.ts:506](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L506)
 
 #### `clawbackOperationRecord.asset_issuer`
 
@@ -8841,7 +8841,7 @@ asset_code: string;
 asset_issuer: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:506](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L506)
+**Source:** [src/horizon/horizon_api.ts:507](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L507)
 
 #### `clawbackOperationRecord.asset_type`
 
@@ -8849,7 +8849,7 @@ asset_issuer: string;
 asset_type: AssetType;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:504](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L504)
+**Source:** [src/horizon/horizon_api.ts:505](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L505)
 
 #### `clawbackOperationRecord.created_at`
 
@@ -8873,7 +8873,7 @@ effects: CallCollectionFunction<EffectRecord>;
 from: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:507](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L507)
+**Source:** [src/horizon/horizon_api.ts:508](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L508)
 
 #### `clawbackOperationRecord.id`
 
@@ -9202,7 +9202,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 amount: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:457](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L457)
+**Source:** [src/horizon/horizon_api.ts:458](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L458)
 
 #### `createClaimableBalanceOperationRecord.asset`
 
@@ -9210,7 +9210,7 @@ amount: string;
 asset: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:456](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L456)
+**Source:** [src/horizon/horizon_api.ts:457](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L457)
 
 #### `createClaimableBalanceOperationRecord.claimants`
 
@@ -9218,7 +9218,7 @@ asset: string;
 claimants: Claimant[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:459](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L459)
+**Source:** [src/horizon/horizon_api.ts:460](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L460)
 
 #### `createClaimableBalanceOperationRecord.created_at`
 
@@ -9282,7 +9282,7 @@ source_account: string;
 sponsor: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:458](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L458)
+**Source:** [src/horizon/horizon_api.ts:459](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L459)
 
 #### `createClaimableBalanceOperationRecord.succeeds`
 
@@ -9401,7 +9401,7 @@ id: string;
 liquidity_pool_id: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:537](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L537)
+**Source:** [src/horizon/horizon_api.ts:538](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L538)
 
 #### `depositLiquidityOperationRecord.max_price`
 
@@ -9409,7 +9409,7 @@ liquidity_pool_id: string;
 max_price: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:541](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L541)
+**Source:** [src/horizon/horizon_api.ts:542](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L542)
 
 #### `depositLiquidityOperationRecord.max_price_r`
 
@@ -9417,7 +9417,7 @@ max_price: string;
 max_price_r: PriceRShorthand;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:542](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L542)
+**Source:** [src/horizon/horizon_api.ts:543](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L543)
 
 #### `depositLiquidityOperationRecord.min_price`
 
@@ -9425,7 +9425,7 @@ max_price_r: PriceRShorthand;
 min_price: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:539](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L539)
+**Source:** [src/horizon/horizon_api.ts:540](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L540)
 
 #### `depositLiquidityOperationRecord.min_price_r`
 
@@ -9433,7 +9433,7 @@ min_price: string;
 min_price_r: PriceRShorthand;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:540](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L540)
+**Source:** [src/horizon/horizon_api.ts:541](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L541)
 
 #### `depositLiquidityOperationRecord.paging_token`
 
@@ -9457,7 +9457,7 @@ precedes: CallFunction<OperationRecord>;
 reserves_deposited: Reserve[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:543](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L543)
+**Source:** [src/horizon/horizon_api.ts:544](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L544)
 
 #### `depositLiquidityOperationRecord.reserves_max`
 
@@ -9465,7 +9465,7 @@ reserves_deposited: Reserve[];
 reserves_max: Reserve[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:538](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L538)
+**Source:** [src/horizon/horizon_api.ts:539](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L539)
 
 #### `depositLiquidityOperationRecord.self`
 
@@ -9481,7 +9481,7 @@ self: CallFunction<OperationRecord>;
 shares_received: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:544](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L544)
+**Source:** [src/horizon/horizon_api.ts:545](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L545)
 
 #### `depositLiquidityOperationRecord.source_account`
 
@@ -9585,7 +9585,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 begin_sponsor: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:481](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L481)
+**Source:** [src/horizon/horizon_api.ts:482](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L482)
 
 #### `endSponsoringFutureReservesOperationRecord.created_at`
 
@@ -9868,7 +9868,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 address: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:577](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L577)
+**Source:** [src/horizon/horizon_api.ts:578](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L578)
 
 #### `invokeHostFunctionOperationRecord.asset_balance_changes`
 
@@ -9876,7 +9876,7 @@ address: string;
 asset_balance_changes: BalanceChange[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:579](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L579)
+**Source:** [src/horizon/horizon_api.ts:580](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L580)
 
 #### `invokeHostFunctionOperationRecord.created_at`
 
@@ -9900,7 +9900,7 @@ effects: CallCollectionFunction<EffectRecord>;
 function: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:572](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L572)
+**Source:** [src/horizon/horizon_api.ts:573](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L573)
 
 #### `invokeHostFunctionOperationRecord.id`
 
@@ -9924,7 +9924,7 @@ paging_token: string;
 parameters: { type: string; value: string }[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:573](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L573)
+**Source:** [src/horizon/horizon_api.ts:574](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L574)
 
 #### `invokeHostFunctionOperationRecord.precedes`
 
@@ -9940,7 +9940,7 @@ precedes: CallFunction<OperationRecord>;
 salt: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:578](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L578)
+**Source:** [src/horizon/horizon_api.ts:579](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L579)
 
 #### `invokeHostFunctionOperationRecord.self`
 
@@ -10357,7 +10357,7 @@ id: string;
 name: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:430](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L430)
+**Source:** [src/horizon/horizon_api.ts:431](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L431)
 
 #### `manageDataOperationRecord.paging_token`
 
@@ -10445,7 +10445,7 @@ type_i: manageData;
 value: Buffer;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:431](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L431)
+**Source:** [src/horizon/horizon_api.ts:432](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L432)
 
 ### Horizon.ServerApi.ManageOfferOperationRecord
 
@@ -11959,7 +11959,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 account_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:488](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L488)
+**Source:** [src/horizon/horizon_api.ts:489](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L489)
 
 #### `revokeSponsorshipOperationRecord.claimable_balance_id`
 
@@ -11967,7 +11967,7 @@ account_id?: string;
 claimable_balance_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:489](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L489)
+**Source:** [src/horizon/horizon_api.ts:490](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L490)
 
 #### `revokeSponsorshipOperationRecord.created_at`
 
@@ -11983,7 +11983,7 @@ created_at: string;
 data_account_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:490](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L490)
+**Source:** [src/horizon/horizon_api.ts:491](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L491)
 
 #### `revokeSponsorshipOperationRecord.data_name`
 
@@ -11991,7 +11991,7 @@ data_account_id?: string;
 data_name?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:491](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L491)
+**Source:** [src/horizon/horizon_api.ts:492](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L492)
 
 #### `revokeSponsorshipOperationRecord.effects`
 
@@ -12015,7 +12015,7 @@ id: string;
 offer_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:492](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L492)
+**Source:** [src/horizon/horizon_api.ts:493](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L493)
 
 #### `revokeSponsorshipOperationRecord.paging_token`
 
@@ -12047,7 +12047,7 @@ self: CallFunction<OperationRecord>;
 signer_account_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:496](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L496)
+**Source:** [src/horizon/horizon_api.ts:497](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L497)
 
 #### `revokeSponsorshipOperationRecord.signer_key`
 
@@ -12055,7 +12055,7 @@ signer_account_id?: string;
 signer_key?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:497](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L497)
+**Source:** [src/horizon/horizon_api.ts:498](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L498)
 
 #### `revokeSponsorshipOperationRecord.source_account`
 
@@ -12103,7 +12103,7 @@ transaction_successful: boolean;
 trustline_account_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:493](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L493)
+**Source:** [src/horizon/horizon_api.ts:494](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L494)
 
 #### `revokeSponsorshipOperationRecord.trustline_asset`
 
@@ -12111,7 +12111,7 @@ trustline_account_id?: string;
 trustline_asset?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:494](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L494)
+**Source:** [src/horizon/horizon_api.ts:495](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L495)
 
 #### `revokeSponsorshipOperationRecord.trustline_liquidity_pool_id`
 
@@ -12119,7 +12119,7 @@ trustline_asset?: string;
 trustline_liquidity_pool_id?: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:495](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L495)
+**Source:** [src/horizon/horizon_api.ts:496](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L496)
 
 #### `revokeSponsorshipOperationRecord.type`
 
@@ -12414,7 +12414,7 @@ _links: { effects: ResponseLink; precedes: ResponseLink; self: ResponseLink; suc
 asset_code: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:523](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L523)
+**Source:** [src/horizon/horizon_api.ts:524](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L524)
 
 #### `setTrustLineFlagsOperationRecord.asset_issuer`
 
@@ -12422,7 +12422,7 @@ asset_code: string;
 asset_issuer: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:524](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L524)
+**Source:** [src/horizon/horizon_api.ts:525](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L525)
 
 #### `setTrustLineFlagsOperationRecord.asset_type`
 
@@ -12430,7 +12430,7 @@ asset_issuer: string;
 asset_type: AssetType;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:522](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L522)
+**Source:** [src/horizon/horizon_api.ts:523](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L523)
 
 #### `setTrustLineFlagsOperationRecord.clear_flags`
 
@@ -12438,7 +12438,7 @@ asset_type: AssetType;
 clear_flags: (1 | 2 | 4)[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:527](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L527)
+**Source:** [src/horizon/horizon_api.ts:528](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L528)
 
 #### `setTrustLineFlagsOperationRecord.created_at`
 
@@ -12494,7 +12494,7 @@ self: CallFunction<OperationRecord>;
 set_flags: (1 | 2 | 4)[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:526](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L526)
+**Source:** [src/horizon/horizon_api.ts:527](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L527)
 
 #### `setTrustLineFlagsOperationRecord.source_account`
 
@@ -12542,7 +12542,7 @@ transaction_successful: boolean;
 trustor: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:525](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L525)
+**Source:** [src/horizon/horizon_api.ts:526](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L526)
 
 #### `setTrustLineFlagsOperationRecord.type`
 
@@ -13352,7 +13352,7 @@ id: string;
 liquidity_pool_id: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:550](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L550)
+**Source:** [src/horizon/horizon_api.ts:551](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L551)
 
 #### `withdrawLiquidityOperationRecord.paging_token`
 
@@ -13376,7 +13376,7 @@ precedes: CallFunction<OperationRecord>;
 reserves_min: Reserve[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:551](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L551)
+**Source:** [src/horizon/horizon_api.ts:552](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L552)
 
 #### `withdrawLiquidityOperationRecord.reserves_received`
 
@@ -13384,7 +13384,7 @@ reserves_min: Reserve[];
 reserves_received: Reserve[];
 ```
 
-**Source:** [src/horizon/horizon_api.ts:553](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L553)
+**Source:** [src/horizon/horizon_api.ts:554](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L554)
 
 #### `withdrawLiquidityOperationRecord.self`
 
@@ -13400,7 +13400,7 @@ self: CallFunction<OperationRecord>;
 shares: string;
 ```
 
-**Source:** [src/horizon/horizon_api.ts:552](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L552)
+**Source:** [src/horizon/horizon_api.ts:553](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/horizon_api.ts#L553)
 
 #### `withdrawLiquidityOperationRecord.source_account`
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { includeIgnoreFile } from "@eslint/compat";
-import { configs } from "eslint-config-airbnb-extended/legacy";
+import tseslint from "typescript-eslint";
 import prettierConfigRules from "eslint-config-prettier/flat";
 import prettierPlugin from "eslint-plugin-prettier";
 import importPlugin from "eslint-plugin-import";
@@ -9,11 +9,6 @@ import js from "@eslint/js";
 import globals from "globals";
 
 const gitignorePath = path.resolve(".", ".gitignore");
-
-configs.base.typescript[0].languageOptions.parserOptions.projectService = false;
-configs.base.typescript[0].languageOptions.parserOptions.project = [
-  "./tsconfig.json",
-];
 
 const javascriptConfig = [
   js.configs.recommended,
@@ -28,8 +23,18 @@ const javascriptConfig = [
   },
 ];
 const typescriptConfig = [
-  // Airbnb Base TypeScript Config
-  ...configs.base.typescript,
+  // typescript-eslint recommended (registers the parser + plugin)
+  ...tseslint.configs.recommended,
+  {
+    name: "typescript/parser-options",
+    files: ["**/*.ts", "**/*.tsx"],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+        project: ["./tsconfig.json"],
+      },
+    },
+  },
   {
     name: "typescript/custom-rules",
     files: ["**/*.ts", "**/*.tsx"],
@@ -41,6 +46,14 @@ const typescriptConfig = [
       "@typescript-eslint/no-unused-vars": "off",
       "no-unused-vars": "off",
       "no-fallthrough": "off",
+      // `any` is used deliberately at dynamic boundaries — XDR decoding,
+      // JSON-RPC payloads, and Horizon response shaping — across ~125 sites,
+      // too many to annotate individually. Tightening these is tracked as
+      // separate, incremental work.
+      "@typescript-eslint/no-explicit-any": "off",
+      // `namespace` declarations are part of the published public API
+      // (e.g. Horizon, rpc `Api`, stellartoml), not an organizational crutch.
+      "@typescript-eslint/no-namespace": "off",
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-replace": "^6.0.2",
     "@rollup/plugin-terser": "^1.0.0",
-    "@stellar/tsconfig": "^1.0.2",
     "@types/detect-node": "^2.0.2",
     "@types/json-schema": "^7.0.15",
     "@types/node": "^22.19.17",

--- a/package.json
+++ b/package.json
@@ -138,8 +138,6 @@
     "@types/json-schema": "^7.0.15",
     "@types/node": "^22.19.17",
     "@types/sha.js": "^2.4.4",
-    "@typescript-eslint/eslint-plugin": "^8.60.0",
-    "@typescript-eslint/parser": "^8.60.0",
     "@vitest/browser": "^4.1.7",
     "@vitest/browser-playwright": "^4.1.7",
     "@vitest/coverage-istanbul": "4.1.7",
@@ -151,7 +149,6 @@
     "dotenv": "^17.4.2",
     "esbuild": "^0.27.7",
     "eslint": "^9.39.1",
-    "eslint-config-airbnb-extended": "^3.1.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
@@ -172,6 +169,7 @@
     "tsx": "^4.22.3",
     "typedoc": "^0.28.19",
     "typescript": "5.9.3",
+    "typescript-eslint": "^8.60.0",
     "vitest": "^4.1.7"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,12 +87,6 @@ importers:
       '@types/sha.js':
         specifier: ^2.4.4
         version: 2.4.4
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.60.0
-        version: 8.60.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/parser':
-        specifier: ^8.60.0
-        version: 8.60.0(eslint@9.39.4)(typescript@5.9.3)
       '@vitest/browser':
         specifier: ^4.1.7
         version: 4.1.7(msw@2.14.6(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(tsx@4.22.3)(yaml@2.8.3))(vitest@4.1.7)
@@ -126,9 +120,6 @@ importers:
       eslint:
         specifier: ^9.39.1
         version: 9.39.4
-      eslint-config-airbnb-extended:
-        specifier: ^3.1.0
-        version: 3.1.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3))(@typescript-eslint/utils@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4)(typescript@5.9.3)
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.4)
@@ -189,6 +180,9 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.60.0
+        version: 8.60.0(eslint@9.39.4)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@types/node@22.19.17)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-istanbul@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@22.19.17)(typescript@5.9.3))(vite@8.0.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(tsx@4.22.3)(yaml@2.8.3))
@@ -1030,27 +1024,12 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/eslint-plugin-next@16.2.6':
-    resolution: {integrity: sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw==}
-
   '@noble/ed25519@3.1.0':
     resolution: {integrity: sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==}
 
   '@noble/hashes@2.2.0':
     resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
-
-  '@nodelib/fs.scandir@2.1.5':
-    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.stat@2.0.5':
-    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
-    engines: {node: '>= 8'}
-
-  '@nodelib/fs.walk@1.2.8':
-    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
-    engines: {node: '>= 8'}
 
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
@@ -1463,12 +1442,6 @@ packages:
 
   '@stellar/tsconfig@1.0.2':
     resolution: {integrity: sha512-lC51QSlYRM8K3oGe0/WGPq+p9+u+yPzwZXSKrZXKOe4sq79vzfiqFbQyp5enOffFzXlahcDyTgY67mBOkJytfw==}
-
-  '@stylistic/eslint-plugin@5.10.0':
-    resolution: {integrity: sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^9.0.0 || ^10.0.0
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -2007,10 +1980,6 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
-  array.prototype.findlast@1.2.5:
-    resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
-    engines: {node: '>= 0.4'}
-
   array.prototype.findlastindex@1.2.6:
     resolution: {integrity: sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==}
     engines: {node: '>= 0.4'}
@@ -2023,10 +1992,6 @@ packages:
     resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
     engines: {node: '>= 0.4'}
 
-  array.prototype.tosorted@1.1.4:
-    resolution: {integrity: sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==}
-    engines: {node: '>= 0.4'}
-
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
@@ -2034,9 +1999,6 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
-
-  ast-types-flow@0.0.8:
-    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
   ast-v8-to-istanbul@1.0.2:
     resolution: {integrity: sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==}
@@ -2065,10 +2027,6 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
-
-  axe-core@4.11.4:
-    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
-    engines: {node: '>=4'}
 
   axios@1.16.1:
     resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
@@ -2145,10 +2103,6 @@ packages:
 
   call-bind@1.0.8:
     resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
-    engines: {node: '>= 0.4'}
-
-  call-bind@1.0.9:
-    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
@@ -2266,9 +2220,6 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  confusing-browser-globals@1.0.11:
-    resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
-
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -2317,9 +2268,6 @@ packages:
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
-
-  damerau-levenshtein@1.0.8:
-    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -2445,13 +2393,6 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-
-  enhanced-resolve@5.22.1:
-    resolution: {integrity: sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==}
-    engines: {node: '>=10.13.0'}
-
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -2472,20 +2413,12 @@ packages:
     resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
     engines: {node: '>= 0.4'}
 
-  es-abstract@1.24.2:
-    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
-    engines: {node: '>= 0.4'}
-
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
 
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
-  es-iterator-helpers@1.3.2:
-    resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
   es-module-lexer@1.7.0:
@@ -2496,10 +2429,6 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
-
-  es-object-atoms@1.1.2:
-    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   es-set-tostringtag@2.1.0:
@@ -2541,18 +2470,6 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
-
-  eslint-compat-utils@0.5.1:
-    resolution: {integrity: sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      eslint: '>=6.0.0'
-
-  eslint-config-airbnb-extended@3.1.0:
-    resolution: {integrity: sha512-uUE5+8gQ9h+QqHOI0OIBIQW0+/bA4l/GE1i5fPAGk64Y5lBKxyZRNDcQUGSaovOzX7yMa0Q+3MS1lj5bq/BC/Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^9.0.0
 
   eslint-config-prettier@10.1.8:
     resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
@@ -2606,12 +2523,6 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
 
-  eslint-plugin-es-x@7.8.0:
-    resolution: {integrity: sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '>=8'
-
   eslint-plugin-import-x@4.16.2:
     resolution: {integrity: sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2635,18 +2546,6 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
-  eslint-plugin-jsx-a11y@6.10.2:
-    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
-
-  eslint-plugin-n@17.24.0:
-    resolution: {integrity: sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: '>=8.23.0'
-
   eslint-plugin-prettier@5.5.6:
     resolution: {integrity: sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -2660,18 +2559,6 @@ packages:
         optional: true
       eslint-config-prettier:
         optional: true
-
-  eslint-plugin-react-hooks@7.1.1:
-    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
-
-  eslint-plugin-react@7.37.5:
-    resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
   eslint-plugin-tsdoc@0.5.2:
     resolution: {integrity: sha512-BlvqjWZdBJDIPO/YU3zcPCF23CvjYT3gyu63yo6b609NNV3D1b6zceAREy2xnweuBoDpZcLNuPyAUq9cvx6bbQ==}
@@ -2777,10 +2664,6 @@ packages:
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
-  fast-glob@3.3.1:
-    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
-    engines: {node: '>=8.6.0'}
-
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -2798,9 +2681,6 @@ packages:
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
-
-  fastq@1.20.1:
-    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2926,20 +2806,12 @@ packages:
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
-
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
-    engines: {node: '>=18'}
-
-  globals@15.15.0:
-    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
 
   globals@17.6.0:
@@ -2950,15 +2822,9 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-
-  graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   graphql@16.14.0:
     resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
@@ -3061,12 +2927,6 @@ packages:
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
-  hermes-estree@0.25.1:
-    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
-
-  hermes-parser@0.25.1:
-    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
-
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -3167,10 +3027,6 @@ packages:
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
-    engines: {node: '>= 0.4'}
-
-  is-core-module@2.16.2:
-    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
   is-data-view@1.0.2:
@@ -3328,10 +3184,6 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
-  iterator.prototype@1.1.5:
-    resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
-    engines: {node: '>= 0.4'}
-
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
@@ -3383,23 +3235,12 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
-  jsx-ast-utils@3.3.5:
-    resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
-    engines: {node: '>=4.0'}
-
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   klona@2.0.6:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
-
-  language-subtag-registry@0.3.23:
-    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
-
-  language-tags@1.0.9:
-    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
-    engines: {node: '>=0.10'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3512,10 +3353,6 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
-  loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
-    hasBin: true
-
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
@@ -3616,10 +3453,6 @@ packages:
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-
-  merge2@1.4.1:
-    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
-    engines: {node: '>= 8'}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -3800,10 +3633,6 @@ packages:
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
 
-  node-exports-info@1.6.0:
-    resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
-    engines: {node: '>= 0.4'}
-
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
@@ -3825,10 +3654,6 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -3839,10 +3664,6 @@ packages:
 
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
-    engines: {node: '>= 0.4'}
-
-  object.entries@1.1.9:
-    resolution: {integrity: sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==}
     engines: {node: '>= 0.4'}
 
   object.fromentries@2.0.8:
@@ -4026,9 +3847,6 @@ packages:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
 
-  prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
-
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -4044,14 +3862,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  queue-microtask@1.2.3:
-    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
-
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
-
-  react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -4151,11 +3963,6 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  resolve@2.0.0-next.7:
-    resolution: {integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==}
-    engines: {node: '>= 0.4'}
-    hasBin: true
-
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -4174,10 +3981,6 @@ packages:
 
   rettime@0.11.11:
     resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
-
-  reusify@1.1.0:
-    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
-    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
@@ -4204,15 +4007,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  run-parallel@1.2.0:
-    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
-
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
-    engines: {node: '>=0.4'}
-
-  safe-array-concat@1.1.4:
-    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
 
   safe-push-apply@1.0.0:
@@ -4385,17 +4181,6 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
-  string.prototype.includes@2.0.1:
-    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.matchall@4.0.12:
-    resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
-    engines: {node: '>= 0.4'}
-
-  string.prototype.repeat@1.0.0:
-    resolution: {integrity: sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==}
-
   string.prototype.trim@1.2.10:
     resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
     engines: {node: '>= 0.4'}
@@ -4460,10 +4245,6 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
-
-  tapable@2.3.3:
-    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
-    engines: {node: '>=6'}
 
   terser@5.46.2:
     resolution: {integrity: sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==}
@@ -4531,11 +4312,6 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-declaration-location@1.0.7:
-    resolution: {integrity: sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==}
-    peerDependencies:
-      typescript: '>=4.0.0'
-
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
@@ -4569,10 +4345,6 @@ packages:
 
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
-    engines: {node: '>= 0.4'}
-
-  typed-array-length@1.0.8:
-    resolution: {integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==}
     engines: {node: '>= 0.4'}
 
   typedoc@0.28.19:
@@ -4927,10 +4699,6 @@ packages:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
 
-  which-typed-array@1.1.21:
-    resolution: {integrity: sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==}
-    engines: {node: '>= 0.4'}
-
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -5006,12 +4774,6 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
-
-  zod-validation-error@4.0.2:
-    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -5830,25 +5592,9 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@next/eslint-plugin-next@16.2.6':
-    dependencies:
-      fast-glob: 3.3.1
-
   '@noble/ed25519@3.1.0': {}
 
   '@noble/hashes@2.2.0': {}
-
-  '@nodelib/fs.scandir@2.1.5':
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      run-parallel: 1.2.0
-
-  '@nodelib/fs.stat@2.0.5': {}
-
-  '@nodelib/fs.walk@1.2.8':
-    dependencies:
-      '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.20.1
 
   '@open-draft/deferred-promise@2.2.0': {}
 
@@ -5865,7 +5611,8 @@ snapshots:
 
   '@oxc-project/types@0.122.0': {}
 
-  '@package-json/types@0.0.12': {}
+  '@package-json/types@0.0.12':
+    optional: true
 
   '@pagefind/darwin-arm64@1.5.2':
     optional: true
@@ -6139,16 +5886,6 @@ snapshots:
   '@stellar/js-xdr@4.0.0': {}
 
   '@stellar/tsconfig@1.0.2': {}
-
-  '@stylistic/eslint-plugin@5.10.0(eslint@9.39.4)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
-      '@typescript-eslint/types': 8.60.0
-      eslint: 9.39.4
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      estraverse: 5.3.0
-      picomatch: 4.0.4
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -6698,15 +6435,6 @@ snapshots:
 
   array-iterate@2.0.1: {}
 
-  array.prototype.findlast@1.2.5:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      es-shim-unscopables: 1.1.0
-
   array.prototype.findlastindex@1.2.6:
     dependencies:
       call-bind: 1.0.8
@@ -6731,14 +6459,6 @@ snapshots:
       es-abstract: 1.24.1
       es-shim-unscopables: 1.1.0
 
-  array.prototype.tosorted@1.1.4:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-errors: 1.3.0
-      es-shim-unscopables: 1.1.0
-
   arraybuffer.prototype.slice@1.0.4:
     dependencies:
       array-buffer-byte-length: 1.0.2
@@ -6750,8 +6470,6 @@ snapshots:
       is-array-buffer: 3.0.5
 
   assertion-error@2.0.1: {}
-
-  ast-types-flow@0.0.8: {}
 
   ast-v8-to-istanbul@1.0.2:
     dependencies:
@@ -6867,8 +6585,6 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axe-core@4.11.4: {}
-
   axios@1.16.1:
     dependencies:
       follow-redirects: 1.16.0
@@ -6953,13 +6669,6 @@ snapshots:
       get-intrinsic: 1.3.0
       set-function-length: 1.2.2
 
-  call-bind@1.0.9:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      get-intrinsic: 1.3.0
-      set-function-length: 1.2.2
-
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -7037,15 +6746,14 @@ snapshots:
 
   commander@2.20.3: {}
 
-  comment-parser@1.4.7: {}
+  comment-parser@1.4.7:
+    optional: true
 
   common-ancestor-path@2.0.0: {}
 
   commondir@1.0.1: {}
 
   concat-map@0.0.1: {}
-
-  confusing-browser-globals@1.0.11: {}
 
   convert-source-map@2.0.0: {}
 
@@ -7095,8 +6803,6 @@ snapshots:
   csso@5.0.5:
     dependencies:
       css-tree: 2.2.1
-
-  damerau-levenshtein@1.0.8: {}
 
   data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
@@ -7211,13 +6917,6 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
-  emoji-regex@9.2.2: {}
-
-  enhanced-resolve@5.22.1:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.3
-
   entities@4.5.0: {}
 
   entities@6.0.1: {}
@@ -7283,95 +6982,15 @@ snapshots:
       unbox-primitive: 1.1.0
       which-typed-array: 1.1.20
 
-  es-abstract@1.24.2:
-    dependencies:
-      array-buffer-byte-length: 1.0.2
-      arraybuffer.prototype.slice: 1.0.4
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      data-view-buffer: 1.0.2
-      data-view-byte-length: 1.0.2
-      data-view-byte-offset: 1.0.1
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      es-set-tostringtag: 2.1.0
-      es-to-primitive: 1.3.0
-      function.prototype.name: 1.1.8
-      get-intrinsic: 1.3.0
-      get-proto: 1.0.1
-      get-symbol-description: 1.1.0
-      globalthis: 1.0.4
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-      has-proto: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.4
-      internal-slot: 1.1.0
-      is-array-buffer: 3.0.5
-      is-callable: 1.2.7
-      is-data-view: 1.0.2
-      is-negative-zero: 2.0.3
-      is-regex: 1.2.1
-      is-set: 2.0.3
-      is-shared-array-buffer: 1.0.4
-      is-string: 1.1.1
-      is-typed-array: 1.1.15
-      is-weakref: 1.1.1
-      math-intrinsics: 1.1.0
-      object-inspect: 1.13.4
-      object-keys: 1.1.1
-      object.assign: 4.1.7
-      own-keys: 1.0.1
-      regexp.prototype.flags: 1.5.4
-      safe-array-concat: 1.1.4
-      safe-push-apply: 1.0.0
-      safe-regex-test: 1.1.0
-      set-proto: 1.0.0
-      stop-iteration-iterator: 1.1.0
-      string.prototype.trim: 1.2.10
-      string.prototype.trimend: 1.0.9
-      string.prototype.trimstart: 1.0.8
-      typed-array-buffer: 1.0.3
-      typed-array-byte-length: 1.0.3
-      typed-array-byte-offset: 1.0.4
-      typed-array-length: 1.0.8
-      unbox-primitive: 1.1.0
-      which-typed-array: 1.1.21
-
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-iterator-helpers@1.3.2:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-errors: 1.3.0
-      es-set-tostringtag: 2.1.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.3.0
-      globalthis: 1.0.4
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-      has-proto: 1.2.0
-      has-symbols: 1.1.0
-      internal-slot: 1.1.0
-      iterator.prototype: 1.1.5
-      math-intrinsics: 1.1.0
 
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
-
-  es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
 
@@ -7470,34 +7089,6 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-compat-utils@0.5.1(eslint@9.39.4):
-    dependencies:
-      eslint: 9.39.4
-      semver: 7.8.1
-
-  eslint-config-airbnb-extended@3.1.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3))(@typescript-eslint/utils@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4)(typescript@5.9.3):
-    dependencies:
-      '@next/eslint-plugin-next': 16.2.6
-      '@stylistic/eslint-plugin': 5.10.0(eslint@9.39.4)
-      confusing-browser-globals: 1.0.11
-      eslint: 9.39.4
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4))(eslint-plugin-import@2.32.0)(eslint@9.39.4)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4)
-      eslint-plugin-import-x: 4.16.2(@typescript-eslint/utils@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4)
-      eslint-plugin-n: 17.24.0(eslint@9.39.4)(typescript@5.9.3)
-      eslint-plugin-react: 7.37.5(eslint@9.39.4)
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4)
-      globals: 17.6.0
-      typescript-eslint: 8.60.0(eslint@9.39.4)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - '@typescript-eslint/utils'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - supports-color
-      - typescript
-
   eslint-config-prettier@10.1.8(eslint@9.39.4):
     dependencies:
       eslint: 9.39.4
@@ -7515,6 +7106,7 @@ snapshots:
       stable-hash-x: 0.2.0
     optionalDependencies:
       unrs-resolver: 1.12.2
+    optional: true
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
@@ -7551,13 +7143,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-es-x@7.8.0(eslint@9.39.4):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
-      '@eslint-community/regexpp': 4.12.2
-      eslint: 9.39.4
-      eslint-compat-utils: 0.5.1(eslint@9.39.4)
-
   eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4):
     dependencies:
       '@package-json/types': 0.0.12
@@ -7576,6 +7161,7 @@ snapshots:
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.4):
     dependencies:
@@ -7606,40 +7192,6 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4):
-    dependencies:
-      aria-query: 5.3.2
-      array-includes: 3.1.9
-      array.prototype.flatmap: 1.3.3
-      ast-types-flow: 0.0.8
-      axe-core: 4.11.4
-      axobject-query: 4.1.0
-      damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
-      eslint: 9.39.4
-      hasown: 2.0.4
-      jsx-ast-utils: 3.3.5
-      language-tags: 1.0.9
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      safe-regex-test: 1.1.0
-      string.prototype.includes: 2.0.1
-
-  eslint-plugin-n@17.24.0(eslint@9.39.4)(typescript@5.9.3):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
-      enhanced-resolve: 5.22.1
-      eslint: 9.39.4
-      eslint-plugin-es-x: 7.8.0(eslint@9.39.4)
-      get-tsconfig: 4.14.0
-      globals: 15.15.0
-      globrex: 0.1.2
-      ignore: 5.3.2
-      semver: 7.8.1
-      ts-declaration-location: 1.0.7(typescript@5.9.3)
-    transitivePeerDependencies:
-      - typescript
-
   eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@9.39.4))(eslint@9.39.4)(prettier@3.8.3):
     dependencies:
       eslint: 9.39.4
@@ -7648,39 +7200,6 @@ snapshots:
       synckit: 0.11.13
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@9.39.4)
-
-  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4):
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/parser': 7.29.7
-      eslint: 9.39.4
-      hermes-parser: 0.25.1
-      zod: 4.4.3
-      zod-validation-error: 4.0.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-react@7.37.5(eslint@9.39.4):
-    dependencies:
-      array-includes: 3.1.9
-      array.prototype.findlast: 1.2.5
-      array.prototype.flatmap: 1.3.3
-      array.prototype.tosorted: 1.1.4
-      doctrine: 2.1.0
-      es-iterator-helpers: 1.3.2
-      eslint: 9.39.4
-      estraverse: 5.3.0
-      hasown: 2.0.4
-      jsx-ast-utils: 3.3.5
-      minimatch: 3.1.5
-      object.entries: 1.1.9
-      object.fromentries: 2.0.8
-      object.values: 1.2.1
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.7
-      semver: 6.3.1
-      string.prototype.matchall: 4.0.12
-      string.prototype.repeat: 1.0.0
 
   eslint-plugin-tsdoc@0.5.2(eslint@9.39.4)(typescript@5.9.3):
     dependencies:
@@ -7830,14 +7349,6 @@ snapshots:
 
   fast-diff@1.3.0: {}
 
-  fast-glob@3.3.1:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -7853,10 +7364,6 @@ snapshots:
   fast-wrap-ansi@0.2.2:
     dependencies:
       fast-string-width: 3.0.2
-
-  fastq@1.20.1:
-    dependencies:
-      reusify: 1.1.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -7975,17 +7482,11 @@ snapshots:
 
   github-slugger@2.0.0: {}
 
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
-
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
 
   globals@14.0.0: {}
-
-  globals@15.15.0: {}
 
   globals@17.6.0: {}
 
@@ -7994,11 +7495,7 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
-  globrex@0.1.2: {}
-
   gopd@1.2.0: {}
-
-  graceful-fs@4.2.11: {}
 
   graphql@16.14.0: {}
 
@@ -8234,12 +7731,6 @@ snapshots:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.0
 
-  hermes-estree@0.25.1: {}
-
-  hermes-parser@0.25.1:
-    dependencies:
-      hermes-estree: 0.25.1
-
   html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
       '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
@@ -8333,10 +7824,6 @@ snapshots:
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.2
-
-  is-core-module@2.16.2:
-    dependencies:
-      hasown: 2.0.4
 
   is-data-view@1.0.2:
     dependencies:
@@ -8474,15 +7961,6 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
-  iterator.prototype@1.1.5:
-    dependencies:
-      define-data-property: 1.1.4
-      es-object-atoms: 1.1.2
-      get-intrinsic: 1.3.0
-      get-proto: 1.0.1
-      has-symbols: 1.1.0
-      set-function-name: 2.0.2
-
   jju@1.4.0: {}
 
   js-tokens@10.0.0: {}
@@ -8537,24 +8015,11 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
-  jsx-ast-utils@3.3.5:
-    dependencies:
-      array-includes: 3.1.9
-      array.prototype.flat: 1.3.3
-      object.assign: 4.1.7
-      object.values: 1.2.1
-
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
 
   klona@2.0.6: {}
-
-  language-subtag-registry@0.3.23: {}
-
-  language-tags@1.0.9:
-    dependencies:
-      language-subtag-registry: 0.3.23
 
   levn@0.4.1:
     dependencies:
@@ -8657,10 +8122,6 @@ snapshots:
       wrap-ansi: 9.0.2
 
   longest-streak@3.1.0: {}
-
-  loose-envify@1.4.0:
-    dependencies:
-      js-tokens: 4.0.0
 
   lru-cache@11.5.1: {}
 
@@ -8889,8 +8350,6 @@ snapshots:
   mdurl@2.0.0: {}
 
   merge-stream@2.0.0: {}
-
-  merge2@1.4.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -9234,13 +8693,6 @@ snapshots:
     dependencies:
       '@types/nlcst': 2.0.3
 
-  node-exports-info@1.6.0:
-    dependencies:
-      array.prototype.flatmap: 1.3.3
-      es-errors: 1.3.0
-      object.entries: 1.1.9
-      semver: 6.3.1
-
   node-fetch-native@1.6.7: {}
 
   node-mock-http@1.0.4: {}
@@ -9257,8 +8709,6 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  object-assign@4.1.1: {}
-
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
@@ -9271,13 +8721,6 @@ snapshots:
       es-object-atoms: 1.1.1
       has-symbols: 1.1.0
       object-keys: 1.1.1
-
-  object.entries@1.1.9:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.2
 
   object.fromentries@2.0.8:
     dependencies:
@@ -9466,12 +8909,6 @@ snapshots:
 
   prismjs@1.30.0: {}
 
-  prop-types@15.8.1:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react-is: 16.13.1
-
   property-information@7.1.0: {}
 
   proxy-from-env@2.1.0: {}
@@ -9480,11 +8917,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  queue-microtask@1.2.3: {}
-
   radix3@1.1.2: {}
-
-  react-is@16.13.1: {}
 
   readdirp@5.0.0: {}
 
@@ -9661,15 +9094,6 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  resolve@2.0.0-next.7:
-    dependencies:
-      es-errors: 1.3.0
-      is-core-module: 2.16.2
-      node-exports-info: 1.6.0
-      object-keys: 1.1.1
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
@@ -9701,8 +9125,6 @@ snapshots:
       unified: 11.0.5
 
   rettime@0.11.11: {}
-
-  reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
 
@@ -9777,21 +9199,9 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
-  run-parallel@1.2.0:
-    dependencies:
-      queue-microtask: 1.2.3
-
   safe-array-concat@1.1.3:
     dependencies:
       call-bind: 1.0.8
-      call-bound: 1.0.4
-      get-intrinsic: 1.3.0
-      has-symbols: 1.1.0
-      isarray: 2.0.5
-
-  safe-array-concat@1.1.4:
-    dependencies:
-      call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
@@ -10000,33 +9410,6 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
-  string.prototype.includes@2.0.1:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-
-  string.prototype.matchall@4.0.12:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      get-intrinsic: 1.3.0
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      internal-slot: 1.1.0
-      regexp.prototype.flags: 1.5.4
-      set-function-name: 2.0.2
-      side-channel: 1.1.0
-
-  string.prototype.repeat@1.0.0:
-    dependencies:
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
-
   string.prototype.trim@1.2.10:
     dependencies:
       call-bind: 1.0.8
@@ -10101,8 +9484,6 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tapable@2.3.3: {}
-
   terser@5.46.2:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -10158,11 +9539,6 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-declaration-location@1.0.7(typescript@5.9.3):
-    dependencies:
-      picomatch: 4.0.4
-      typescript: 5.9.3
-
   tsconfig-paths@3.15.0:
     dependencies:
       '@types/json5': 0.0.29
@@ -10214,15 +9590,6 @@ snapshots:
   typed-array-length@1.0.7:
     dependencies:
       call-bind: 1.0.8
-      for-each: 0.3.5
-      gopd: 1.2.0
-      is-typed-array: 1.1.15
-      possible-typed-array-names: 1.1.0
-      reflect.getprototypeof: 1.0.10
-
-  typed-array-length@1.0.8:
-    dependencies:
-      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       is-typed-array: 1.1.15
@@ -10391,6 +9758,7 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.12.2
       '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
       '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
+    optional: true
 
   unstorage@1.17.5:
     dependencies:
@@ -10563,16 +9931,6 @@ snapshots:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
 
-  which-typed-array@1.1.21:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      for-each: 0.3.5
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -10627,10 +9985,6 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
-
-  zod-validation-error@4.0.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
 
   zod@4.4.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,9 +72,6 @@ importers:
       '@rollup/plugin-terser':
         specifier: ^1.0.0
         version: 1.0.0(rollup@4.60.4)
-      '@stellar/tsconfig':
-        specifier: ^1.0.2
-        version: 1.0.2
       '@types/detect-node':
         specifier: ^2.0.2
         version: 2.0.2
@@ -1439,9 +1436,6 @@ packages:
   '@stellar/js-xdr@4.0.0':
     resolution: {integrity: sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==}
     engines: {node: '>=20.0.0', pnpm: '>=9.0.0'}
-
-  '@stellar/tsconfig@1.0.2':
-    resolution: {integrity: sha512-lC51QSlYRM8K3oGe0/WGPq+p9+u+yPzwZXSKrZXKOe4sq79vzfiqFbQyp5enOffFzXlahcDyTgY67mBOkJytfw==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -5884,8 +5878,6 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@stellar/js-xdr@4.0.0': {}
-
-  '@stellar/tsconfig@1.0.2': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@stellar/tsconfig",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
     "noUnusedLocals": true,

--- a/src/bindings/config.ts
+++ b/src/bindings/config.ts
@@ -3,7 +3,7 @@
 // failed at runtime in deeper build outputs (e.g. lib/axios) because the
 // relative path `../../package.json` resolved into the output tree rather
 // than the project root.
-// eslint-disable-next-line @typescript-eslint/naming-convention
+
 declare const __PACKAGE_VERSION__: string;
 
 export interface ConfigGenerateOptions {

--- a/src/bindings/wasm_fetcher.ts
+++ b/src/bindings/wasm_fetcher.ts
@@ -99,7 +99,7 @@ async function fetchWasmFromContract(
     }
 
     const wasmHash = instance.executable().wasmHash();
-    let wasmBytes = await getRemoteWasmFromHash(server, wasmHash);
+    const wasmBytes = await getRemoteWasmFromHash(server, wasmHash);
     return { type: "wasm", wasmBytes };
   } catch (error) {
     if (error instanceof WasmFetchError) {

--- a/src/contract/client.ts
+++ b/src/contract/client.ts
@@ -127,7 +127,7 @@ export class Client {
             spec.funcResToNative(method, result),
         });
 
-      // @ts-ignore error TS7053: Element implicitly has an 'any' type
+      // @ts-expect-error error TS7053: Element implicitly has an 'any' type
       this[sanitizeIdentifier(method)] =
         spec.getFunc(method).inputs().length === 0
           ? (opts?: MethodOptions) => assembleTransaction(undefined, opts)

--- a/src/contract/spec.ts
+++ b/src/contract/spec.ts
@@ -722,11 +722,11 @@ export class Spec {
                   `expected ${bytesN.n()} bytes, but got ${copy.length}`,
                 );
               }
-              //@ts-ignore
+              //@ts-expect-error scvBytes' generated type expects Buffer; copy is a Uint8Array accepted at runtime
               return xdr.ScVal.scvBytes(copy);
             }
             case xdr.ScSpecType.scSpecTypeBytes().value:
-              //@ts-ignore
+              //@ts-expect-error scvBytes' generated type expects Buffer; copy is a Uint8Array accepted at runtime
               return xdr.ScVal.scvBytes(copy);
             default:
               throw new TypeError(
@@ -1221,7 +1221,6 @@ export class Spec {
           const fn = entry.functionV0();
           const fnName = fn.name().toString();
           const { input } = functionToJsonSchema(fn);
-          // @ts-ignore
           definitions[fnName] = input;
           break;
         }

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -1,4 +1,5 @@
-/* disable PascalCase naming convention, to avoid breaking change */
+/* Type aliases below intentionally use non-PascalCase names (e.g. `XDR_BASE64`,
+   `u32`) to preserve the public API — renaming them would be a breaking change. */
 
 import { Transaction, xdr } from "../base/index.js";
 import type { SentTransaction } from "./sent_transaction.js";

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -1,5 +1,5 @@
 /* disable PascalCase naming convention, to avoid breaking change */
-/* eslint-disable @typescript-eslint/naming-convention */
+
 import { Transaction, xdr } from "../base/index.js";
 import type { SentTransaction } from "./sent_transaction.js";
 import type { Client } from "./client.js";

--- a/src/contract/utils.ts
+++ b/src/contract/utils.ts
@@ -43,7 +43,7 @@ export async function withExponentialBackoff<T>(
         }ms)`,
       );
     }
-    // eslint-disable-next-line
+
     await new Promise((res) => setTimeout(res, waitTime));
     // Exponential backoff
     waitTime *= exponentialFactor;
@@ -182,7 +182,7 @@ export function processSpecEntryStream(buffer: Buffer) {
   const reader = new cereal.XdrReader(buffer);
   const res: xdr.ScSpecEntry[] = [];
   while (!reader.eof) {
-    // @ts-ignore
+    // @ts-expect-error ScSpecEntry.read expects the generated XdrReader type; reader is cereal.XdrReader
     res.push(xdr.ScSpecEntry.read(reader));
   }
   return res;

--- a/src/contract/wasm_spec_parser.ts
+++ b/src/contract/wasm_spec_parser.ts
@@ -7,7 +7,7 @@ import { parseWasmCustomSections } from "./utils.js";
  */
 export function specFromWasm(wasm: Buffer) {
   const customData = parseWasmCustomSections(wasm);
-  let xdrSections = customData.get("contractspecv0");
+  const xdrSections = customData.get("contractspecv0");
 
   if (!xdrSections || xdrSections.length === 0) {
     throw new Error("Could not obtain contract spec from wasm");

--- a/src/horizon/call_builder.ts
+++ b/src/horizon/call_builder.ts
@@ -153,7 +153,7 @@ export class CallBuilder<
       timeout = setTimeout(
         () => {
           es?.close();
-          // eslint-disable-next-line @typescript-eslint/no-use-before-define
+
           es = createEventSource();
         },
         options.reconnectTimeout || 15 * 1000,

--- a/src/horizon/horizon_api.ts
+++ b/src/horizon/horizon_api.ts
@@ -419,6 +419,7 @@ export namespace HorizonApi {
   > {
     into: string;
   }
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- empty interface names a public API response type
   export interface InflationOperationResponse extends BaseOperationResponse<
     OperationResponseType.inflation,
     OperationResponseTypeI.inflation
@@ -586,6 +587,7 @@ export namespace HorizonApi {
     ledgers_to_expire: number;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- empty interface names a public API response type
   export interface RestoreFootprintOperationResponse extends BaseOperationResponse<
     OperationResponseType.restoreFootprint,
     OperationResponseTypeI.restoreFootprint
@@ -601,6 +603,7 @@ export namespace HorizonApi {
       records: T[];
     };
   }
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- empty interface names a public API response type
   export interface TransactionResponseCollection extends ResponseCollection<TransactionResponse> {}
 
   export interface FeeDistribution {

--- a/src/horizon/horizon_axios_client.ts
+++ b/src/horizon/horizon_axios_client.ts
@@ -4,7 +4,6 @@ import {
   type HttpResponseHeaders,
 } from "../http-client/index.js";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 declare const __PACKAGE_VERSION__: string;
 export const version = __PACKAGE_VERSION__;
 

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -14,6 +14,7 @@ import {
   type Interceptor,
 } from "./types.js";
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- named extension point for additional response properties
 export interface HttpResponse<T = any> extends AxiosResponse<T> {
   // You can add any additional properties here if needed
 }
@@ -581,7 +582,7 @@ function createFetchClient(
         // The chain is built as [fulfilled, rejected, fulfilled, rejected, ...]
         // and wired via .then(onFulfilled, onRejected) so each pair can
         // recover from an upstream error (matching Axios interceptor semantics).
-        let modifiedConfig = config;
+        const modifiedConfig = config;
         if (requestInterceptors.handlers.length > 0) {
           const chain = requestInterceptors.handlers
             .filter(

--- a/src/http-client/types.ts
+++ b/src/http-client/types.ts
@@ -20,6 +20,7 @@ export interface HttpClientResponse<T = any> {
   statusText: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- intentionally merged with the CancelToken class below to declare its members
 export interface CancelToken {
   promise: Promise<void>;
   throwIfRequested(): void;
@@ -118,6 +119,7 @@ export interface InterceptorManager<V> {
   handlers: Array<Interceptor<V> | null>;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- intentionally merged with the CancelToken interface above
 export class CancelToken {
   promise: Promise<void>;
   reason?: string;

--- a/src/rpc/axios.ts
+++ b/src/rpc/axios.ts
@@ -1,6 +1,5 @@
 import { create, type HttpClient } from "../http-client/index.js";
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 declare const __PACKAGE_VERSION__: string;
 export const version = __PACKAGE_VERSION__;
 

--- a/src/rpc/jsonrpc.ts
+++ b/src/rpc/jsonrpc.ts
@@ -28,6 +28,7 @@ export interface Error<E = any> {
 
 // Check if the given object X has a field Y, and make that available to
 // typescript typing.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- `{}` is the intended constraint (any non-nullish value with own properties)
 function hasOwnProperty<X extends {}, Y extends PropertyKey>(
   obj: X,
   prop: Y,

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -310,10 +310,10 @@ export class RpcServer {
   ): Promise<xdr.ClaimableBalanceEntry> {
     let balanceId;
     if (StrKey.isValidClaimableBalance(id)) {
-      let buffer = StrKey.decodeClaimableBalance(id);
+      const buffer = StrKey.decodeClaimableBalance(id);
 
       // Pad the version byte to be a full int32 like in the XDR spec
-      let v = Buffer.concat([
+      const v = Buffer.concat([
         Buffer.from("\x00\x00\x00"),
         buffer.subarray(0, 1),
       ]);

--- a/src/rpc/utils.ts
+++ b/src/rpc/utils.ts
@@ -1,5 +1,6 @@
 // Check if the given object X has a field Y, and make that available to
 // typescript typing.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- `{}` is the intended constraint (any non-nullish value with own properties)
 export function hasOwnProperty<X extends {}, Y extends PropertyKey>(
   obj: X,
   prop: Y,

--- a/src/webauth/challenge_transaction.ts
+++ b/src/webauth/challenge_transaction.ts
@@ -64,7 +64,7 @@ export function buildChallengeTx(
   serverKeypair: Keypair,
   clientAccountID: string,
   homeDomain: string,
-  // eslint-disable-next-line @typescript-eslint/default-param-last
+
   timeout: number = 300,
   networkPassphrase: string,
   webAuthDomain: string,

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@stellar/tsconfig",
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2022",
     "module": "node16",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,29 @@
+{
+  // Shared TypeScript compiler options for the SDK. Inlined from the former
+  // `@stellar/tsconfig` dependency (unmaintained since 2020); the values below
+  // are a verbatim copy of what that package provided.
+  "compilerOptions": {
+    "allowJs": true,
+    "emitDecoratorMetadata": false,
+    "experimentalDecorators": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
+    "isolatedModules": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "pretty": true,
+    "preserveWatchOutput": false,
+    "removeComments": true,
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "stripInternal": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@stellar/tsconfig",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "declaration": true,
     "emitDeclarationOnly": true,


### PR DESCRIPTION
- Swapped `eslint-config-airbnb-extended` for the `typescript-eslint` - use more standard ESLint rules
- Replaced `@stellar/tsconfig` with a local config - `@stellar/tsconfig` is not actively maintained, so it might be better to have our own config which we can adjust as needed