### PR TITLE
V16.0.0 release

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -42,4 +42,4 @@ jobs:
         run: pnpm run preversion
 
       - name: Publish npm package
-        run: npm publish --access public --provenance --tag "p27"
+        run: npm publish --access public --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,17 +205,9 @@ depending on how you use the API.
 - **CAP-71 `SOROBAN_CREDENTIALS_ADDRESS_V2` auth is opt-in; the default stays
   legacy `SOROBAN_CREDENTIALS_ADDRESS` (V1).** `ADDRESS_V2` entries are only
   valid on networks that have activated CAP-71, so the default keeps submissions
-  safe before activation. Opt in with the new `authV2` flag (default `false`),
-  threaded through:
-  - `rpc.Server.simulateTransaction` — a 4th optional argument; when `true`, the
-    `authV2` request flag is sent so simulation returns `ADDRESS_V2` entries,
-    otherwise the flag is omitted and legacy `ADDRESS` entries are returned.
-  - `authorizeInvocation` — an optional `authV2` field on its params object,
-    selecting between `ADDRESS` and `ADDRESS_V2` credentials.
-  - `contract.Client` / `AssembledTransaction` — `authV2` in `MethodOptions`,
-    threaded through to simulation.
-
-  The default will flip to V2 once the protocol makes it mandatory. ([#1429], [#1450])
+  safe before activation. `authorizeInvocation` gained an optional `authV2`
+  field (default `false`) on its params object, selecting between `ADDRESS` and
+  `ADDRESS_V2` credentials. The default will flip to V2 in protocol 28 ([#1429], [#1450])
 
 #### Internal-detail shifts (low likelihood of impact)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,296 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
-### Fixed
-- `TransactionBuilder.cloneFrom` now accounts for Soroban transactions: the
-  resource fee is excluded from the total fee before deriving the per-operation
-  base fee (previously it was treated as part of the inclusion fee and re-added
-  on `build()`, doubling it), and the transaction's `sorobanData` is carried
-  over into the new builder. If the declared resource fee equals or exceeds the
-  total fee (a malformed transaction), the subtraction is skipped and the full
-  fee is used as-is.
+## [v16.0.0](https://github.com/stellar/js-stellar-sdk/compare/v15.1.0...v16.0.0)
+
+There are a few major updates in this release:
+
+- JS Stellar Base (`@stellar/stellar-base`) was rewritten
+  in TypeScript, which provides proper type definitions and fixes
+  inconsistencies caused by manual type declarations. ([#1399])
+- JS Stellar Base is now merged into the JS Stellar SDK. Everything lives in one
+  place now. ([#1399])
+- The JS SDK now has better tree-shaking, which should result in a lighter
+  bundle size. ([#1397])
+- Protocol 27 support: the XDR was regenerated for CAP-71, and the Soroban
+  authorization helpers can build and sign the new address-bound
+  (`SOROBAN_CREDENTIALS_ADDRESS_V2`) and delegated
+  (`SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES`) credential types. The legacy
+  `SOROBAN_CREDENTIALS_ADDRESS` (V1) credential remains the default;
+  `ADDRESS_V2` is opt-in (see below), as it is only valid on networks that have
+  activated CAP-71. ([#1429], [#1450])
+
+### 1. Breaking Changes
+
+These break code, builds, or installs until you change something.
+
+#### Install & runtime
+
+- **Drop `@stellar/stellar-base` from your dependencies** if you were importing
+  it manually. It is now bundled into `@stellar/stellar-sdk`. Remove the package
+  and switch all imports from `@stellar/stellar-base` to `@stellar/stellar-sdk`.
+  ([#1399])
+- **Upgrade to Node 22 or later.** `engines.node` is now `>=22.0.0`; CI tests
+  against `[22, 24]`. ([#1408])
+- **Stop using the default import.**
+  `import StellarBase from '@stellar/stellar-sdk'` no longer works. Use
+  `import * as StellarBase` or named imports. ([#1396])
+- **Adjust deep `lib/` imports.** Library output paths moved:
+  - ESM at `lib/esm/`,
+  - CJS at `lib/cjs/`,
+  - axios variants at `lib/axios/esm/` and `lib/axios/cjs/`,
+  - type declarations alongside the ESM output at `lib/esm/` (e.g.
+    `lib/esm/index.d.ts`).
+
+  The `dist/` UMD bundle filenames are unchanged. ([#1397])
+- **The package.json `browser` field and browser export conditions were
+  removed.** Bundlers no longer auto-substitute the prebuilt UMD bundle for the
+  package entry — they bundle the ESM/CJS source directly. Load the UMD build
+  from its explicit `dist/` path if you need it. ([#1396], [#1397])
+
+#### HTTP client
+
+- **Default HTTP client switched from axios to fetch.** If you rely on axios
+  behavior (interceptors, adapters, regression fallback), import from the
+  alternative entry point `@stellar/stellar-sdk/axios` instead. ([#1394])
+- **The `no-eventsource` build variant is gone.** `eventsource` was upgraded to
+  v4, which uses `fetch` internally and works in every supported runtime (Node
+  22+, browsers, Deno, Bun, `workerd`). Remove any `no-eventsource`
+  build/import; the default build covers all environments. ([#1395])
+- **The `/no-axios` and `/minimal` subpath exports are removed**, along with
+  their `/contract` and `/rpc` variants. Axios is now opt-in through the
+  `@stellar/stellar-sdk/axios` family (`/axios`, `/axios/contract`,
+  `/axios/rpc`, and `@stellar/stellar-sdk/http-client/axios`); the minimal build
+  no longer exists. ([#1394])
+- **`Horizon.Server.serverURL` and `rpc.Server.serverURL` are now native `URL`
+  objects** (and `readonly`) instead of `urijs` `URI` instances. Code that called
+  urijs methods on them (`server.serverURL.protocol()`, `.clone()`, `.segment()`,
+  `.query()`) must move to the WHATWG `URL` API (e.g.
+  `serverURL.protocol === "https:"`, `serverURL.hostname`). ([#1402])
+
+#### `Transaction` & `TransactionBuilder`
+
+- **`Transaction.minAccountSequenceAge` is now `bigint`.** The underlying XDR
+  type is 64-bit; consuming code must switch from `number` to native `bigint`
+  (the runtime value is no longer an `xdr.UnsignedHyper` object either). ([#1399])
+
+- **`TransactionBuilder.setMinAccountSequenceAge` requires `bigint`.** Pass
+  `60n` instead of `60`. `TransactionBuilderOptions.minAccountSequenceAge` is
+  also `bigint`. ([#1399])
+- **`Transaction.extraSigners` is now `xdr.SignerKey[]`.** It always was at
+  runtime — only the type was wrong. Use `SignerKey.encodeSignerKey()` to get
+  StrKey strings. ([#1399])
+- **`Transaction` is no longer generic.** Remove `<TMemo, TOps>` parameters
+  (e.g., `Transaction<Memo<MemoType.Text>>` no longer compiles). ([#1399])
+- **`Operation.isValidAmount()`, `Operation.constructAmountRequirementsError()`,
+  and `Operation.setSourceAccount()` are no longer on the runtime `Operation`
+  class.** JavaScript callers that reached for these need to drop them — they
+  remain only as internal helpers in `src/base/util/operations.ts`. ([#1399])
+- **Revoke-sponsorship operation `type` is split into seven strings.**
+  `"revokeSponsorship"` is replaced by `"revokeAccountSponsorship"`,
+  `"revokeTrustlineSponsorship"`, `"revokeOfferSponsorship"`,
+  `"revokeDataSponsorship"`, `"revokeClaimableBalanceSponsorship"`,
+  `"revokeLiquidityPoolSponsorship"`, `"revokeSignerSponsorship"`. The runtime
+  always returned the specific strings; consumers that switched on `type` should
+  update their cases. ([#1399])
+
+#### `Asset`, `Keypair`, signing helpers
+
+- **`Asset.code` and `Asset.issuer` are now `readonly`.** Stop mutating them in
+  place — construct a new `Asset` instead. ([#1399])
+- **`Asset.issuer` is typed as `string | undefined`.** Native assets have no
+  issuer; add nullish checks. ([#1399])
+- **`FastSigning` constant removed.** Signing now goes through
+  `@noble/ed25519` exclusively — drop the import. ([#1401])
+- **`TransactionI` removed.** Use `TransactionBase` instead. ([#1399])
+- **`authorizeInvocation()` takes a single object parameter.** Switch from
+  `authorizeInvocation(signer, validUntilLedgerSeq, invocation, publicKey, networkPassphrase)`
+  to
+  `authorizeInvocation({ signer, validUntilLedgerSeq, invocation, networkPassphrase, publicKey })`.
+  ([#1399])
+- **`authorizeEntry()` no longer defaults `networkPassphrase` to
+  `Networks.FUTURENET`.** Pass the network passphrase explicitly at every call
+  site. ([#1399])
+
+### 2. Should know (type-only or behavior changes that may surface)
+
+Won't fail at install. May fail at compile time, or change behavior at runtime,
+depending on how you use the API.
+
+#### TypeScript-only
+
+- **`CreateInvocation.token` renamed to `CreateInvocation.asset`** in the type
+  declarations — runtime was already `.asset`. ([#1399])
+- **`ScIntType` adds `'timepoint'` and `'duration'`.** Exhaustive switches on
+  `ScIntType` need new cases. ([#1399])
+- **`XdrLargeInt.getType()` returns `ScIntType | undefined`** instead of a raw
+  lowercased string; non-integer types yield `undefined`. ([#1399])
+- **`SorobanDataBuilder.fromXDR` return type corrected** to
+  `xdr.SorobanTransactionData`. Runtime always returned this — only the type was
+  wrong. ([#1399])
+- **`SetOptions.clearFlags` / `setFlags` accept arbitrary numeric bitmasks.**
+  The type was widened from `AuthFlag` to `AuthFlags` (`AuthFlag | (number & {})`),
+  so you can now pass combined flag values without a cast. This is a widening —
+  existing code keeps compiling. ([#1399])
+- **`supportMuxing` parameter removed** from `decodeAddressToMuxedAccount` /
+  `encodeMuxedAccountToAddress` type declarations. It was silently ignored at
+  runtime. ([#1399])
+
+#### Runtime behavior
+
+- **`Keypair.rawSecretKey()` throws on public-key-only instances** with
+  `Error("no secret seed available")` instead of returning `undefined`. ([#1399])
+- **`TransactionBase.tx` returns a defensive copy — mutating it is now a SILENT
+  no-op.** `tx` no longer returns the live XDR object, so setting fields through
+  it (`tx.tx.fee(…)`, `tx.tx.operations(…)`, `tx.tx.cond(…)`, etc.) mutates a
+  throwaway copy and has **no effect** on the transaction that gets signed or
+  serialized. It does **not** throw and no types change, so code that relied on
+  in-place mutation keeps compiling and running while silently signing the
+  unmodified transaction. Rebuild instead via `TransactionBuilder` /
+  `TransactionBuilder.cloneFrom`. ([#1399])
+- **`TransactionBuilder` constructor preserves `0n` for
+  `minAccountSequenceAge`** instead of coercing falsy values to `null`. This may
+  flip `hasV2Preconditions()` to `true` when the field is set to `0n`. ([#1399])
+- **`toXDRPrice` rejects more bad input earlier.** Zero/negative/`NaN`/
+  `Infinity` numeric prices now throw `"price must be positive"` before reaching
+  `best_r()`. Zero denominators also rejected (`d <= 0`). ([#1399])
+- **Constructor and input validation now throw where the SDK was previously
+  lenient.** `MuxedAccount` validates uint64 IDs; `Claimant` rejects falsy
+  destinations; `Account` rejects `NaN` sequences; `Memo` is fully immutable and
+  throws on invalid types instead of returning `null`; `Memo.id()` rejects
+  non-plain-digit strings; `allow_trust` throws when `authorize` is missing;
+  `setTrustLineFlags` rejects non-boolean flag values; `Asset.getAssetType()`
+  throws for unknown types instead of returning `"unknown"`. (`set_options` also
+  no longer mutates the caller's signer fields.) ([#1399])
+- **`TransactionBuilder` now validates and throws.** `build()` throws on
+  total-fee overflow past `uint32` max; `cloneFrom()` throws on zero-operation
+  inputs; the constructor rejects negative or inverted `timebounds` /
+  `ledgerbounds`. ([#1399])
+- **`TransactionBuilder.cloneFrom` excludes the Soroban resource fee when
+  deriving the per-operation base fee.** Previously the resource fee was treated
+  as part of the inclusion fee and re-added on `build()`, doubling it (or
+  overflowing `uint32` and throwing). If a malformed transaction declares a
+  resource fee that meets or exceeds its total fee, the subtraction is skipped
+  and the full fee is used as-is. ([#1478])
+- **`Operation.setOptions()` rejects malformed numeric strings.** Flag, weight,
+  and threshold fields (`setFlags`, `clearFlags`, `masterWeight`, the signer
+  weight, and the `*Threshold` options) now reject values like `"123abc"` that
+  `parseFloat()` previously accepted by reading only the leading digits. ([#1399])
+- **`XdrLargeInt` / `ScInt` built from an array of limbs now decode correctly.**
+  Passing multiple big-endian integer parts (for `i128`/`u128`/`i256`/`u256`)
+  previously wrapped them in a nested array and produced wrong values; the limbs
+  are now passed through correctly. ([#1399])
+- **Large-integer conversions reject out-of-range / malformed input.**
+  `nativeToScVal` bounds-checks `u32`/`i32` values and rejects non-numeric
+  strings like `"123abc"`; `XdrLargeInt.toI128()` / `toI256()` reject unsigned
+  values exceeding the signed range instead of silently flipping the sign bit.
+  ([#1399])
+- **`bignumber.js` upgraded to v11; v9's `DEBUG` guard replaced by `STRICT`
+  mode.** Invalid values (non-numeric strings, unsupported types) still throw, as
+  before. The behavior that changed: v11 dropped v9's "more than 15 significant
+  digits" check, so a high-precision JS `number` passed as an amount or price no
+  longer throws — it is silently rounded to floating-point precision instead.
+  Pass such values as strings or `bigint` to avoid quiet precision loss.
+  ([#1401])
+- **`eventsource` v4 no longer swallows exceptions thrown inside stream
+  callbacks.** A throw inside a `CallBuilder.stream()` `onmessage`/`onerror`
+  handler now surfaces as an uncaught exception (v4's spec-compliant
+  `EventTarget` no longer discards it); make those callbacks handle their own
+  errors. ([#1395])
+- **CAP-71 `SOROBAN_CREDENTIALS_ADDRESS_V2` auth is opt-in; the default stays
+  legacy `SOROBAN_CREDENTIALS_ADDRESS` (V1).** `ADDRESS_V2` entries are only
+  valid on networks that have activated CAP-71, so the default keeps submissions
+  safe before activation. Opt in with the new `authV2` flag (default `false`),
+  threaded through:
+  - `rpc.Server.simulateTransaction` — a 4th optional argument; when `true`, the
+    `authV2` request flag is sent so simulation returns `ADDRESS_V2` entries,
+    otherwise the flag is omitted and legacy `ADDRESS` entries are returned.
+  - `authorizeInvocation` — an optional `authV2` field on its params object,
+    selecting between `ADDRESS` and `ADDRESS_V2` credentials.
+  - `contract.Client` / `AssembledTransaction` — `authV2` in `MethodOptions`,
+    threaded through to simulation.
+
+  The default will flip to V2 once the protocol makes it mandatory. ([#1429], [#1450])
+
+#### Internal-detail shifts (low likelihood of impact)
+
+- `uri.js` replaced with native `URL` / `URLSearchParams` for internal request
+  building (the consumer-visible part is the `serverURL` type change noted under
+  Breaking Changes → HTTP client). ([#1402])
+- Root `tsconfig.json` moved from `config/tsconfig.json` to project root —
+  matters if your tooling references the old path. ([#1401])
+
+### 3. Quietly improved (no caller action needed)
+
+These are robustness and correctness gains rolled up by theme.
+
+- **`nativeToScVal` robustness.** Plain-object detection, per-key type lookups,
+  prefixed numeric inputs, and map-key sorting are more predictable.
+  (Caller-visible new throws are listed under Should know → Runtime behavior.)
+  ([#1399])
+- **`TransactionBuilder.addSacTransferOperation` accepts muxed addresses.** Both
+  the destination and source may now be muxed (`M...`) addresses. ([#1399])
+- **`ScInt` auto-type classification fixed for negative boundary values.**
+  `-(2^63)` is now classified as `i64`, not `i128`. (The related `toI128()` /
+  `toI256()` range rejections are listed under Should know → Runtime behavior.)
+  ([#1399])
+- **Round-trip fidelity with `Operation.fromXDRObject`.** `changeTrust` accepts
+  `line` as a fallback for `asset`; `manageData` accepts `undefined` for
+  `opts.value` as a delete; `ed25519SignedPayload` signer keys are now decoded
+  instead of throwing in the default case. ([#1399])
+- **Soroban-specific fixes.** Token amount formatting, custom-contract errors,
+  claimable-balance addresses, sorted-map comparisons, and `best_r` edge cases
+  are more reliable. ([#1399])
+- **Horizon call builders.** Asset-filtered queries (offers, order book, paths,
+  trade aggregations) no longer emit `*_asset_code`/`*_asset_issuer` parameters
+  for issuerless assets, avoiding `undefined` values in the outgoing request.
+  ([#1402])
+- **Misc.** `Transaction` construction avoids unnecessary copy overhead,
+  `authorizeInvocation` has a clearer missing-`publicKey` error, and a `signHashX`
+  error-message typo was fixed. ([#1399])
+
+#### Newly typed / newly available (the `Added` section, summarized)
+
+`Address`, `hash`, `sign`, `verify`, `Keypair.xdrMuxedAccount(id)`,
+`SorobanDataBuilder`, `Memo.return()`, `revokeSignerSponsorship`, and
+`Operation.fromXDRObject` have more complete types or signer support.
+`scvSortedMap` is now exported. New type exports: `NativeToScValOpts`,
+`WasmCreateDetails`, and `OperationRecord`. Contract-create/upload operations now
+accept an `auth` array. ([#1399])
+
+For protocol 27 / CAP-71 Soroban authorization, `authorizeEntry()` now signs the
+new address-bound and delegated credential types, accepts `forAddress`, and
+exports `buildAuthorizationEntryPreimage()`, `buildWithDelegatesEntry()`,
+`DelegateSignature`, and `BuildWithDelegatesParams`. ([#1429])
+
+### 4. Internal / FYI (no consumer-visible effect)
+
+Toolchain modernization that consumers won't notice but is worth knowing if you
+build the SDK from source or maintain forks.
+
+- **Build switched from Webpack + Babel to Rollup.** One `rollup.config.mjs`
+  now produces library + UMD output, with a single `tsc` types pass. ([#1397])
+- **Dual ESM + CJS package layout.** `package.json` declares `"type": "module"`;
+  CJS output lives under `lib/cjs/`, and internal relative imports now use
+  explicit `.js` extensions. ([#1396])
+- **Dependency swaps for smaller footprint.** `randombytes` removed (randomness
+  now comes from `crypto.getRandomValues` / `@noble/ed25519`); `sha.js` →
+  `@noble/hashes`; `@noble/curves` Ed25519 → `@noble/ed25519`; `toml` →
+  `smol-toml`. ([#1401])
+- **`eventsource` v2 → v4.** Native `fetch` transport under the hood; the
+  dependency contributes well under 2 KB to bundles. ([#1395])
+
+[#1394]: https://github.com/stellar/js-stellar-sdk/pull/1394
+[#1395]: https://github.com/stellar/js-stellar-sdk/pull/1395
+[#1396]: https://github.com/stellar/js-stellar-sdk/pull/1396
+[#1397]: https://github.com/stellar/js-stellar-sdk/pull/1397
+[#1399]: https://github.com/stellar/js-stellar-sdk/pull/1399
+[#1401]: https://github.com/stellar/js-stellar-sdk/pull/1401
+[#1402]: https://github.com/stellar/js-stellar-sdk/pull/1402
+[#1408]: https://github.com/stellar/js-stellar-sdk/pull/1408
+[#1429]: https://github.com/stellar/js-stellar-sdk/pull/1429
+[#1450]: https://github.com/stellar/js-stellar-sdk/pull/1450
+[#1478]: https://github.com/stellar/js-stellar-sdk/pull/1478
 
 ## [v16.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v16.0.0-rc.1...v16.0.0-rc.2)
 

--- a/docs/guides/00-migration.md
+++ b/docs/guides/00-migration.md
@@ -409,15 +409,12 @@ adds two address-bound Soroban credential types, `AddressV2` and
 `AddressWithDelegates`. This only affects code that signs Soroban authorization
 entries or inspects their credential arms.
 
-By default the SDK still uses the legacy `ADDRESS` credential: simulation is
-asked for `ADDRESS` entries and `authorizeInvocation` builds them. `ADDRESS_V2`
+By default the SDK still uses the legacy `ADDRESS` credential: simulation
+returns `ADDRESS` entries and `authorizeInvocation` builds them. `ADDRESS_V2`
 is only valid on networks that have upgraded to protocol 27, so it is **opt-in** until
  protocol 28 makes it mandatory (at which point the default flips). Opt in with
-the `authV2` flag — on
-`rpc.Server.simulateTransaction`,
-on `authorizeInvocation`'s params, or via `authV2` in
-[`contract.Client`](/reference/contracts-client/#contractclient) /
-`MethodOptions` — when your target network supports it.
+the `authV2` flag on `authorizeInvocation`'s params — when your target network
+supports it.
 
 SDK-driven signing ([`contract.Client`](/reference/contracts-client/#contractclient),
 [`basicNodeSigner`](/reference/contracts-client/#contractbasicnodesigner),

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -423,7 +423,7 @@ returns `false`, then you need to call `signAndSend` on this transaction.
 readonly isReadCall: boolean;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:1094](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1094)
+**Source:** [src/contract/assembled_transaction.ts:1089](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1089)
 
 ### `assembledTransaction.result`
 
@@ -431,7 +431,7 @@ readonly isReadCall: boolean;
 readonly result: T;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:743](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L743)
+**Source:** [src/contract/assembled_transaction.ts:738](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L738)
 
 ### `assembledTransaction.simulationData`
 
@@ -439,7 +439,7 @@ readonly result: T;
 readonly simulationData: { result: SimulateHostFunctionResult; transactionData: SorobanTransactionData };
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:700](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L700)
+**Source:** [src/contract/assembled_transaction.ts:695](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L695)
 
 ### `assembledTransaction.needsNonInvokerSigningBy(__namedParameters)`
 
@@ -469,7 +469,7 @@ needsNonInvokerSigningBy(__namedParameters: { includeAlreadySigned?: boolean } =
 
 - **`__namedParameters`** — `{ includeAlreadySigned?: boolean }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:929](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L929)
+**Source:** [src/contract/assembled_transaction.ts:924](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L924)
 
 ### `assembledTransaction.restoreFootprint(restorePreamble, account)`
 
@@ -504,7 +504,7 @@ Client initialization.
 - - Throws a custom error if the
 restore transaction fails, providing the details of the failure.
 
-**Source:** [src/contract/assembled_transaction.ts:1123](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1123)
+**Source:** [src/contract/assembled_transaction.ts:1118](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1118)
 
 ### `assembledTransaction.send(watcher)`
 
@@ -521,7 +521,7 @@ send(watcher?: Watcher): Promise<SentTransaction<T>>;
 
 - **`watcher`** — `Watcher` (optional)
 
-**Source:** [src/contract/assembled_transaction.ts:858](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L858)
+**Source:** [src/contract/assembled_transaction.ts:853](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L853)
 
 ### `assembledTransaction.sign(__namedParameters)`
 
@@ -536,7 +536,7 @@ sign(__namedParameters: { force?: boolean; signTransaction?: SignTransaction } =
 
 - **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransaction }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:771](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L771)
+**Source:** [src/contract/assembled_transaction.ts:766](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L766)
 
 ### `assembledTransaction.signAndSend(__namedParameters)`
 
@@ -555,7 +555,7 @@ signAndSend(__namedParameters: { force?: boolean; signTransaction?: SignTransact
 
 - **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransaction; watcher?: Watcher }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:876](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L876)
+**Source:** [src/contract/assembled_transaction.ts:871](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L871)
 
 ### `assembledTransaction.signAuthEntries(__namedParameters)`
 
@@ -582,7 +582,7 @@ signAuthEntries(__namedParameters: { address?: string; authorizeEntry?: (entry: 
 
 - **`__namedParameters`** — `{ address?: string; authorizeEntry?: (entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string) => Promise<SorobanAuthorizationEntry>; expiration?: number | Promise<number>; signAuthEntry?: SignAuthEntry }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:990](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L990)
+**Source:** [src/contract/assembled_transaction.ts:985](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L985)
 
 ### `assembledTransaction.simulate(__namedParameters)`
 
@@ -791,7 +791,7 @@ _before_ transaction signing.
 const DEFAULT_TIMEOUT: number
 ```
 
-**Source:** [src/contract/types.ts:303](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L303)
+**Source:** [src/contract/types.ts:293](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L293)
 
 ## contract.NULL_ACCOUNT
 
@@ -801,7 +801,7 @@ An impossible account on the Stellar network
 const NULL_ACCOUNT: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
 ```
 
-**Source:** [src/contract/types.ts:309](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L309)
+**Source:** [src/contract/types.ts:299](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L299)
 
 ## contract.SentTransaction
 
@@ -1341,7 +1341,7 @@ basicNodeSigner(keypair: Keypair, networkPassphrase: string): { signAuthEntry: S
 type AssembledTransactionOptions<T = string> = MethodOptions & ClientOptions & { address?: string; args?: any[]; method: string; parseResultXdr: (xdr: xdr.ScVal) => T; submit?: boolean; submitUrl?: string }
 ```
 
-**Source:** [src/contract/types.ts:271](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L271)
+**Source:** [src/contract/types.ts:261](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L261)
 
 ### contract.ClientOptions
 
@@ -1392,7 +1392,7 @@ message: string;
 Options for a smart contract method invocation.
 
 ```ts
-type MethodOptions = { authV2?: boolean; fee?: string; publicKey?: string; restore?: boolean; signAuthEntry?: SignAuthEntry; signTransaction?: SignTransaction; simulate?: boolean; timeoutInSeconds?: number }
+type MethodOptions = { fee?: string; publicKey?: string; restore?: boolean; signAuthEntry?: SignAuthEntry; signTransaction?: SignTransaction; simulate?: boolean; timeoutInSeconds?: number }
 ```
 
 **Source:** [src/contract/types.ts:204](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L204)

--- a/docs/reference/core-transactions.md
+++ b/docs/reference/core-transactions.md
@@ -2964,7 +2964,7 @@ static buildFeeBumpTransaction(feeSource: string | Keypair, baseFee: string, inn
 
 - https://developers.stellar.org/docs/glossary/fee-bumps/#replace-by-fee
 
-**Source:** [src/base/transaction_builder.ts:1114](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1114)
+**Source:** [src/base/transaction_builder.ts:1110](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1110)
 
 ### `TransactionBuilder.cloneFrom(tx, opts)`
 
@@ -3014,7 +3014,7 @@ static fromXDR(envelope: string | TransactionEnvelope, networkPassphrase: string
       Stellar network (e.g. "Public Global Stellar Network ; September
       2015"), see `Networks`.
 
-**Source:** [src/base/transaction_builder.ts:1225](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1225)
+**Source:** [src/base/transaction_builder.ts:1221](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1221)
 
 ### `transactionBuilder.baseFee`
 
@@ -3124,7 +3124,7 @@ addMemo(memo: Memo): TransactionBuilder;
 
 - **`memo`** — `Memo` (required) — `Memo` object
 
-**Source:** [src/base/transaction_builder.ts:416](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L416)
+**Source:** [src/base/transaction_builder.ts:412](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L412)
 
 ### `transactionBuilder.addOperation(operation)`
 
@@ -3138,7 +3138,7 @@ addOperation(operation: Operation2): TransactionBuilder;
 
 - **`operation`** — `Operation2` (required) — The xdr operation object, use `Operation` static methods.
 
-**Source:** [src/base/transaction_builder.ts:378](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L378)
+**Source:** [src/base/transaction_builder.ts:374](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L374)
 
 ### `transactionBuilder.addOperationAt(operation, index)`
 
@@ -3153,7 +3153,7 @@ addOperationAt(operation: Operation2, index: number): TransactionBuilder;
 - **`operation`** — `Operation2` (required) — The xdr operation object to add, use `Operation` static methods.
 - **`index`** — `number` (required) — The index at which to insert the operation.
 
-**Source:** [src/base/transaction_builder.ts:389](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L389)
+**Source:** [src/base/transaction_builder.ts:385](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L385)
 
 ### `transactionBuilder.addSacTransferOperation(destination, asset, amount, sorobanFees)`
 
@@ -3172,7 +3172,7 @@ addSacTransferOperation(destination: string, asset: Asset, amount: string | bigi
 - **`amount`** — `string | bigint` (required) — the amount of tokens to be transferred in 7 decimals. IE 1 token with 7 decimals of precision would be represented as "1_0000000"
 - **`sorobanFees`** — `SorobanFees` (optional) — optional Soroban fees for the transaction to override the default fees used
 
-**Source:** [src/base/transaction_builder.ts:723](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L723)
+**Source:** [src/base/transaction_builder.ts:719](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L719)
 
 ### `transactionBuilder.build()`
 
@@ -3183,7 +3183,7 @@ number by 1.
 build(): Transaction;
 ```
 
-**Source:** [src/base/transaction_builder.ts:943](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L943)
+**Source:** [src/base/transaction_builder.ts:939](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L939)
 
 ### `transactionBuilder.clearOperationAt(index)`
 
@@ -3197,7 +3197,7 @@ clearOperationAt(index: number): TransactionBuilder;
 
 - **`index`** — `number` (required) — The index of the operation to remove.
 
-**Source:** [src/base/transaction_builder.ts:407](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L407)
+**Source:** [src/base/transaction_builder.ts:403](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L403)
 
 ### `transactionBuilder.clearOperations()`
 
@@ -3207,7 +3207,7 @@ Removes the operations from the builder (useful when cloning).
 clearOperations(): TransactionBuilder;
 ```
 
-**Source:** [src/base/transaction_builder.ts:397](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L397)
+**Source:** [src/base/transaction_builder.ts:393](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L393)
 
 ### `transactionBuilder.hasV2Preconditions()`
 
@@ -3217,7 +3217,7 @@ Checks whether any v2 preconditions have been set on this builder.
 hasV2Preconditions(): boolean;
 ```
 
-**Source:** [src/base/transaction_builder.ts:1082](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1082)
+**Source:** [src/base/transaction_builder.ts:1078](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1078)
 
 ### `transactionBuilder.setExtraSigners(extraSigners)`
 
@@ -3234,7 +3234,7 @@ setExtraSigners(extraSigners: string[]): TransactionBuilder;
 
 - **`extraSigners`** — `string[]` (required) — required extra signers (as `StrKey`s)
 
-**Source:** [src/base/transaction_builder.ts:658](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L658)
+**Source:** [src/base/transaction_builder.ts:654](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L654)
 
 ### `transactionBuilder.setLedgerbounds(minLedger, maxLedger)`
 
@@ -3255,7 +3255,7 @@ setLedgerbounds(minLedger: number, maxLedger: number): TransactionBuilder;
       before. Cannot be negative. If the value is `0`, the transaction is
       valid indefinitely.
 
-**Source:** [src/base/transaction_builder.ts:546](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L546)
+**Source:** [src/base/transaction_builder.ts:542](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L542)
 
 ### `transactionBuilder.setMinAccountSequence(minAccountSequence)`
 
@@ -3279,7 +3279,7 @@ setMinAccountSequence(minAccountSequence: string): TransactionBuilder;
       default), the transaction is valid when `sourceAccount`'s sequence
       number `== tx.seqNum - 1`.
 
-**Source:** [src/base/transaction_builder.ts:583](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L583)
+**Source:** [src/base/transaction_builder.ts:579](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L579)
 
 ### `transactionBuilder.setMinAccountSequenceAge(durationInSeconds)`
 
@@ -3298,7 +3298,7 @@ setMinAccountSequenceAge(durationInSeconds: bigint): TransactionBuilder;
       will become valid. If the value is `0`, the transaction is unrestricted
       by the account sequence age. Cannot be negative.
 
-**Source:** [src/base/transaction_builder.ts:605](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L605)
+**Source:** [src/base/transaction_builder.ts:601](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L601)
 
 ### `transactionBuilder.setMinAccountSequenceLedgerGap(gap)`
 
@@ -3317,7 +3317,7 @@ setMinAccountSequenceLedgerGap(gap: number): TransactionBuilder;
       If the value is `0`, the transaction is unrestricted by the account
       sequence ledger. Cannot be negative.
 
-**Source:** [src/base/transaction_builder.ts:634](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L634)
+**Source:** [src/base/transaction_builder.ts:630](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L630)
 
 ### `transactionBuilder.setNetworkPassphrase(networkPassphrase)`
 
@@ -3332,7 +3332,7 @@ setNetworkPassphrase(networkPassphrase: string): TransactionBuilder;
 - **`networkPassphrase`** — `string` (required) — passphrase of the target Stellar
       network (e.g. "Public Global Stellar Network ; September 2015").
 
-**Source:** [src/base/transaction_builder.ts:684](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L684)
+**Source:** [src/base/transaction_builder.ts:680](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L680)
 
 ### `transactionBuilder.setSorobanData(sorobanData)`
 
@@ -3360,7 +3360,7 @@ setSorobanData(sorobanData: string | SorobanTransactionData): TransactionBuilder
 
 - `SorobanDataBuilder`
 
-**Source:** [src/base/transaction_builder.ts:706](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L706)
+**Source:** [src/base/transaction_builder.ts:702](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L702)
 
 ### `transactionBuilder.setTimebounds(minEpochOrDate, maxEpochOrDate)`
 
@@ -3384,7 +3384,7 @@ setTimebounds(minEpochOrDate: number | Date, maxEpochOrDate: number | Date): Tra
       Can't be negative. If the value is `0`, the transaction is valid
       indefinitely.
 
-**Source:** [src/base/transaction_builder.ts:497](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L497)
+**Source:** [src/base/transaction_builder.ts:493](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L493)
 
 ### `transactionBuilder.setTimeout(timeoutSeconds)`
 
@@ -3424,7 +3424,7 @@ setTimeout(timeoutSeconds: number): TransactionBuilder;
 - - `TimeoutInfinite`
  - https://developers.stellar.org/docs/tutorials/handling-errors/
 
-**Source:** [src/base/transaction_builder.ts:450](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L450)
+**Source:** [src/base/transaction_builder.ts:446](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L446)
 
 ## Uint128
 

--- a/docs/reference/network-rpc.md
+++ b/docs/reference/network-rpc.md
@@ -110,7 +110,7 @@ class Server {
   _getTransaction(hash: string): Promise<RawGetTransactionResponse>;
   _getTransactions(request: GetTransactionsRequest): Promise<RawGetTransactionsResponse>;
   _sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<RawSendTransactionResponse>;
-  _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, authV2: boolean = false): Promise<RawSimulateTransactionResponse>;
+  _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode): Promise<RawSimulateTransactionResponse>;
   fundAddress(address: string, friendbotUrl?: string): Promise<GetSuccessfulTransactionResponse>;
   getAccount(address: string): Promise<Account>;
   getAccountEntry(address: string): Promise<AccountEntry>;
@@ -136,7 +136,7 @@ class Server {
   prepareTransaction(tx: Transaction | FeeBumpTransaction): Promise<Transaction>;
   requestAirdrop(address: string | Pick<Account, "accountId">, friendbotUrl?: string): Promise<Account>;
   sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<SendTransactionResponse>;
-  simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, authV2: boolean = false): Promise<SimulateTransactionResponse>;
+  simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode): Promise<SimulateTransactionResponse>;
 }
 ```
 
@@ -233,7 +233,7 @@ _getLedgers(request: GetLedgersRequest): Promise<RawGetLedgersResponse>;
 
 - **`request`** — `GetLedgersRequest` (required)
 
-**Source:** [src/rpc/server.ts:1569](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1569)
+**Source:** [src/rpc/server.ts:1558](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1558)
 
 ### `server._getTransaction(hash)`
 
@@ -269,12 +269,12 @@ _sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<RawSend
 
 - **`transaction`** — `Transaction | FeeBumpTransaction` (required)
 
-**Source:** [src/rpc/server.ts:1205](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1205)
+**Source:** [src/rpc/server.ts:1194](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1194)
 
-### `server._simulateTransaction(transaction, addlResources, authMode, authV2)`
+### `server._simulateTransaction(transaction, addlResources, authMode)`
 
 ```ts
-_simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, authV2: boolean = false): Promise<RawSimulateTransactionResponse>;
+_simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode): Promise<RawSimulateTransactionResponse>;
 ```
 
 **Parameters**
@@ -282,9 +282,8 @@ _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResource
 - **`transaction`** — `Transaction | FeeBumpTransaction` (required)
 - **`addlResources`** — `ResourceLeeway` (optional)
 - **`authMode`** — `SimulationAuthMode` (optional)
-- **`authV2`** — `boolean` (optional) (default: `false`)
 
-**Source:** [src/rpc/server.ts:1047](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1047)
+**Source:** [src/rpc/server.ts:1041](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1041)
 
 ### `server.fundAddress(address, friendbotUrl)`
 
@@ -337,7 +336,7 @@ console.log("Contract funded! Hash:", tx.txHash);
 
 - `Friendbot docs`
 
-**Source:** [src/rpc/server.ts:1328](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1328)
+**Source:** [src/rpc/server.ts:1317](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1317)
 
 ### `server.getAccount(address)`
 
@@ -690,7 +689,7 @@ the fee stats
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getFeeStats
 
-**Source:** [src/rpc/server.ts:1374](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1374)
+**Source:** [src/rpc/server.ts:1363](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1363)
 
 ### `server.getHealth()`
 
@@ -876,7 +875,7 @@ const nextPage = await server.getLedgers({
 
 - `getLedgers docs`
 
-**Source:** [src/rpc/server.ts:1553](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1553)
+**Source:** [src/rpc/server.ts:1542](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1542)
 
 ### `server.getNetwork()`
 
@@ -964,7 +963,7 @@ console.log(
 - - getLedgerEntries
  - https://developers.stellar.org/docs/tokens/stellar-asset-contract
 
-**Source:** [src/rpc/server.ts:1438](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1438)
+**Source:** [src/rpc/server.ts:1427](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1427)
 
 ### `server.getTransaction(hash)`
 
@@ -1095,7 +1094,7 @@ the version info
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getVersionInfo
 
-**Source:** [src/rpc/server.ts:1388](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1388)
+**Source:** [src/rpc/server.ts:1377](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1377)
 
 ### `server.pollTransaction(hash, opts)`
 
@@ -1224,7 +1223,7 @@ server.sendTransaction(transaction).then(result => {
 - - module:rpc.assembleTransaction
  - `simulateTransaction docs`
 
-**Source:** [src/rpc/server.ts:1144](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1144)
+**Source:** [src/rpc/server.ts:1133](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1133)
 
 ### `server.requestAirdrop(address, friendbotUrl)`
 
@@ -1274,7 +1273,7 @@ server
 - - `Friendbot docs`
  - `Friendbot.Api.Response`
 
-**Source:** [src/rpc/server.ts:1250](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1250)
+**Source:** [src/rpc/server.ts:1239](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1239)
 
 ### `server.sendTransaction(transaction)`
 
@@ -1335,15 +1334,15 @@ server.sendTransaction(transaction).then((result) => {
 - - `transaction docs`
  - `sendTransaction docs`
 
-**Source:** [src/rpc/server.ts:1199](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1199)
+**Source:** [src/rpc/server.ts:1188](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1188)
 
-### `server.simulateTransaction(tx, addlResources, authMode, authV2)`
+### `server.simulateTransaction(tx, addlResources, authMode)`
 
 Submit a trial contract invocation to get back return values, expected
 ledger footprint, expected authorizations, and expected costs.
 
 ```ts
-simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, authV2: boolean = false): Promise<SimulateTransactionResponse>;
+simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode): Promise<SimulateTransactionResponse>;
 ```
 
 **Parameters**
@@ -1360,11 +1359,6 @@ simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: Resour
      auth mode to use for simulation: `enforce` for enforcement mode,
      `record` for recording mode, or `record_allow_nonroot` for recording
      mode that allows non-root authorization
-- **`authV2`** — `boolean` (optional) (default: `false`) — (optional) request `SOROBAN_CREDENTIALS_ADDRESS_V2`
-     (CAP-71) auth credentials from simulation instead of the legacy
-     `SOROBAN_CREDENTIALS_ADDRESS`. Defaults to `false`; only enable it for
-     networks that have activated CAP-71, as V2 credentials are otherwise
-     rejected.
 
 **Returns**
 
@@ -1406,7 +1400,7 @@ server.simulateTransaction(transaction).then((sim) => {
  - module:rpc.Server#prepareTransaction
  - module:rpc.assembleTransaction
 
-**Source:** [src/rpc/server.ts:1036](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1036)
+**Source:** [src/rpc/server.ts:1031](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1031)
 
 ## rpc.assembleTransaction
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/stellar-sdk",
-  "version": "16.0.0-rc.2",
+  "version": "16.0.0",
   "type": "module",
   "packageManager": "pnpm@10.28.0",
   "description": "A library for working with the Stellar network, including communication with the Horizon and Soroban RPC servers.",

--- a/src/base/transaction_builder.ts
+++ b/src/base/transaction_builder.ts
@@ -334,10 +334,6 @@ export class TransactionBuilder {
       networkPassphrase: tx.networkPassphrase,
     };
 
-    if (sorobanData) {
-      builderOpts.sorobanData = sorobanData;
-    }
-
     if (tx.timeBounds) {
       builderOpts.timebounds = tx.timeBounds;
     }

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -654,12 +654,7 @@ export class AssembledTransaction<T> {
     // need to force re-calculation of simulationData for new simulation
     delete this.simulationResult;
     delete this.simulationTransactionData;
-    this.simulation = await this.server.simulateTransaction(
-      this.built,
-      undefined,
-      undefined,
-      this.options.authV2,
-    );
+    this.simulation = await this.server.simulateTransaction(this.built);
 
     if (restore && Api.isSimulationRestore(this.simulation)) {
       const account = await getAccount(this.options, this.server);

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -230,16 +230,6 @@ export type MethodOptions = {
   restore?: boolean;
 
   /**
-   * Request `SOROBAN_CREDENTIALS_ADDRESS_V2` (CAP-71) auth credentials from
-   * simulation instead of the legacy `SOROBAN_CREDENTIALS_ADDRESS`. V2
-   * credentials are only valid on networks that have activated CAP-71, so leave
-   * this off until the activation vote passes for your target network. The
-   * default flips to `true` once V2 becomes mandatory.
-   * @defaultValue false
-   */
-  authV2?: boolean;
-
-  /**
    * The public key of the source account for this transaction.
    *
    * Default: the one provided to the {@link Client} in {@link ClientOptions}

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -988,11 +988,6 @@ export class RpcServer {
    *    auth mode to use for simulation: `enforce` for enforcement mode,
    *    `record` for recording mode, or `record_allow_nonroot` for recording
    *    mode that allows non-root authorization
-   * @param authV2 - (optional) request `SOROBAN_CREDENTIALS_ADDRESS_V2`
-   *    (CAP-71) auth credentials from simulation instead of the legacy
-   *    `SOROBAN_CREDENTIALS_ADDRESS`. Defaults to `false`; only enable it for
-   *    networks that have activated CAP-71, as V2 credentials are otherwise
-   *    rejected.
    *
    * @returns An object with the
    *    cost, footprint, result/auth requirements (if applicable), and error of
@@ -1037,9 +1032,8 @@ export class RpcServer {
     tx: Transaction | FeeBumpTransaction,
     addlResources?: RpcServer.ResourceLeeway,
     authMode?: Api.SimulationAuthMode,
-    authV2: boolean = false,
   ): Promise<Api.SimulateTransactionResponse> {
-    return this._simulateTransaction(tx, addlResources, authMode, authV2).then(
+    return this._simulateTransaction(tx, addlResources, authMode).then(
       parseRawSimulation,
     );
   }
@@ -1048,7 +1042,6 @@ export class RpcServer {
     transaction: Transaction | FeeBumpTransaction,
     addlResources?: RpcServer.ResourceLeeway,
     authMode?: Api.SimulationAuthMode,
-    authV2: boolean = false,
   ): Promise<Api.RawSimulateTransactionResponse> {
     return jsonrpc.postObject(
       this.httpClient,
@@ -1062,10 +1055,6 @@ export class RpcServer {
             instructionLeeway: addlResources.cpuInstructions,
           },
         }),
-        // CAP-71: only request ADDRESS_V2 auth credentials when explicitly
-        // opted in. They are rejected by networks that have not activated
-        // CAP-71, so default to omitting the flag (legacy ADDRESS credentials).
-        ...(authV2 && { authV2: true }),
       },
     );
   }

--- a/test/unit/base/transaction_builder.test.ts
+++ b/test/unit/base/transaction_builder.test.ts
@@ -1725,12 +1725,9 @@ describe("TransactionBuilder.cloneFrom", () => {
     expect(builder.baseFee).toBe("150");
 
     const cloneTx = builder.build();
-    expect(cloneTx.fee).toBe(tx.fee);
-    expect(
-      expectDefined(cloneTx.toEnvelope().v1().tx().ext().value())
-        .resourceFee()
-        .toString(),
-    ).toBe(resourceFee);
+    // The cloned transaction does not include the original transactions xdr.SorobanTransactionData so
+    // it does not have a resource fee
+    expect(cloneTx.fee).toBe("150");
   });
 
   it("skips the resource fee subtraction when it would zero out the fee", () => {

--- a/test/unit/server/soroban/simulate_transaction.test.ts
+++ b/test/unit/server/soroban/simulate_transaction.test.ts
@@ -439,36 +439,6 @@ describe("Server#simulateTransaction", () => {
     });
   });
 
-  it("omits authV2 by default and requests it when opted in", async () => {
-    const mockResponse = { data: { id: 1, result: simulationResponse } };
-    mockPost.mockResolvedValue(mockResponse);
-
-    // default: no authV2 field on the wire (legacy ADDRESS credentials)
-    await server.simulateTransaction(transaction);
-    expect(mockPost).toHaveBeenLastCalledWith(serverUrl, {
-      jsonrpc: "2.0",
-      id: 1,
-      method: "simulateTransaction",
-      params: {
-        transaction: blob,
-        authMode: undefined,
-      },
-    });
-
-    // opt-in: authV2: true requests CAP-71 ADDRESS_V2 credentials
-    await server.simulateTransaction(transaction, undefined, undefined, true);
-    expect(mockPost).toHaveBeenLastCalledWith(serverUrl, {
-      jsonrpc: "2.0",
-      id: 1,
-      method: "simulateTransaction",
-      params: {
-        transaction: blob,
-        authMode: undefined,
-        authV2: true,
-      },
-    });
-  });
-
   it.skipIf(
     typeof window !== "undefined" &&
       (window as any).__STELLAR_SDK_BROWSER_TEST__,


### PR DESCRIPTION
## What

- Reverts copying of `xdr.SorobanTransactionData` in `TransactionBuilder.cloneFrom`
- Updates the changelog with the aggregated list of changes 
- Set the package version to full v16.0.0 release
- Reverts `authV2` parameter field on the `rpc.Server.simulateTransaction` until confirmed on the RPC