### PR TITLE
Add `rpc.Server.getContractMethods` for contract method discovery

### DIFF
--- a/docs/guides/06-invoke-a-contract.md
+++ b/docs/guides/06-invoke-a-contract.md
@@ -23,7 +23,8 @@ free and safe to repeat.
   [Deploy the Increment Contract](https://developers.stellar.org/docs/build/smart-contracts/getting-started/deploy-increment-contract)
   tutorial once (about 20 to 30 minutes), then paste the contract ID it prints
   into `contractId` below. You will not touch the CLI again in this guide.
-  Generating a typed client from a contract is covered later in the series.
+  This guide types the client with a small hand-written interface; generating one
+  from a contract's spec is covered later in the series.
 - The examples use testnet RPC at `https://soroban-testnet.stellar.org`.
 
 ## Connect and load the contract
@@ -41,9 +42,18 @@ import { contract, Keypair, Networks } from "@stellar/stellar-sdk";
 const rpcUrl = "https://soroban-testnet.stellar.org";
 const networkPassphrase = Networks.TESTNET;
 
+// Describe just the methods you call. `Client.from<T>()` uses this to type the
+// returned client, so the calls below are checked and autocompleted — no code
+// generation needed.
+interface IncrementContract {
+  increment: (
+    options?: contract.MethodOptions,
+  ) => Promise<contract.AssembledTransaction<number>>;
+}
+
 const { signTransaction } = contract.basicNodeSigner(keypair, networkPassphrase);
 
-const client = await contract.Client.from({
+const client = await contract.Client.from<IncrementContract>({
   contractId,
   rpcUrl,
   networkPassphrase,
@@ -54,10 +64,12 @@ const client = await contract.Client.from({
 
 Here `keypair` is your funded account from
 [Connect and Fund an Account](/guides/01-connect-and-fund/) and `contractId` is
-your deployed contract's `C...` ID. Because the client is built from the live
-contract at runtime, its methods are **not typed**: TypeScript does not know
-`client.increment` exists, so calls below use `(client as any)`. A fully typed
-client comes from generating bindings, covered later in the series.
+your deployed contract's `C...` ID. The client is built from the live contract at
+runtime, so TypeScript cannot infer its methods on its own. Passing an interface
+to [`Client.from<T>()`](/reference/contracts-client/#contractclient) types them:
+`client.increment()` below is fully typed and autocompleted, with no code
+generation. For a contract with many methods, generate that interface from its
+spec (covered later in the series) rather than writing it by hand.
 
 ## Query contract state
 
@@ -108,7 +120,7 @@ no signature. Read the predicted return value from
 [`tx.result`](/reference/contracts-client/#contractassembledtransaction):
 
 ```ts
-const tx = await (client as any).increment();
+const tx = await client.increment();
 
 tx.result; // the value the call would return; nothing has been sent
 ```
@@ -153,6 +165,12 @@ const rpcUrl = "https://soroban-testnet.stellar.org";
 const networkPassphrase = Networks.TESTNET;
 const contractId = "C..."; // your deployed increment contract (see Prerequisites)
 
+interface IncrementContract {
+  increment: (
+    options?: contract.MethodOptions,
+  ) => Promise<contract.AssembledTransaction<number>>;
+}
+
 async function main() {
   const server = new rpc.Server(rpcUrl);
   const keypair = Keypair.random();
@@ -165,7 +183,7 @@ async function main() {
     // Fund a throwaway account to invoke from (the RPC-side friendbot).
     await server.fundAddress(keypair.publicKey());
 
-    const client = await contract.Client.from({
+    const client = await contract.Client.from<IncrementContract>({
       contractId,
       rpcUrl,
       networkPassphrase,
@@ -174,7 +192,7 @@ async function main() {
     });
 
     // Preview the call for free with simulation.
-    const tx = await (client as any).increment();
+    const tx = await client.increment();
     console.log("preview:", tx.result);
 
     // Sign and send to apply it on-chain.

--- a/docs/guides/06-invoke-a-contract.md
+++ b/docs/guides/06-invoke-a-contract.md
@@ -59,6 +59,46 @@ contract at runtime, its methods are **not typed**: TypeScript does not know
 `client.increment` exists, so calls below use `(client as any)`. A fully typed
 client comes from generating bindings, covered later in the series.
 
+## Query contract state
+
+Sometimes you only want to **inspect** a contract or **read** a value from it, not
+change anything. For that, `rpc.Server` has two one-line shortcuts that build the
+contract's interface for you — including the built-in spec for Stellar Asset
+Contracts (SACs) — so they work from just a contract ID, with no client setup.
+
+[`getContractMethods`](/reference/network-rpc/#servergetcontractmethodscontractid-networkpassphrase)
+lists a contract's callable methods and their signatures, which is handy when you
+are inspecting a contract you did not write.
+[`queryContract`](/reference/network-rpc/#serverquerycontractcontractid-method-args-networkpassphrase)
+runs a **read-only**
+call and returns the decoded result. It simulates the call the same way the preview
+below does, so it needs no signing or fee, but it hands you the value directly. Here
+both run against a token contract — discover its methods, then read one:
+
+```ts
+import { rpc } from "@stellar/stellar-sdk";
+
+const server = new rpc.Server(rpcUrl);
+
+// Discover what the contract exposes, from just its ID.
+const methods = await server.getContractMethods(tokenId);
+// [
+//   { name: "decimals", inputs: [], outputs: ["U32"] },
+//   { name: "balance", inputs: [{ name: "id", type: "Address" }], outputs: ["I128"] },
+//   { name: "transfer", inputs: [...], outputs: [] },
+// ]
+
+// Read one of its read-only methods in a single line.
+const decimals = await server.queryContract<number>(tokenId, "decimals");
+
+const balance = await server.queryContract<bigint>(tokenId, "balance", {
+  id: "G...", // named arguments, keyed by the method's parameter names
+});
+```
+
+`queryContract` is for reads only. To **change** state you build a client and sign a
+transaction, as shown next.
+
 ## Preview a call with simulation
 
 Calling a contract method does not send anything yet: it builds a transaction and

--- a/docs/guides/07-contract-auth.md
+++ b/docs/guides/07-contract-auth.md
@@ -108,7 +108,7 @@ authorization entry that account must sign. Build the transaction as in
 need to sign:
 
 ```ts
-const tx = await (client as any).increment({ user: signer.publicKey(), value: 1 });
+const tx = await client.increment({ user: signer.publicKey(), value: 1 });
 
 tx.needsNonInvokerSigningBy(); // [signer.publicKey()]
 ```
@@ -218,6 +218,13 @@ const rpcUrl = "https://soroban-testnet.stellar.org";
 const networkPassphrase = Networks.TESTNET;
 const contractId = "C..."; // your deployed Auth contract (see Prerequisites)
 
+interface AuthContract {
+  increment: (
+    args: { user: string; value: number },
+    options?: contract.MethodOptions,
+  ) => Promise<contract.AssembledTransaction<number>>;
+}
+
 async function main() {
   const server = new rpc.Server(rpcUrl);
 
@@ -234,7 +241,7 @@ async function main() {
       source,
       networkPassphrase,
     );
-    const client = await contract.Client.from({
+    const client = await contract.Client.from<AuthContract>({
       contractId,
       rpcUrl,
       networkPassphrase,
@@ -243,7 +250,7 @@ async function main() {
     });
 
     // A call that requires `signer` (not the source) to authorize it.
-    const tx = await (client as any).increment({
+    const tx = await client.increment({
       user: signer.publicKey(),
       value: 1,
     });

--- a/docs/reference/network-rpc.md
+++ b/docs/reference/network-rpc.md
@@ -118,6 +118,7 @@ class Server {
   getClaimableBalance(id: string): Promise<ClaimableBalanceEntry>;
   getContractData(contract: string | Address | Contract, key: ScVal, durability: Durability = Durability.Persistent): Promise<LedgerEntryResult>;
   getContractInstance(contractId: string): Promise<ScContractInstance>;
+  getContractMethods(contractId: string, networkPassphrase?: string): Promise<ContractMethod[]>;
   getContractWasmByContractId(contractId: string): Promise<Buffer<ArrayBufferLike>>;
   getContractWasmByHash(wasmHash: string | Buffer<ArrayBufferLike>, format: "base64" | "hex" | undefined = undefined): Promise<Buffer<ArrayBufferLike>>;
   getEvents(request: GetEventsRequest): Promise<GetEventsResponse>;
@@ -159,7 +160,7 @@ constructor(serverURL: string, opts: Options = {});
 - **`serverURL`** — `string` (required)
 - **`opts`** — `Options` (optional) (default: `{}`)
 
-**Source:** [src/rpc/server.ts:170](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L170)
+**Source:** [src/rpc/server.ts:182](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L182)
 
 ### `server.httpClient`
 
@@ -183,7 +184,7 @@ server.httpClient.interceptors.request.use((config) => {
 });
 ```
 
-**Source:** [src/rpc/server.ts:169](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L169)
+**Source:** [src/rpc/server.ts:181](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L181)
 
 ### `server.serverURL`
 
@@ -191,7 +192,7 @@ server.httpClient.interceptors.request.use((config) => {
 readonly serverURL: URL;
 ```
 
-**Source:** [src/rpc/server.ts:152](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L152)
+**Source:** [src/rpc/server.ts:164](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L164)
 
 ### `server._getEvents(request)`
 
@@ -203,7 +204,7 @@ _getEvents(request: GetEventsRequest): Promise<RawGetEventsResponse>;
 
 - **`request`** — `GetEventsRequest` (required)
 
-**Source:** [src/rpc/server.ts:1022](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1022)
+**Source:** [src/rpc/server.ts:1105](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1105)
 
 ### `server._getLatestLedger()`
 
@@ -211,7 +212,7 @@ _getEvents(request: GetEventsRequest): Promise<RawGetEventsResponse>;
 _getLatestLedger(): Promise<RawGetLatestLedgerResponse>;
 ```
 
-**Source:** [src/rpc/server.ts:1093](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1093)
+**Source:** [src/rpc/server.ts:1176](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1176)
 
 ### `server._getLedgerEntries(keys)`
 
@@ -223,7 +224,7 @@ _getLedgerEntries(...keys: LedgerKey[]): Promise<RawGetLedgerEntriesResponse>;
 
 - **`...keys`** — `LedgerKey[]` (required)
 
-**Source:** [src/rpc/server.ts:787](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L787)
+**Source:** [src/rpc/server.ts:870](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L870)
 
 ### `server._getLedgers(request)`
 
@@ -235,7 +236,7 @@ _getLedgers(request: GetLedgersRequest): Promise<RawGetLedgersResponse>;
 
 - **`request`** — `GetLedgersRequest` (required)
 
-**Source:** [src/rpc/server.ts:1684](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1684)
+**Source:** [src/rpc/server.ts:1767](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1767)
 
 ### `server._getTransaction(hash)`
 
@@ -247,7 +248,7 @@ _getTransaction(hash: string): Promise<RawGetTransactionResponse>;
 
 - **`hash`** — `string` (required)
 
-**Source:** [src/rpc/server.ts:910](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L910)
+**Source:** [src/rpc/server.ts:993](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L993)
 
 ### `server._getTransactions(request)`
 
@@ -259,7 +260,7 @@ _getTransactions(request: GetTransactionsRequest): Promise<RawGetTransactionsRes
 
 - **`request`** — `GetTransactionsRequest` (required)
 
-**Source:** [src/rpc/server.ts:961](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L961)
+**Source:** [src/rpc/server.ts:1044](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1044)
 
 ### `server._sendTransaction(transaction)`
 
@@ -271,7 +272,7 @@ _sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<RawSend
 
 - **`transaction`** — `Transaction | FeeBumpTransaction` (required)
 
-**Source:** [src/rpc/server.ts:1320](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1320)
+**Source:** [src/rpc/server.ts:1403](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1403)
 
 ### `server._simulateTransaction(transaction, addlResources, authMode)`
 
@@ -285,7 +286,7 @@ _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResource
 - **`addlResources`** — `ResourceLeeway` (optional)
 - **`authMode`** — `SimulationAuthMode` (optional)
 
-**Source:** [src/rpc/server.ts:1167](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1167)
+**Source:** [src/rpc/server.ts:1250](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1250)
 
 ### `server.fundAddress(address, friendbotUrl)`
 
@@ -338,7 +339,7 @@ console.log("Contract funded! Hash:", tx.txHash);
 
 - `Friendbot docs`
 
-**Source:** [src/rpc/server.ts:1443](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1443)
+**Source:** [src/rpc/server.ts:1526](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1526)
 
 ### `server.getAccount(address)`
 
@@ -373,7 +374,7 @@ server.getAccount(accountId).then((account) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:203](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L203)
+**Source:** [src/rpc/server.ts:215](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L215)
 
 ### `server.getAccountEntry(address)`
 
@@ -405,7 +406,7 @@ server.getAccountEntry(accountId).then((account) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:226](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L226)
+**Source:** [src/rpc/server.ts:238](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L238)
 
 ### `server.getAssetBalance(address, asset, networkPassphrase)`
 
@@ -451,7 +452,7 @@ const balance = await server.getAssetBalance("GD...", usdc);
 console.log(balance.balanceEntry?.amount);
 ```
 
-**Source:** [src/rpc/server.ts:376](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L376)
+**Source:** [src/rpc/server.ts:388](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L388)
 
 ### `server.getClaimableBalance(id)`
 
@@ -487,7 +488,7 @@ server.getClaimableBalance(id).then((entry) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:308](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L308)
+**Source:** [src/rpc/server.ts:320](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L320)
 
 ### `server.getContractData(contract, key, durability)`
 
@@ -535,7 +536,7 @@ server.getContractData(contractId, key, Durability.Temporary).then(data => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:477](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L477)
+**Source:** [src/rpc/server.ts:489](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L489)
 
 ### `server.getContractInstance(contractId)`
 
@@ -569,7 +570,52 @@ const instance = await server.getContractInstance(
 console.log(instance.executable().switch().name);
 ```
 
-**Source:** [src/rpc/server.ts:546](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L546)
+**Source:** [src/rpc/server.ts:558](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L558)
+
+### `server.getContractMethods(contractId, networkPassphrase)`
+
+Lists a contract's callable methods and their signatures.
+
+A discovery helper for tooling, dapps, and agents that need to inspect an
+arbitrary contract without knowing its interface up front. It resolves the
+contract's spec (embedded in the Wasm for regular contracts, or the
+built-in spec for Stellar Asset Contracts — see `contract.Client.from`)
+and reports each declared function's name, inputs, and outputs. No method
+is invoked or simulated; this performs only the spec lookup.
+
+The complement to `queryContract`: list methods here, then call a
+read-only one with `server.queryContract(contractId, method, args?)`.
+
+```ts
+getContractMethods(contractId: string, networkPassphrase?: string): Promise<ContractMethod[]>;
+```
+
+**Parameters**
+
+- **`contractId`** — `string` (required) — the contract to inspect (`C...`)
+- **`networkPassphrase`** — `string` (optional) — (optional) the network passphrase. If omitted, a
+     request about network information will be made (see `getNetwork`).
+     You can refer to `Networks` for a list of built-in passphrases,
+     e.g., `Networks.TESTNET`.
+
+**Returns**
+
+The contract's methods, in the order they appear in the spec
+
+**Example**
+
+```ts
+const methods = await server.getContractMethods(
+  "CCJZ5DGASBWQXR5MPFCJXMBI333XE5U3FSJTNQU7RIKE3P5GN2K2WYD5",
+);
+// [
+//   { name: "decimals", inputs: [], outputs: ["U32"] },
+//   { name: "balance", inputs: [{ name: "id", type: "Address" }], outputs: ["I128"] },
+//   { name: "transfer", inputs: [...], outputs: [] },
+// ]
+```
+
+**Source:** [src/rpc/server.ts:793](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L793)
 
 ### `server.getContractWasmByContractId(contractId)`
 
@@ -612,7 +658,7 @@ server.getContractWasmByContractId(contractId).then(wasmBuffer => {
 });
 ```
 
-**Source:** [src/rpc/server.ts:588](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L588)
+**Source:** [src/rpc/server.ts:600](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L600)
 
 ### `server.getContractWasmByHash(wasmHash, format)`
 
@@ -652,7 +698,7 @@ server.getContractWasmByHash(wasmHash).then(wasmBuffer => {
 });
 ```
 
-**Source:** [src/rpc/server.ts:632](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L632)
+**Source:** [src/rpc/server.ts:644](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L644)
 
 ### `server.getEvents(request)`
 
@@ -710,7 +756,7 @@ server.getEvents({
 
 - `getEvents docs`
 
-**Source:** [src/rpc/server.ts:1016](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1016)
+**Source:** [src/rpc/server.ts:1099](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1099)
 
 ### `server.getFeeStats()`
 
@@ -729,7 +775,7 @@ the fee stats
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getFeeStats
 
-**Source:** [src/rpc/server.ts:1489](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1489)
+**Source:** [src/rpc/server.ts:1572](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1572)
 
 ### `server.getHealth()`
 
@@ -757,7 +803,7 @@ server.getHealth().then((health) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:435](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L435)
+**Source:** [src/rpc/server.ts:447](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L447)
 
 ### `server.getLatestLedger()`
 
@@ -787,7 +833,7 @@ server.getLatestLedger().then((response) => {
 
 - `getLatestLedger docs`
 
-**Source:** [src/rpc/server.ts:1089](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1089)
+**Source:** [src/rpc/server.ts:1172](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1172)
 
 ### `server.getLedgerEntries(keys)`
 
@@ -837,7 +883,7 @@ server.getLedgerEntries([key]).then(response => {
 - - `getLedgerEntries docs`
  - RpcServer._getLedgerEntries
 
-**Source:** [src/rpc/server.ts:783](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L783)
+**Source:** [src/rpc/server.ts:866](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L866)
 
 ### `server.getLedgerEntry(key)`
 
@@ -849,7 +895,7 @@ getLedgerEntry(key: LedgerKey): Promise<LedgerEntryResult>;
 
 - **`key`** — `LedgerKey` (required)
 
-**Source:** [src/rpc/server.ts:798](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L798)
+**Source:** [src/rpc/server.ts:881](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L881)
 
 ### `server.getLedgers(request)`
 
@@ -915,7 +961,7 @@ const nextPage = await server.getLedgers({
 
 - `getLedgers docs`
 
-**Source:** [src/rpc/server.ts:1668](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1668)
+**Source:** [src/rpc/server.ts:1751](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1751)
 
 ### `server.getNetwork()`
 
@@ -944,7 +990,7 @@ server.getNetwork().then((network) => {
 
 - `getNetwork docs`
 
-**Source:** [src/rpc/server.ts:1063](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1063)
+**Source:** [src/rpc/server.ts:1146](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1146)
 
 ### `server.getSACBalance(address, sac, networkPassphrase)`
 
@@ -1003,7 +1049,7 @@ console.log(
 - - getLedgerEntries
  - https://developers.stellar.org/docs/tokens/stellar-asset-contract
 
-**Source:** [src/rpc/server.ts:1553](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1553)
+**Source:** [src/rpc/server.ts:1636](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1636)
 
 ### `server.getTransaction(hash)`
 
@@ -1041,7 +1087,7 @@ server.getTransaction(transactionHash).then((tx) => {
 
 - `getTransaction docs`
 
-**Source:** [src/rpc/server.ts:883](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L883)
+**Source:** [src/rpc/server.ts:966](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L966)
 
 ### `server.getTransactions(request)`
 
@@ -1077,7 +1123,7 @@ server.getTransactions({
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getTransactions
 
-**Source:** [src/rpc/server.ts:943](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L943)
+**Source:** [src/rpc/server.ts:1026](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1026)
 
 ### `server.getTrustline(account, asset)`
 
@@ -1116,7 +1162,7 @@ server.getTrustline(accountId, asset).then((entry) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:265](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L265)
+**Source:** [src/rpc/server.ts:277](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L277)
 
 ### `server.getVersionInfo()`
 
@@ -1134,7 +1180,7 @@ the version info
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getVersionInfo
 
-**Source:** [src/rpc/server.ts:1503](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1503)
+**Source:** [src/rpc/server.ts:1586](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1586)
 
 ### `server.pollTransaction(hash, opts)`
 
@@ -1174,7 +1220,7 @@ const txStatus = await server.pollTransaction(h, {
 }); // this will take 5,050 seconds to complete
 ```
 
-**Source:** [src/rpc/server.ts:836](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L836)
+**Source:** [src/rpc/server.ts:919](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L919)
 
 ### `server.prepareTransaction(tx)`
 
@@ -1263,7 +1309,7 @@ server.sendTransaction(transaction).then(result => {
 - - module:rpc.assembleTransaction
  - `simulateTransaction docs`
 
-**Source:** [src/rpc/server.ts:1259](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1259)
+**Source:** [src/rpc/server.ts:1342](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1342)
 
 ### `server.queryContract(contractId, method, args, networkPassphrase)`
 
@@ -1316,7 +1362,7 @@ const balance = await server.queryContract<bigint>(
 );
 ```
 
-**Source:** [src/rpc/server.ts:697](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L697)
+**Source:** [src/rpc/server.ts:709](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L709)
 
 ### `server.requestAirdrop(address, friendbotUrl)`
 
@@ -1366,7 +1412,7 @@ server
 - - `Friendbot docs`
  - `Friendbot.Api.Response`
 
-**Source:** [src/rpc/server.ts:1365](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1365)
+**Source:** [src/rpc/server.ts:1448](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1448)
 
 ### `server.sendTransaction(transaction)`
 
@@ -1427,7 +1473,7 @@ server.sendTransaction(transaction).then((result) => {
 - - `transaction docs`
  - `sendTransaction docs`
 
-**Source:** [src/rpc/server.ts:1314](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1314)
+**Source:** [src/rpc/server.ts:1397](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1397)
 
 ### `server.simulateTransaction(tx, addlResources, authMode)`
 
@@ -1493,7 +1539,7 @@ server.simulateTransaction(transaction).then((sim) => {
  - module:rpc.Server#prepareTransaction
  - module:rpc.assembleTransaction
 
-**Source:** [src/rpc/server.ts:1157](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1157)
+**Source:** [src/rpc/server.ts:1240](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1240)
 
 ## rpc.assembleTransaction
 
@@ -1698,6 +1744,95 @@ latestLedger: number;
 ```
 
 **Source:** [src/rpc/api.ts:415](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/api.ts#L415)
+
+### rpc.Api.ContractMethod
+
+A callable method declared in a contract's spec, as returned by
+`RpcServer.getContractMethods`.
+
+```ts
+interface ContractMethod {
+  doc?: string;
+  inputs: ContractMethodInput[];
+  name: string;
+  outputs: string[];
+}
+```
+
+**Source:** [src/rpc/api.ts:717](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/api.ts#L717)
+
+#### `contractMethod.doc`
+
+the method's spec doc string, when the contract declares one
+
+```ts
+doc?: string;
+```
+
+**Source:** [src/rpc/api.ts:725](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/api.ts#L725)
+
+#### `contractMethod.inputs`
+
+the method's parameters, in declaration order
+
+```ts
+inputs: ContractMethodInput[];
+```
+
+**Source:** [src/rpc/api.ts:721](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/api.ts#L721)
+
+#### `contractMethod.name`
+
+the on-chain method name
+
+```ts
+name: string;
+```
+
+**Source:** [src/rpc/api.ts:719](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/api.ts#L719)
+
+#### `contractMethod.outputs`
+
+human-readable return type name(s); empty when the method returns void
+
+```ts
+outputs: string[];
+```
+
+**Source:** [src/rpc/api.ts:723](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/api.ts#L723)
+
+### rpc.Api.ContractMethodInput
+
+A single input parameter of a `ContractMethod`.
+
+```ts
+interface ContractMethodInput {
+  name: string;
+  type: string;
+}
+```
+
+**Source:** [src/rpc/api.ts:706](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/api.ts#L706)
+
+#### `contractMethodInput.name`
+
+the declared parameter name
+
+```ts
+name: string;
+```
+
+**Source:** [src/rpc/api.ts:708](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/api.ts#L708)
+
+#### `contractMethodInput.type`
+
+a human-readable type name, e.g. `U32`, `Address`, or a UDT's name
+
+```ts
+type: string;
+```
+
+**Source:** [src/rpc/api.ts:710](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/api.ts#L710)
 
 ### rpc.Api.EventFilter
 

--- a/src/rpc/api.ts
+++ b/src/rpc/api.ts
@@ -701,4 +701,27 @@ export namespace Api {
     /** a base-64 encoded {@link xdr.LedgerCloseMeta} instance */
     metadataXdr: string;
   }
+
+  /** A single input parameter of a {@link ContractMethod}. */
+  export interface ContractMethodInput {
+    /** the declared parameter name */
+    name: string;
+    /** a human-readable type name, e.g. `U32`, `Address`, or a UDT's name */
+    type: string;
+  }
+
+  /**
+   * A callable method declared in a contract's spec, as returned by
+   * `RpcServer.getContractMethods`.
+   */
+  export interface ContractMethod {
+    /** the on-chain method name */
+    name: string;
+    /** the method's parameters, in declaration order */
+    inputs: ContractMethodInput[];
+    /** human-readable return type name(s); empty when the method returns void */
+    outputs: string[];
+    /** the method's spec doc string, when the contract declares one */
+    doc?: string;
+  }
 }

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -135,6 +135,18 @@ function findCreatedAccountSequenceInTransactionMeta(
 }
 
 /**
+ * Best-effort, human-readable name for a contract spec type, e.g.
+ * `scSpecTypeU32` becomes `U32` and `scSpecTypeAddress` becomes `Address`.
+ * User-defined types (structs/enums/unions) are shown by their declared name.
+ */
+function contractSpecTypeName(td: xdr.ScSpecTypeDef): string {
+  if (td.switch().value === xdr.ScSpecType.scSpecTypeUdt().value) {
+    return td.udt().name().toString();
+  }
+  return td.switch().name.replace(/^scSpecType/, "");
+}
+
+/**
  * Handles the network connection to a Soroban RPC instance, exposing an
  * interface for requests to that instance.
  *
@@ -744,6 +756,77 @@ export class RpcServer {
     // true); `.result` is the spec-decoded return value.
     const assembled = await invoke(args);
     return assembled.result as T;
+  }
+
+  /**
+   * Lists a contract's callable methods and their signatures.
+   *
+   * A discovery helper for tooling, dapps, and agents that need to inspect an
+   * arbitrary contract without knowing its interface up front. It resolves the
+   * contract's spec (embedded in the Wasm for regular contracts, or the
+   * built-in spec for Stellar Asset Contracts — see {@link contract.Client.from})
+   * and reports each declared function's name, inputs, and outputs. No method
+   * is invoked or simulated; this performs only the spec lookup.
+   *
+   * The complement to {@link queryContract}: list methods here, then call a
+   * read-only one with `server.queryContract(contractId, method, args?)`.
+   *
+   * @param contractId - the contract to inspect (`C...`)
+   * @param networkPassphrase - (optional) the network passphrase. If omitted, a
+   *    request about network information will be made (see {@link getNetwork}).
+   *    You can refer to {@link Networks} for a list of built-in passphrases,
+   *    e.g., `Networks.TESTNET`.
+   * @returns The contract's methods, in the order they appear in the spec
+   *
+   * @example
+   * ```ts
+   * const methods = await server.getContractMethods(
+   *   "CCJZ5DGASBWQXR5MPFCJXMBI333XE5U3FSJTNQU7RIKE3P5GN2K2WYD5",
+   * );
+   * // [
+   * //   { name: "decimals", inputs: [], outputs: ["U32"] },
+   * //   { name: "balance", inputs: [{ name: "id", type: "Address" }], outputs: ["I128"] },
+   * //   { name: "transfer", inputs: [...], outputs: [] },
+   * // ]
+   * ```
+   */
+  public async getContractMethods(
+    contractId: string,
+    networkPassphrase?: string,
+  ): Promise<Api.ContractMethod[]> {
+    const passphrase =
+      networkPassphrase ?? (await this.getNetwork()).passphrase;
+
+    // Dynamically import to avoid a static circular dependency: the contract
+    // module imports this rpc module. The import resolves at call time, by
+    // which point this module has finished loading.
+    const { Client } = await import("../contract/client.js");
+
+    // `Client.from` is SAC-aware: it uses the embedded SAC spec for built-in
+    // Stellar Asset Contracts and downloads Wasm otherwise. We pass
+    // `server: this` so the call reuses this server's transport.
+    const client = await Client.from({
+      contractId,
+      rpcUrl: this.serverURL.toString(),
+      networkPassphrase: passphrase,
+      server: this,
+    });
+
+    return client.spec.funcs().map((fn) => {
+      const doc = fn.doc().toString();
+      const method: Api.ContractMethod = {
+        name: fn.name().toString(),
+        inputs: fn.inputs().map((input) => ({
+          name: input.name().toString(),
+          type: contractSpecTypeName(input.type()),
+        })),
+        outputs: fn.outputs().map(contractSpecTypeName),
+      };
+      if (doc) {
+        method.doc = doc;
+      }
+      return method;
+    });
   }
 
   /**

--- a/test/e2e/src/query-contract.test.ts
+++ b/test/e2e/src/query-contract.test.ts
@@ -68,6 +68,18 @@ describe("Server#queryContract", () => {
       );
       expect(result).toBe(1);
     });
+
+    it("lists the contract's methods and signatures", async () => {
+      const methods = await server.getContractMethods(contractId);
+      const byName = new Map(methods.map((m) => [m.name, m]));
+
+      // The same methods exercised by queryContract above must show up.
+      expect(byName.get("get_count")).toMatchObject({ inputs: [] });
+      expect(byName.get("multi_args")?.inputs.map((i) => i.name)).toEqual([
+        "a",
+        "b",
+      ]);
+    });
   });
 
   describe("Stellar Asset Contract (SAC)", () => {
@@ -91,6 +103,14 @@ describe("Server#queryContract", () => {
     it("reads name from the embedded SAC spec", async () => {
       expect(await server.queryContract<string>(sacId, "name")).toBe(
         `TST:${issuer.publicKey()}`,
+      );
+    });
+
+    it("lists the built-in SAC methods from the embedded spec", async () => {
+      const names = (await server.getContractMethods(sacId)).map((m) => m.name);
+      // A representative subset of the well-known SAC interface.
+      expect(names).toEqual(
+        expect.arrayContaining(["decimals", "name", "balance", "transfer"]),
       );
     });
   });

--- a/test/unit/server/soroban/get_contract_methods.test.ts
+++ b/test/unit/server/soroban/get_contract_methods.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
+import * as StellarSdk from "../../../../src/index.js";
+
+import { serverUrl } from "../../../constants";
+
+const { Server } = StellarSdk.rpc;
+const { Client } = StellarSdk.contract;
+const { xdr } = StellarSdk;
+
+/** A `ScSpecTypeDef` for a user-defined type referenced by name. */
+function udt(name: string) {
+  return xdr.ScSpecTypeDef.scSpecTypeUdt(new xdr.ScSpecTypeUdt({ name }));
+}
+
+/** A real `ScSpecFunctionV0`, so the type-name mapping is exercised for real. */
+function func(opts: {
+  doc?: string;
+  name: string;
+  inputs?: { name: string; type: xdr.ScSpecTypeDef }[];
+  outputs?: xdr.ScSpecTypeDef[];
+}) {
+  return new xdr.ScSpecFunctionV0({
+    doc: opts.doc ?? "",
+    name: opts.name,
+    inputs: (opts.inputs ?? []).map(
+      (i) =>
+        new xdr.ScSpecFunctionInputV0({
+          doc: "",
+          name: i.name,
+          type: i.type,
+        }),
+    ),
+    outputs: opts.outputs ?? [],
+  });
+}
+
+/** Build a fake `contract.Client` whose `spec.funcs()` returns the given funcs. */
+function fakeClient(funcs: xdr.ScSpecFunctionV0[]) {
+  return { spec: { funcs: () => funcs } };
+}
+
+describe("Server#getContractMethods", () => {
+  let server: any;
+  const contractId = "CCJZ5DGASBWQXR5MPFCJXMBI333XE5U3FSJTNQU7RIKE3P5GN2K2WYD5";
+  const networkPassphrase = "Test SDF Network ; September 2015";
+
+  beforeEach(() => {
+    server = new Server(serverUrl);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults the network passphrase to getNetwork() when not provided", async () => {
+    const getNetwork = vi
+      .spyOn(server, "getNetwork")
+      .mockResolvedValue({ passphrase: networkPassphrase } as any);
+    const from = vi
+      .spyOn(Client, "from")
+      .mockResolvedValue(fakeClient([func({ name: "decimals" })]) as any);
+
+    await server.getContractMethods(contractId);
+
+    expect(getNetwork).toHaveBeenCalledOnce();
+    expect(from).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contractId,
+        rpcUrl: server.serverURL.toString(),
+        networkPassphrase,
+        server,
+      }),
+    );
+  });
+
+  it("uses the provided networkPassphrase and skips getNetwork()", async () => {
+    const getNetwork = vi.spyOn(server, "getNetwork");
+    const from = vi
+      .spyOn(Client, "from")
+      .mockResolvedValue(fakeClient([func({ name: "decimals" })]) as any);
+
+    await server.getContractMethods(contractId, "Custom Network ; 2024");
+
+    expect(getNetwork).not.toHaveBeenCalled();
+    expect(from).toHaveBeenCalledWith(
+      expect.objectContaining({ networkPassphrase: "Custom Network ; 2024" }),
+    );
+  });
+
+  it("maps names, inputs, and outputs to readable type names", async () => {
+    vi.spyOn(server, "getNetwork").mockResolvedValue({
+      passphrase: networkPassphrase,
+    } as any);
+    vi.spyOn(Client, "from").mockResolvedValue(
+      fakeClient([
+        func({
+          name: "decimals",
+          outputs: [xdr.ScSpecTypeDef.scSpecTypeU32()],
+        }),
+        func({
+          name: "balance",
+          inputs: [{ name: "id", type: xdr.ScSpecTypeDef.scSpecTypeAddress() }],
+          outputs: [xdr.ScSpecTypeDef.scSpecTypeI128()],
+        }),
+        func({
+          name: "transfer",
+          inputs: [
+            { name: "from", type: xdr.ScSpecTypeDef.scSpecTypeAddress() },
+            { name: "to", type: xdr.ScSpecTypeDef.scSpecTypeAddress() },
+            { name: "amount", type: xdr.ScSpecTypeDef.scSpecTypeI128() },
+          ],
+        }),
+      ]) as any,
+    );
+
+    const methods = await server.getContractMethods(contractId);
+
+    expect(methods).toEqual([
+      { name: "decimals", inputs: [], outputs: ["U32"] },
+      {
+        name: "balance",
+        inputs: [{ name: "id", type: "Address" }],
+        outputs: ["I128"],
+      },
+      {
+        name: "transfer",
+        inputs: [
+          { name: "from", type: "Address" },
+          { name: "to", type: "Address" },
+          { name: "amount", type: "I128" },
+        ],
+        outputs: [],
+      },
+    ]);
+  });
+
+  it("resolves user-defined types by their declared name", async () => {
+    vi.spyOn(server, "getNetwork").mockResolvedValue({
+      passphrase: networkPassphrase,
+    } as any);
+    vi.spyOn(Client, "from").mockResolvedValue(
+      fakeClient([
+        func({
+          name: "submit",
+          inputs: [{ name: "order", type: udt("Order") }],
+          outputs: [udt("Receipt")],
+        }),
+      ]) as any,
+    );
+
+    const [method] = await server.getContractMethods(contractId);
+
+    expect(method.inputs).toEqual([{ name: "order", type: "Order" }]);
+    expect(method.outputs).toEqual(["Receipt"]);
+  });
+
+  it("includes doc only when the spec declares one", async () => {
+    vi.spyOn(server, "getNetwork").mockResolvedValue({
+      passphrase: networkPassphrase,
+    } as any);
+    vi.spyOn(Client, "from").mockResolvedValue(
+      fakeClient([
+        func({ name: "documented", doc: "Returns the token decimals." }),
+        func({ name: "undocumented" }),
+      ]) as any,
+    );
+
+    const [documented, undocumented] =
+      await server.getContractMethods(contractId);
+
+    expect(documented.doc).toBe("Returns the token decimals.");
+    expect(undocumented).not.toHaveProperty("doc");
+  });
+});


### PR DESCRIPTION
Adds a discovery helper that complements `queryContract`: given only a contract ID, it lists the contract's callable methods and their signatures. Built for dapps, agents, and tooling that inspect arbitrary contracts without knowing their interface up front.

- **`rpc.Server.getContractMethods(contractId, networkPassphrase?)`** — resolves the contract's spec SAC-aware via `Client.from` (embedded spec for SACs, Wasm download otherwise) and returns `{ name, inputs: [{ name, type }], outputs, doc? }` per method, with human-readable type names. No invocation or simulation — a spec lookup only.
- New `Api.ContractMethod` / `Api.ContractMethodInput` response types.

### Docs
- New "Query contract state" section in the Invoke a Contract guide covering `getContractMethods` and `queryContract` as a unified discover-then-read example.
- Updated the invoke and auth guides to type the `contract.Client` examples via `Client.from<T>()` and drop the `(client as any)` casts.

### Testing
- Unit tests exercising the real type-name mapping (built-ins + UDTs), passphrase defaulting, and doc handling.
- e2e happy-path coverage for both a Wasm contract and a SAC.
- Manually verified end to end against testnet, including UDT resolution on a freshly deployed contract.