### PR TITLE
Harden CLI --timeout validation against silent truncation

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -125,7 +125,13 @@ function runCli() {
         let timeout: number | undefined;
         if (options.timeout) {
           timeout = parseInt(options.timeout, 10);
-          if (Number.isNaN(timeout) || timeout <= 0) {
+          // strict: reject trailing garbage / decimals that parseInt would
+          // otherwise silently truncate (e.g. "10abc" -> 10, "10.9" -> 10)
+          if (
+            Number.isNaN(timeout) ||
+            timeout <= 0 ||
+            String(timeout) !== options.timeout.trim()
+          ) {
             throw new Error(
               `Invalid timeout value: ${options.timeout}. Must be a positive integer.`,
             );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -125,13 +125,9 @@ function runCli() {
         let timeout: number | undefined;
         if (options.timeout) {
           timeout = parseInt(options.timeout, 10);
-          // strict: reject trailing garbage / decimals that parseInt would
-          // otherwise silently truncate (e.g. "10abc" -> 10, "10.9" -> 10)
-          if (
-            Number.isNaN(timeout) ||
-            timeout <= 0 ||
-            String(timeout) !== options.timeout.trim()
-          ) {
+          // require digits only, so values parseInt would otherwise silently
+          // truncate ("10abc" -> 10, "10.9" -> 10) are rejected
+          if (!/^\d+$/.test(options.timeout.trim()) || timeout <= 0) {
             throw new Error(
               `Invalid timeout value: ${options.timeout}. Must be a positive integer.`,
             );

--- a/test/e2e/src/cli.test.ts
+++ b/test/e2e/src/cli.test.ts
@@ -347,6 +347,30 @@ describe("CLI generate command", () => {
       expect(result.stderr).toContain("Invalid timeout");
     });
 
+    it("fails with trailing garbage in timeout value", () => {
+      const wasmPath = contracts.customTypes.path;
+      const testOutputDir = path.join(outputDir, "trailing-garbage-timeout");
+
+      const result = runCli(
+        `generate --wasm ${wasmPath} --output-dir ${testOutputDir} --timeout 10abc`,
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Invalid timeout");
+    });
+
+    it("fails with decimal timeout value", () => {
+      const wasmPath = contracts.customTypes.path;
+      const testOutputDir = path.join(outputDir, "decimal-timeout");
+
+      const result = runCli(
+        `generate --wasm ${wasmPath} --output-dir ${testOutputDir} --timeout 10.9`,
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Invalid timeout");
+    });
+
     it("fails with invalid JSON for --headers", () => {
       const wasmPath = contracts.customTypes.path;
       const testOutputDir = path.join(outputDir, "invalid-headers");


### PR DESCRIPTION
## What changed

Tightened `--timeout` validation in the CLI to require digits-only input. Previously `parseInt` silently truncated malformed values (`10.9` → 10, `10abc` → 10); these now error instead. Leading zeros and whitespace are still accepted.

Added two e2e test cases covering both inputs.

## What we didn't change, and why

This started as a broader "replace `parseInt` with `BigInt`" idea. After auditing all 9 `parseInt` sites, we left the other 8 as-is:

- **`BigInt` is only the right tool for genuine int64 precision loss (>2⁵³)**, and none of these sites carry such values in normal operation — fees are small, the SEP-10 sequence must be `0`, timebounds are Unix timestamps, and prices are `Int32`. A blanket swap would also break the public `fetchBaseFee` return type, throw on `bigint`↔`number` math, and break JSON serialization — for no precision gain.
- **The remaining sites are already safe** — either SDK-internal (always-numeric strings that fail safe on bad input) or already guarded (`|| 100` fallback in `fetchBaseFee`, a `\d+` regex for contract-error codes).

The CLI `--timeout` was the only site taking direct human input where a typo produced a silently-wrong value, so it was the one worth hardening.