### PR TITLE
SPIKE: Protocol 28 (CAP-0085)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Added
+- Protocol 28 (CAP-0085): externally managed contract executables. The vendored `next`-channel XDR now includes the `SCV_EXECUTABLE_TAG` `SCVal` arm, the `CONTRACT_EXECUTABLE_EXTERNAL_REF` `ContractExecutable` variant, and the `ContractExecutableExternalRef` struct. Encode/decode support is via the generated codec; no new hand-written SDK helpers were added.
 - `rpc.Server.queryContract<T>(contractId, method, args?, networkPassphrase?)`: a one-line read-only contract call that builds a client, simulates the method, and returns `{ result, isReadCall }` — the spec-decoded return value plus whether this specific call is a signature-free read that wrote no state (per-call, reflecting the given `args`). No manual transaction assembly, signing, or submission. Works for both Wasm contracts and built-in Stellar Asset Contracts (SACs) ([#1502](https://github.com/stellar/js-stellar-sdk/pull/1502)).
 - `rpc.Server.getContractMethods(contractId, networkPassphrase?)`: lists a contract's callable methods and their signatures (name, inputs, outputs, and doc string) for discovery and tooling, without invoking or simulating anything. Adds the `Api.ContractMethod` and `Api.ContractMethodInput` types ([#1502](https://github.com/stellar/js-stellar-sdk/pull/1502)).
 - `rpc.Server.getContractInstance(contractId)`: returns a contract's `xdr.ScContractInstance` (its executable and instance storage) ([#1501](https://github.com/stellar/js-stellar-sdk/pull/1501)).

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
+# Protocol 28 / CAP-0085 (externally managed contract executables) pre-release.
+# The `next` channel pins stellar-xdr#308 head (76218a99) and enables
+# CAP_0085_EXECUTABLE_REF via `stellar-xdr xfile preprocess` before xdrgen
+# (the Ruby xdrgen used here does not understand #ifdef). CAP_0085_EXECUTABLE_REF
+# is gated to `next` only: the new SCVal/ContractExecutable arms are not enabled
+# on `curr` until protocol 28 ships, so `curr` deliberately stays pinned at
+# 68fa1ac5 with no features.
 XDR_BASE_URL_CURR=https://github.com/stellar/stellar-xdr/raw/68fa1ac55692f68ad2a2ca549d0a283273554439
 XDR_BASE_LOCAL_CURR=xdr/curr
+XDR_FEATURES_CURR=
 XDR_FILES_CURR= \
 	Stellar-SCP.x \
 	Stellar-ledger-entries.x \
@@ -15,8 +23,9 @@ XDR_FILES_CURR= \
 	Stellar-exporter.x
 XDR_FILES_LOCAL_CURR=$(addprefix xdr/curr/,$(XDR_FILES_CURR))
 
-XDR_BASE_URL_NEXT=https://github.com/stellar/stellar-xdr/raw/68fa1ac55692f68ad2a2ca549d0a283273554439
+XDR_BASE_URL_NEXT=https://github.com/stellar/stellar-xdr/raw/76218a994f8c5ba752cba368080fb2f89843ad3c
 XDR_BASE_LOCAL_NEXT=xdr/next
+XDR_FEATURES_NEXT=CAP_0085_EXECUTABLE_REF
 XDR_FILES_NEXT= \
 	Stellar-SCP.x \
 	Stellar-ledger-entries.x \
@@ -48,6 +57,7 @@ src/base/generated/curr_generated.js: $(XDR_FILES_LOCAL_CURR)
 		gem specific_install https://github.com/stellar/xdrgen.git -b $(XDRGEN_COMMIT) && \
 		xdrgen --language javascript --namespace curr --output src/base/generated $^ \
 		'
+	python3 scripts/post-process-generated.py $@
 
 src/base/generated/next_generated.js: $(XDR_FILES_LOCAL_NEXT)
 	mkdir -p $(dir $@)
@@ -57,6 +67,7 @@ src/base/generated/next_generated.js: $(XDR_FILES_LOCAL_NEXT)
 		gem specific_install https://github.com/stellar/xdrgen.git -b $(XDRGEN_COMMIT) && \
 		xdrgen --language javascript --namespace next --output src/base/generated $^ \
 		'
+	python3 scripts/post-process-generated.py $@
 
 src/base/generated/curr.d.ts: src/base/generated/curr_generated.js
 	docker run -it --rm -v $$PWD:/wd -w / --entrypoint /bin/sh node:22-alpine -c '\
@@ -92,12 +103,12 @@ clean:
 $(XDR_FILES_LOCAL_CURR):
 	mkdir -p $(dir $@)
 	curl -L -o $@ $(XDR_BASE_URL_CURR)/$(notdir $@)
-	stellar-xdr xfile preprocess --features "$(XDR_FEATURES)" $@ > $@.pp && mv -f $@.pp $@
+	stellar-xdr xfile preprocess --features "$(XDR_FEATURES_CURR)" $@ > $@.pp && mv -f $@.pp $@
 
 $(XDR_FILES_LOCAL_NEXT):
 	mkdir -p $(dir $@)
 	curl -L -o $@ $(XDR_BASE_URL_NEXT)/$(notdir $@)
-	stellar-xdr xfile preprocess --features "$(XDR_FEATURES)" $@ > $@.pp && mv -f $@.pp $@
+	stellar-xdr xfile preprocess --features "$(XDR_FEATURES_NEXT)" $@ > $@.pp && mv -f $@.pp $@
 reset-xdr:
 	rm -f xdr/*/*.x
 	rm -f src/base/generated/*.js

--- a/scripts/post-process-generated.py
+++ b/scripts/post-process-generated.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Post-process xdrgen JS output to inline xdr.const values at usage sites.
+
+xdrgen master emits `xdr.const("NAME", N);` to register a constant in the
+xdr namespace, then uses the bare identifier later (`xdr.string(NAME)`).
+But `@stellar/js-xdr`'s TypeBuilder.const() does not put NAME into JS scope,
+so the bare identifier ReferenceErrors at runtime.
+
+Injecting `var NAME = N;` at the IIFE top fixes runtime but gets DCE'd by
+terser in the production browser dist. The robust fix is to inline the
+literal at each usage site so there's no identifier for terser to drop.
+
+The `xdr.const("NAME", N);` declaration itself is left untouched: the NAME
+there is a string literal (preceded by a quote), so the negative lookbehind
+below skips it. Constants only referenced via `xdr.lookup("NAME")` string
+lookups are likewise untouched.
+"""
+import re
+import pathlib
+import sys
+
+
+def inline_consts(path: pathlib.Path) -> int:
+    s = path.read_text()
+    consts = dict(re.findall(
+        r'xdr\.const\("([A-Z][A-Z0-9_]+)",\s*(0x[0-9a-fA-F]+|\d+)\);', s
+    ))
+    n_replaced = 0
+    for name, value in consts.items():
+        # Replace bare identifier (not preceded by quote or word char,
+        # not followed by quote or word char). This skips string literals
+        # like "NAME" and xdr.lookup("NAME"), so the xdr.const(...)
+        # declaration's string name is preserved.
+        new_s, count = re.subn(
+            rf'(?<![\w"\'$]){re.escape(name)}(?![\w"\'$])',
+            value,
+            s,
+        )
+        if count > 0:
+            s = new_s
+            n_replaced += count
+    path.write_text(s)
+    return n_replaced
+
+
+if __name__ == "__main__":
+    files = sys.argv[1:] or [
+        "src/base/generated/curr_generated.js",
+        "src/base/generated/next_generated.js",
+    ]
+    for f in files:
+        p = pathlib.Path(f)
+        n = inline_consts(p)
+        print(f"{f}: inlined {n} bare-identifier const reference(s)")

--- a/src/base/generated/next.d.ts
+++ b/src/base/generated/next.d.ts
@@ -1975,7 +1975,8 @@ export namespace xdr {
       | "scvAddress"
       | "scvContractInstance"
       | "scvLedgerKeyContractInstance"
-      | "scvLedgerKeyNonce";
+      | "scvLedgerKeyNonce"
+      | "scvExecutableTag";
 
     readonly value:
       | 0
@@ -1999,7 +2000,8 @@ export namespace xdr {
       | 18
       | 19
       | 20
-      | 21;
+      | 21
+      | 22;
 
     static scvBool(): ScValType;
 
@@ -2044,6 +2046,8 @@ export namespace xdr {
     static scvLedgerKeyContractInstance(): ScValType;
 
     static scvLedgerKeyNonce(): ScValType;
+
+    static scvExecutableTag(): ScValType;
   }
 
   class ScErrorType {
@@ -2119,13 +2123,18 @@ export namespace xdr {
   }
 
   class ContractExecutableType {
-    readonly name: "contractExecutableWasm" | "contractExecutableStellarAsset";
+    readonly name:
+      | "contractExecutableWasm"
+      | "contractExecutableStellarAsset"
+      | "contractExecutableExternalRef";
 
-    readonly value: 0 | 1;
+    readonly value: 0 | 1 | 2;
 
     static contractExecutableWasm(): ContractExecutableType;
 
     static contractExecutableStellarAsset(): ContractExecutableType;
+
+    static contractExecutableExternalRef(): ContractExecutableType;
   }
 
   class ScAddressType {
@@ -9508,6 +9517,43 @@ export namespace xdr {
     static validateXDR(input: string, format: "hex" | "base64"): boolean;
   }
 
+  class ContractExecutableExternalRef {
+    constructor(attributes: {
+      executableOwner: ScAddress;
+      tag: string | Buffer;
+    });
+
+    executableOwner(value?: ScAddress): ScAddress;
+
+    tag(value?: string | Buffer): string | Buffer;
+
+    toXDR(format?: "raw"): Buffer;
+
+    toXDR(format: "hex" | "base64"): string;
+
+    static read(io: Buffer): ContractExecutableExternalRef;
+
+    static write(value: ContractExecutableExternalRef, io: Buffer): void;
+
+    static isValid(value: ContractExecutableExternalRef): boolean;
+
+    static toXDR(value: ContractExecutableExternalRef): Buffer;
+
+    static fromXDR(
+      input: Buffer,
+      format?: "raw",
+    ): ContractExecutableExternalRef;
+
+    static fromXDR(
+      input: string,
+      format: "hex" | "base64",
+    ): ContractExecutableExternalRef;
+
+    static validateXDR(input: Buffer, format?: "raw"): boolean;
+
+    static validateXDR(input: string, format: "hex" | "base64"): boolean;
+  }
+
   class ScNonceKey {
     constructor(attributes: { nonce: Int64 });
 
@@ -15621,11 +15667,19 @@ export namespace xdr {
 
     wasmHash(value?: Buffer): Buffer;
 
+    externalRef(
+      value?: ContractExecutableExternalRef,
+    ): ContractExecutableExternalRef;
+
     static contractExecutableWasm(value: Buffer): ContractExecutable;
 
     static contractExecutableStellarAsset(): ContractExecutable;
 
-    value(): Buffer | void;
+    static contractExecutableExternalRef(
+      value: ContractExecutableExternalRef,
+    ): ContractExecutable;
+
+    value(): Buffer | ContractExecutableExternalRef | void;
 
     toXDR(format?: "raw"): Buffer;
 
@@ -15742,6 +15796,8 @@ export namespace xdr {
 
     nonceKey(value?: ScNonceKey): ScNonceKey;
 
+    executableTag(value?: string | Buffer): string | Buffer;
+
     static scvBool(value: boolean): ScVal;
 
     static scvVoid(): ScVal;
@@ -15785,6 +15841,8 @@ export namespace xdr {
     static scvLedgerKeyContractInstance(): ScVal;
 
     static scvLedgerKeyNonce(value: ScNonceKey): ScVal;
+
+    static scvExecutableTag(value: string | Buffer): ScVal;
 
     value():
       | boolean

--- a/src/base/generated/next_generated.js
+++ b/src/base/generated/next_generated.js
@@ -525,21 +525,21 @@ xdr.enum("AccountFlags", {
 
 // === xdr source ============================================================
 //
-//   const MASK_ACCOUNT_FLAGS = 0x7;
+//   const 0x7 = 0x7;
 //
 // ===========================================================================
 xdr.const("MASK_ACCOUNT_FLAGS", 0x7);
 
 // === xdr source ============================================================
 //
-//   const MASK_ACCOUNT_FLAGS_V17 = 0xF;
+//   const 0xF = 0xF;
 //
 // ===========================================================================
 xdr.const("MASK_ACCOUNT_FLAGS_V17", 0xF);
 
 // === xdr source ============================================================
 //
-//   const MAX_SIGNERS = 20;
+//   const 20 = 20;
 //
 // ===========================================================================
 xdr.const("MAX_SIGNERS", 20);
@@ -602,7 +602,7 @@ xdr.union("AccountEntryExtensionV2Ext", {
 //   {
 //       uint32 numSponsored;
 //       uint32 numSponsoring;
-//       SponsorshipDescriptor signerSponsoringIDs<MAX_SIGNERS>;
+//       SponsorshipDescriptor signerSponsoringIDs<20>;
 //   
 //       union switch (int v)
 //       {
@@ -708,7 +708,7 @@ xdr.union("AccountEntryExt", {
 //       // thresholds stores unsigned bytes: [weight of master|low|medium|high]
 //       Thresholds thresholds;
 //   
-//       Signer signers<MAX_SIGNERS>; // possible signers for this account
+//       Signer signers<20>; // possible signers for this account
 //   
 //       // reserved for future use
 //       union switch (int v)
@@ -758,21 +758,21 @@ xdr.enum("TrustLineFlags", {
 
 // === xdr source ============================================================
 //
-//   const MASK_TRUSTLINE_FLAGS = 1;
+//   const 1 = 1;
 //
 // ===========================================================================
 xdr.const("MASK_TRUSTLINE_FLAGS", 1);
 
 // === xdr source ============================================================
 //
-//   const MASK_TRUSTLINE_FLAGS_V13 = 3;
+//   const 3 = 3;
 //
 // ===========================================================================
 xdr.const("MASK_TRUSTLINE_FLAGS_V13", 3);
 
 // === xdr source ============================================================
 //
-//   const MASK_TRUSTLINE_FLAGS_V17 = 7;
+//   const 7 = 7;
 //
 // ===========================================================================
 xdr.const("MASK_TRUSTLINE_FLAGS_V17", 7);
@@ -1005,7 +1005,7 @@ xdr.enum("OfferEntryFlags", {
 
 // === xdr source ============================================================
 //
-//   const MASK_OFFERENTRY_FLAGS = 1;
+//   const 1 = 1;
 //
 // ===========================================================================
 xdr.const("MASK_OFFERENTRY_FLAGS", 1);
@@ -1240,7 +1240,7 @@ xdr.enum("ClaimableBalanceFlags", {
 
 // === xdr source ============================================================
 //
-//   const MASK_CLAIMABLE_BALANCE_FLAGS = 0x1;
+//   const 0x1 = 0x1;
 //
 // ===========================================================================
 xdr.const("MASK_CLAIMABLE_BALANCE_FLAGS", 0x1);
@@ -2263,7 +2263,7 @@ xdr.struct("StellarValue", [
 
 // === xdr source ============================================================
 //
-//   const MASK_LEDGER_HEADER_FLAGS = 0x7;
+//   const 0x7 = 0x7;
 //
 // ===========================================================================
 xdr.const("MASK_LEDGER_HEADER_FLAGS", 0x7);
@@ -3669,7 +3669,7 @@ xdr.struct("Hello", [
 
 // === xdr source ============================================================
 //
-//   const AUTH_MSG_FLAG_FLOW_CONTROL_BYTES_REQUESTED = 200;
+//   const 200 = 200;
 //
 // ===========================================================================
 xdr.const("AUTH_MSG_FLAG_FLOW_CONTROL_BYTES_REQUESTED", 200);
@@ -4155,14 +4155,14 @@ xdr.union("SurveyResponseBody", {
 
 // === xdr source ============================================================
 //
-//   const TX_ADVERT_VECTOR_MAX_SIZE = 1000;
+//   const 1000 = 1000;
 //
 // ===========================================================================
 xdr.const("TX_ADVERT_VECTOR_MAX_SIZE", 1000);
 
 // === xdr source ============================================================
 //
-//   typedef Hash TxAdvertVector<TX_ADVERT_VECTOR_MAX_SIZE>;
+//   typedef Hash TxAdvertVector<1000>;
 //
 // ===========================================================================
 xdr.typedef("TxAdvertVector", xdr.varArray(xdr.lookup("Hash"), xdr.lookup("TX_ADVERT_VECTOR_MAX_SIZE")));
@@ -4181,14 +4181,14 @@ xdr.struct("FloodAdvert", [
 
 // === xdr source ============================================================
 //
-//   const TX_DEMAND_VECTOR_MAX_SIZE = 1000;
+//   const 1000 = 1000;
 //
 // ===========================================================================
 xdr.const("TX_DEMAND_VECTOR_MAX_SIZE", 1000);
 
 // === xdr source ============================================================
 //
-//   typedef Hash TxDemandVector<TX_DEMAND_VECTOR_MAX_SIZE>;
+//   typedef Hash TxDemandVector<1000>;
 //
 // ===========================================================================
 xdr.typedef("TxDemandVector", xdr.varArray(xdr.lookup("Hash"), xdr.lookup("TX_DEMAND_VECTOR_MAX_SIZE")));
@@ -4359,7 +4359,7 @@ xdr.union("AuthenticatedMessage", {
 
 // === xdr source ============================================================
 //
-//   const MAX_OPS_PER_TX = 100;
+//   const 100 = 100;
 //
 // ===========================================================================
 xdr.const("MAX_OPS_PER_TX", 100);
@@ -4925,7 +4925,7 @@ xdr.struct("SetTrustLineFlagsOp", [
 
 // === xdr source ============================================================
 //
-//   const LIQUIDITY_POOL_FEE_V18 = 30;
+//   const 30 = 30;
 //
 // ===========================================================================
 xdr.const("LIQUIDITY_POOL_FEE_V18", 30);
@@ -6001,7 +6001,7 @@ xdr.union("TransactionV0Ext", {
 //       SequenceNumber seqNum;
 //       TimeBounds* timeBounds;
 //       Memo memo;
-//       Operation operations<MAX_OPS_PER_TX>;
+//       Operation operations<100>;
 //       union switch (int v)
 //       {
 //       case 0:
@@ -6078,7 +6078,7 @@ xdr.union("TransactionExt", {
 //   
 //       Memo memo;
 //   
-//       Operation operations<MAX_OPS_PER_TX>;
+//       Operation operations<100>;
 //   
 //       union switch (int v)
 //       {
@@ -9119,7 +9119,8 @@ xdr.union("ClaimableBalanceId", {
 //       // symbolic SCVals used as the key for ledger entries for a contract's
 //       // instance and an address' nonce, respectively.
 //       SCV_LEDGER_KEY_CONTRACT_INSTANCE = 20,
-//       SCV_LEDGER_KEY_NONCE = 21
+//       SCV_LEDGER_KEY_NONCE = 21,
+//       SCV_EXECUTABLE_TAG = 22
 //   };
 //
 // ===========================================================================
@@ -9146,6 +9147,7 @@ xdr.enum("ScValType", {
   scvContractInstance: 19,
   scvLedgerKeyContractInstance: 20,
   scvLedgerKeyNonce: 21,
+  scvExecutableTag: 22,
 });
 
 // === xdr source ============================================================
@@ -9313,14 +9315,29 @@ xdr.struct("Int256Parts", [
 //   enum ContractExecutableType
 //   {
 //       CONTRACT_EXECUTABLE_WASM = 0,
-//       CONTRACT_EXECUTABLE_STELLAR_ASSET = 1
+//       CONTRACT_EXECUTABLE_STELLAR_ASSET = 1,
+//       CONTRACT_EXECUTABLE_EXTERNAL_REF = 2
 //   };
 //
 // ===========================================================================
 xdr.enum("ContractExecutableType", {
   contractExecutableWasm: 0,
   contractExecutableStellarAsset: 1,
+  contractExecutableExternalRef: 2,
 });
+
+// === xdr source ============================================================
+//
+//   struct ContractExecutableExternalRef {
+//       SCAddress executable_owner;
+//       SCString tag;
+//   };
+//
+// ===========================================================================
+xdr.struct("ContractExecutableExternalRef", [
+  ["executableOwner", xdr.lookup("ScAddress")],
+  ["tag", xdr.lookup("ScString")],
+]);
 
 // === xdr source ============================================================
 //
@@ -9330,6 +9347,8 @@ xdr.enum("ContractExecutableType", {
 //       Hash wasm_hash;
 //   case CONTRACT_EXECUTABLE_STELLAR_ASSET:
 //       void;
+//   case CONTRACT_EXECUTABLE_EXTERNAL_REF:
+//       ContractExecutableExternalRef external_ref;
 //   };
 //
 // ===========================================================================
@@ -9339,9 +9358,11 @@ xdr.union("ContractExecutable", {
   switches: [
     ["contractExecutableWasm", "wasmHash"],
     ["contractExecutableStellarAsset", xdr.void()],
+    ["contractExecutableExternalRef", "externalRef"],
   ],
   arms: {
     wasmHash: xdr.lookup("Hash"),
+    externalRef: xdr.lookup("ContractExecutableExternalRef"),
   },
 });
 
@@ -9417,7 +9438,7 @@ xdr.union("ScAddress", {
 
 // === xdr source ============================================================
 //
-//   const SCSYMBOL_LIMIT = 32;
+//   const 32 = 32;
 //
 // ===========================================================================
 xdr.const("SCSYMBOL_LIMIT", 32);
@@ -9452,10 +9473,10 @@ xdr.typedef("ScString", xdr.string());
 
 // === xdr source ============================================================
 //
-//   typedef string SCSymbol<SCSYMBOL_LIMIT>;
+//   typedef string SCSymbol<32>;
 //
 // ===========================================================================
-xdr.typedef("ScSymbol", xdr.string(SCSYMBOL_LIMIT));
+xdr.typedef("ScSymbol", xdr.string(32));
 
 // === xdr source ============================================================
 //
@@ -9542,6 +9563,8 @@ xdr.struct("ScContractInstance", [
 //       void;
 //   case SCV_LEDGER_KEY_NONCE:
 //       SCNonceKey nonce_key;
+//   case SCV_EXECUTABLE_TAG:
+//       SCString executable_tag;
 //   };
 //
 // ===========================================================================
@@ -9571,6 +9594,7 @@ xdr.union("ScVal", {
     ["scvContractInstance", "instance"],
     ["scvLedgerKeyContractInstance", xdr.void()],
     ["scvLedgerKeyNonce", "nonceKey"],
+    ["scvExecutableTag", "executableTag"],
   ],
   arms: {
     b: xdr.bool(),
@@ -9593,6 +9617,7 @@ xdr.union("ScVal", {
     address: xdr.lookup("ScAddress"),
     instance: xdr.lookup("ScContractInstance"),
     nonceKey: xdr.lookup("ScNonceKey"),
+    executableTag: xdr.lookup("ScString"),
   },
 });
 
@@ -9706,7 +9731,7 @@ xdr.union("ScMetaEntry", {
 
 // === xdr source ============================================================
 //
-//   const SC_SPEC_DOC_LIMIT = 1024;
+//   const 1024 = 1024;
 //
 // ===========================================================================
 xdr.const("SC_SPEC_DOC_LIMIT", 1024);
@@ -9954,14 +9979,14 @@ xdr.union("ScSpecTypeDef", {
 //
 //   struct SCSpecUDTStructFieldV0
 //   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
+//       string doc<1024>;
 //       string name<30>;
 //       SCSpecTypeDef type;
 //   };
 //
 // ===========================================================================
 xdr.struct("ScSpecUdtStructFieldV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
+  ["doc", xdr.string(1024)],
   ["name", xdr.string(30)],
   ["type", xdr.lookup("ScSpecTypeDef")],
 ]);
@@ -9970,7 +9995,7 @@ xdr.struct("ScSpecUdtStructFieldV0", [
 //
 //   struct SCSpecUDTStructV0
 //   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
+//       string doc<1024>;
 //       string lib<80>;
 //       string name<60>;
 //       SCSpecUDTStructFieldV0 fields<>;
@@ -9978,7 +10003,7 @@ xdr.struct("ScSpecUdtStructFieldV0", [
 //
 // ===========================================================================
 xdr.struct("ScSpecUdtStructV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
+  ["doc", xdr.string(1024)],
   ["lib", xdr.string(80)],
   ["name", xdr.string(60)],
   ["fields", xdr.varArray(xdr.lookup("ScSpecUdtStructFieldV0"), 2147483647)],
@@ -9988,13 +10013,13 @@ xdr.struct("ScSpecUdtStructV0", [
 //
 //   struct SCSpecUDTUnionCaseVoidV0
 //   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
+//       string doc<1024>;
 //       string name<60>;
 //   };
 //
 // ===========================================================================
 xdr.struct("ScSpecUdtUnionCaseVoidV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
+  ["doc", xdr.string(1024)],
   ["name", xdr.string(60)],
 ]);
 
@@ -10002,14 +10027,14 @@ xdr.struct("ScSpecUdtUnionCaseVoidV0", [
 //
 //   struct SCSpecUDTUnionCaseTupleV0
 //   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
+//       string doc<1024>;
 //       string name<60>;
 //       SCSpecTypeDef type<>;
 //   };
 //
 // ===========================================================================
 xdr.struct("ScSpecUdtUnionCaseTupleV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
+  ["doc", xdr.string(1024)],
   ["name", xdr.string(60)],
   ["type", xdr.varArray(xdr.lookup("ScSpecTypeDef"), 2147483647)],
 ]);
@@ -10056,7 +10081,7 @@ xdr.union("ScSpecUdtUnionCaseV0", {
 //
 //   struct SCSpecUDTUnionV0
 //   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
+//       string doc<1024>;
 //       string lib<80>;
 //       string name<60>;
 //       SCSpecUDTUnionCaseV0 cases<>;
@@ -10064,7 +10089,7 @@ xdr.union("ScSpecUdtUnionCaseV0", {
 //
 // ===========================================================================
 xdr.struct("ScSpecUdtUnionV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
+  ["doc", xdr.string(1024)],
   ["lib", xdr.string(80)],
   ["name", xdr.string(60)],
   ["cases", xdr.varArray(xdr.lookup("ScSpecUdtUnionCaseV0"), 2147483647)],
@@ -10074,14 +10099,14 @@ xdr.struct("ScSpecUdtUnionV0", [
 //
 //   struct SCSpecUDTEnumCaseV0
 //   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
+//       string doc<1024>;
 //       string name<60>;
 //       uint32 value;
 //   };
 //
 // ===========================================================================
 xdr.struct("ScSpecUdtEnumCaseV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
+  ["doc", xdr.string(1024)],
   ["name", xdr.string(60)],
   ["value", xdr.lookup("Uint32")],
 ]);
@@ -10090,7 +10115,7 @@ xdr.struct("ScSpecUdtEnumCaseV0", [
 //
 //   struct SCSpecUDTEnumV0
 //   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
+//       string doc<1024>;
 //       string lib<80>;
 //       string name<60>;
 //       SCSpecUDTEnumCaseV0 cases<>;
@@ -10098,7 +10123,7 @@ xdr.struct("ScSpecUdtEnumCaseV0", [
 //
 // ===========================================================================
 xdr.struct("ScSpecUdtEnumV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
+  ["doc", xdr.string(1024)],
   ["lib", xdr.string(80)],
   ["name", xdr.string(60)],
   ["cases", xdr.varArray(xdr.lookup("ScSpecUdtEnumCaseV0"), 2147483647)],
@@ -10108,14 +10133,14 @@ xdr.struct("ScSpecUdtEnumV0", [
 //
 //   struct SCSpecUDTErrorEnumCaseV0
 //   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
+//       string doc<1024>;
 //       string name<60>;
 //       uint32 value;
 //   };
 //
 // ===========================================================================
 xdr.struct("ScSpecUdtErrorEnumCaseV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
+  ["doc", xdr.string(1024)],
   ["name", xdr.string(60)],
   ["value", xdr.lookup("Uint32")],
 ]);
@@ -10124,7 +10149,7 @@ xdr.struct("ScSpecUdtErrorEnumCaseV0", [
 //
 //   struct SCSpecUDTErrorEnumV0
 //   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
+//       string doc<1024>;
 //       string lib<80>;
 //       string name<60>;
 //       SCSpecUDTErrorEnumCaseV0 cases<>;
@@ -10132,7 +10157,7 @@ xdr.struct("ScSpecUdtErrorEnumCaseV0", [
 //
 // ===========================================================================
 xdr.struct("ScSpecUdtErrorEnumV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
+  ["doc", xdr.string(1024)],
   ["lib", xdr.string(80)],
   ["name", xdr.string(60)],
   ["cases", xdr.varArray(xdr.lookup("ScSpecUdtErrorEnumCaseV0"), 2147483647)],
@@ -10142,14 +10167,14 @@ xdr.struct("ScSpecUdtErrorEnumV0", [
 //
 //   struct SCSpecFunctionInputV0
 //   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
+//       string doc<1024>;
 //       string name<30>;
 //       SCSpecTypeDef type;
 //   };
 //
 // ===========================================================================
 xdr.struct("ScSpecFunctionInputV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
+  ["doc", xdr.string(1024)],
   ["name", xdr.string(30)],
   ["type", xdr.lookup("ScSpecTypeDef")],
 ]);
@@ -10158,7 +10183,7 @@ xdr.struct("ScSpecFunctionInputV0", [
 //
 //   struct SCSpecFunctionV0
 //   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
+//       string doc<1024>;
 //       SCSymbol name;
 //       SCSpecFunctionInputV0 inputs<>;
 //       SCSpecTypeDef outputs<1>;
@@ -10166,7 +10191,7 @@ xdr.struct("ScSpecFunctionInputV0", [
 //
 // ===========================================================================
 xdr.struct("ScSpecFunctionV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
+  ["doc", xdr.string(1024)],
   ["name", xdr.lookup("ScSymbol")],
   ["inputs", xdr.varArray(xdr.lookup("ScSpecFunctionInputV0"), 2147483647)],
   ["outputs", xdr.varArray(xdr.lookup("ScSpecTypeDef"), 1)],
@@ -10190,7 +10215,7 @@ xdr.enum("ScSpecEventParamLocationV0", {
 //
 //   struct SCSpecEventParamV0
 //   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
+//       string doc<1024>;
 //       string name<30>;
 //       SCSpecTypeDef type;
 //       SCSpecEventParamLocationV0 location;
@@ -10198,7 +10223,7 @@ xdr.enum("ScSpecEventParamLocationV0", {
 //
 // ===========================================================================
 xdr.struct("ScSpecEventParamV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
+  ["doc", xdr.string(1024)],
   ["name", xdr.string(30)],
   ["type", xdr.lookup("ScSpecTypeDef")],
   ["location", xdr.lookup("ScSpecEventParamLocationV0")],
@@ -10224,7 +10249,7 @@ xdr.enum("ScSpecEventDataFormat", {
 //
 //   struct SCSpecEventV0
 //   {
-//       string doc<SC_SPEC_DOC_LIMIT>;
+//       string doc<1024>;
 //       string lib<80>;
 //       SCSymbol name;
 //       SCSymbol prefixTopics<2>;
@@ -10234,7 +10259,7 @@ xdr.enum("ScSpecEventDataFormat", {
 //
 // ===========================================================================
 xdr.struct("ScSpecEventV0", [
-  ["doc", xdr.string(SC_SPEC_DOC_LIMIT)],
+  ["doc", xdr.string(1024)],
   ["lib", xdr.string(80)],
   ["name", xdr.lookup("ScSymbol")],
   ["prefixTopics", xdr.varArray(xdr.lookup("ScSymbol"), 2)],
@@ -10907,14 +10932,14 @@ xdr.struct("FreezeBypassTxsDelta", [
 
 // === xdr source ============================================================
 //
-//   const CONTRACT_COST_COUNT_LIMIT = 1024;
+//   const 1024 = 1024;
 //
 // ===========================================================================
 xdr.const("CONTRACT_COST_COUNT_LIMIT", 1024);
 
 // === xdr source ============================================================
 //
-//   typedef ContractCostParamEntry ContractCostParams<CONTRACT_COST_COUNT_LIMIT>;
+//   typedef ContractCostParamEntry ContractCostParams<1024>;
 //
 // ===========================================================================
 xdr.typedef("ContractCostParams", xdr.varArray(xdr.lookup("ContractCostParamEntry"), xdr.lookup("CONTRACT_COST_COUNT_LIMIT")));

--- a/xdr/next/Stellar-contract.x
+++ b/xdr/next/Stellar-contract.x
@@ -70,7 +70,8 @@ enum SCValType
     // symbolic SCVals used as the key for ledger entries for a contract's
     // instance and an address' nonce, respectively.
     SCV_LEDGER_KEY_CONTRACT_INSTANCE = 20,
-    SCV_LEDGER_KEY_NONCE = 21
+    SCV_LEDGER_KEY_NONCE = 21,
+    SCV_EXECUTABLE_TAG = 22
 };
 
 enum SCErrorType
@@ -165,7 +166,13 @@ struct Int256Parts {
 enum ContractExecutableType
 {
     CONTRACT_EXECUTABLE_WASM = 0,
-    CONTRACT_EXECUTABLE_STELLAR_ASSET = 1
+    CONTRACT_EXECUTABLE_STELLAR_ASSET = 1,
+    CONTRACT_EXECUTABLE_EXTERNAL_REF = 2
+};
+
+struct ContractExecutableExternalRef {
+    SCAddress executable_owner;
+    SCString tag;
 };
 
 union ContractExecutable switch (ContractExecutableType type)
@@ -174,6 +181,8 @@ case CONTRACT_EXECUTABLE_WASM:
     Hash wasm_hash;
 case CONTRACT_EXECUTABLE_STELLAR_ASSET:
     void;
+case CONTRACT_EXECUTABLE_EXTERNAL_REF:
+    ContractExecutableExternalRef external_ref;
 };
 
 enum SCAddressType
@@ -285,6 +294,9 @@ case SCV_LEDGER_KEY_CONTRACT_INSTANCE:
     void;
 case SCV_LEDGER_KEY_NONCE:
     SCNonceKey nonce_key;
+
+case SCV_EXECUTABLE_TAG:
+    SCString executable_tag;
 };
 
 struct SCMapEntry


### PR DESCRIPTION
SPIKE (draft): Protocol 28 / CAP-0085 — externally managed contract executables. Based on the canonical XDR in stellar/stellar-xdr#308.

## Changes
- Makefile: pin the `next` XDR channel to stellar-xdr#308 head (`76218a99`) and add `XDR_FEATURES_NEXT=CAP_0085_EXECUTABLE_REF` (next-only; `curr` pin/features left unchanged — protocol 28 is not on `curr` yet).
- `xdr/next/Stellar-contract.x` + regenerated `src/base/generated/next_{generated.js,d.ts}`: `SCVal` `SCV_EXECUTABLE_TAG` (22), `ContractExecutable` `CONTRACT_EXECUTABLE_EXTERNAL_REF` (2), and `ContractExecutableExternalRef` struct. String fields typed `string | Buffer` (the codec's convention; `ScString` is a value, not a type).
- Added `scripts/post-process-generated.py` (xdrgen const-inlining, mirrors the CAP-0084 stack) and applied it to `next_generated.js`: the `next` codec was un-loadable on `main` (bare `SCSYMBOL_LIMIT`/`SC_SPEC_DOC_LIMIT` → ReferenceError), which blocked verifying the new types.
- Verified: `next` codec round-trips `scvExecutableTag` and `ContractExecutable` external_ref; `pnpm build:prod` (tsc) passes.

## Deferred
- No SDK convenience constructor for external-ref executables or for building an `SCV_EXECUTABLE_TAG` (host-side operation; `scValToNative`'s default already decodes the arm). Flagged for reviewer.
- `curr` const-inlining left untouched (pre-existing; `curr` uses the older declaration style the script would corrupt, and it's out of scope for CAP-0085).
- Full `make generate` at the new pin would also surface an unrelated upstream `Stellar-ledger.x` comment change (stellar-xdr main, not #308); not in this PR's committed files (targeted edits).

## Upstream
- stellar/stellar-xdr#308 (canonical `.x`, CAP_0085_EXECUTABLE_REF)
- stellar/rs-soroban-env#1703 (host draft, context)

Independent of the CAP-0083/CAP-0084 p28 SPIKE stacks. Stays draft.