### PR TITLE
Add inspectAuthEntry and checkAuthEntryReadiness for decoding Soroban auth entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Added
+- `inspectAuthEntry(entry)`: decodes a `xdr.SorobanAuthorizationEntry` into a typed summary — credential type (`sourceAccount`/`address`/`addressV2`/`addressWithDelegates`), authorizing address, nonce, `signatureExpirationLedger`, and a `signers` list covering the top-level credentials plus any CAP-71 delegates (depth-first), each reporting whether it's signed and, when the payload uses the SDK's standard ed25519 format, the parsed `{publicKey, signature}` pairs (custom-account payloads are surfaced raw). Adds the `AuthEntryInfo`, `AuthEntrySigner`, `AuthEntrySignature`, and `AuthEntryCredentialType` types ([#1468](https://github.com/stellar/js-stellar-sdk/issues/1468)).
+- `checkAuthEntryReadiness(entry, currentLedgerSeq)`: reports whether an auth entry is ready to submit — `{ ready, expired, unsignedBy }` — comparing the entry's expiration (exclusively) against a caller-supplied current ledger, so it stays a pure decode with no network dependency. Source-account entries are always ready ([#1468](https://github.com/stellar/js-stellar-sdk/issues/1468)).
 - `Spec.nativeToScVal` now supports contract parameters typed as `Val`
   (`scSpecTypeVal`) by delegating to the generic `nativeToScVal` converter, so
   raw JS values (strings, numbers, bigints, booleans, arrays, `Map`s, plain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Added
-- `inspectAuthEntry(entry)`: decodes a `xdr.SorobanAuthorizationEntry` into a typed summary — credential type (`sourceAccount`/`address`/`addressV2`/`addressWithDelegates`), authorizing address, nonce, `signatureExpirationLedger`, and a `signers` list covering the top-level credentials plus any CAP-71 delegates (depth-first), each reporting whether it's signed and, when the payload uses the SDK's standard ed25519 format, the parsed `{publicKey, signature}` pairs (custom-account payloads are surfaced raw). Adds the `AuthEntryInfo`, `AuthEntrySigner`, `AuthEntrySignature`, and `AuthEntryCredentialType` types ([#1468](https://github.com/stellar/js-stellar-sdk/issues/1468)).
-- `checkAuthEntryReadiness(entry, currentLedgerSeq)`: reports whether an auth entry is ready to submit — `{ ready, expired, unsignedBy }` — comparing the entry's expiration (exclusively) against a caller-supplied current ledger, so it stays a pure decode with no network dependency. Source-account entries are always ready ([#1468](https://github.com/stellar/js-stellar-sdk/issues/1468)).
+- `inspectAuthEntry(entry)`: decodes a `xdr.SorobanAuthorizationEntry` into a typed summary — credential type (`sourceAccount`/`address`/`addressV2`/`addressWithDelegates`), authorizing address, nonce, `signatureExpirationLedger`, and a `signers` list covering the top-level credentials plus any CAP-71 delegates (depth-first), each reporting whether it's signed and, when the payload uses the SDK's standard ed25519 format, the parsed `{publicKey, signature}` pairs (custom-account payloads are surfaced raw). Adds the `AuthEntryInfo`, `AuthEntrySigner`, `AuthEntrySignature`, and `AuthEntryCredentialType` types ([#1529](https://github.com/stellar/js-stellar-sdk/pull/1529)).
+- `checkAuthEntryReadiness(entry, currentLedgerSeq)`: reports whether an auth entry is ready to submit — `{ ready, expired, unsignedBy }` — comparing the entry's expiration (exclusively) against a caller-supplied current ledger, so it stays a pure decode with no network dependency. Source-account entries are always ready ([#1529](https://github.com/stellar/js-stellar-sdk/pull/1529)).
 - `Spec.nativeToScVal` now supports contract parameters typed as `Val`
   (`scSpecTypeVal`) by delegating to the generic `nativeToScVal` converter, so
   raw JS values (strings, numbers, bigints, booleans, arrays, `Map`s, plain
@@ -28,7 +28,7 @@ A breaking change will get clearly marked in this log.
 - The UMD (`dist/`) build now sets `inlineDynamicImports` so the single-file bundle stays whole despite the SAC spec's lazy `import()` ([#1501](https://github.com/stellar/js-stellar-sdk/pull/1501)).
 
 ### Fixed
-- `contract.AssembledTransaction.needsNonInvokerSigningBy` now treats an empty `scvVec` signature — the placeholder `authorizeInvocation` writes on unsigned entries — as unsigned, matching the existing `scvVoid` check. Previously such entries were wrongly considered already signed and omitted from the list ([#1468](https://github.com/stellar/js-stellar-sdk/issues/1468)).
+- `contract.AssembledTransaction.needsNonInvokerSigningBy` now treats an empty `scvVec` signature — the placeholder `authorizeInvocation` writes on unsigned entries — as unsigned, matching the existing `scvVoid` check. Previously such entries were wrongly considered already signed and omitted from the list ([#1529](https://github.com/stellar/js-stellar-sdk/pull/1529)).
 - `Spec.nativeToScVal` no longer misclassifies plain objects that have a
   `constructor` key, and handles null-prototype objects
   (`Object.create(null)`); non-plain class instances now consistently get the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ A breaking change will get clearly marked in this log.
 - The UMD (`dist/`) build now sets `inlineDynamicImports` so the single-file bundle stays whole despite the SAC spec's lazy `import()` ([#1501](https://github.com/stellar/js-stellar-sdk/pull/1501)).
 
 ### Fixed
+- `contract.AssembledTransaction.needsNonInvokerSigningBy` now treats an empty `scvVec` signature — the placeholder `authorizeInvocation` writes on unsigned entries — as unsigned, matching the existing `scvVoid` check. Previously such entries were wrongly considered already signed and omitted from the list ([#1468](https://github.com/stellar/js-stellar-sdk/issues/1468)).
 - `Spec.nativeToScVal` no longer misclassifies plain objects that have a
   `constructor` key, and handles null-prototype objects
   (`Object.create(null)`); non-plain class instances now consistently get the

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -236,7 +236,7 @@ class AssembledTransaction<T> {
 }
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:257](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L257)
+**Source:** [src/contract/assembled_transaction.ts:258](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L258)
 
 ### `AssembledTransaction.Errors`
 
@@ -248,7 +248,7 @@ logic.
 static Errors: { ExpiredState: typeof ExpiredStateError; ExternalServiceError: typeof ExternalServiceError; FakeAccount: typeof FakeAccountError; InternalWalletError: typeof InternalWalletError; InvalidClientRequest: typeof InvalidClientRequestError; NeedsMoreSignatures: typeof NeedsMoreSignaturesError; NoSignatureNeeded: typeof NoSignatureNeededError; NoSigner: typeof NoSignerError; NotYetSimulated: typeof NotYetSimulatedError; NoUnsignedNonInvokerAuthEntries: typeof NoUnsignedNonInvokerAuthEntriesError; RestorationFailure: typeof RestoreFailureError; SimulationFailed: typeof SimulationFailedError; UserRejected: typeof UserRejectedError };
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:338](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L338)
+**Source:** [src/contract/assembled_transaction.ts:339](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L339)
 
 ### `AssembledTransaction.build(options)`
 
@@ -284,7 +284,7 @@ const tx = await AssembledTransaction.build({
 })
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:572](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L572)
+**Source:** [src/contract/assembled_transaction.ts:573](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L573)
 
 ### `AssembledTransaction.buildWithOp(operation, options)`
 
@@ -316,7 +316,7 @@ const tx = await AssembledTransaction.buildWithOp(
 )
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:601](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L601)
+**Source:** [src/contract/assembled_transaction.ts:602](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L602)
 
 ### `AssembledTransaction.fromJSON(options, __namedParameters)`
 
@@ -329,7 +329,7 @@ static fromJSON<T>(options: Omit<AssembledTransactionOptions<T>, "args">, __name
 - **`options`** — `Omit<AssembledTransactionOptions<T>, "args">` (required)
 - **`__namedParameters`** — `{ simulationResult: { auth: string[]; retval: string }; simulationTransactionData: string; tx: string }` (required)
 
-**Source:** [src/contract/assembled_transaction.ts:433](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L433)
+**Source:** [src/contract/assembled_transaction.ts:434](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L434)
 
 ### `AssembledTransaction.fromXDR(options, encodedXDR, spec)`
 
@@ -345,7 +345,7 @@ static fromXDR<T>(options: Omit<AssembledTransactionOptions<T>, "args" | "method
 - **`encodedXDR`** — `string` (required)
 - **`spec`** — `Spec` (required)
 
-**Source:** [src/contract/assembled_transaction.ts:492](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L492)
+**Source:** [src/contract/assembled_transaction.ts:493](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L493)
 
 ### `assembledTransaction.built`
 
@@ -357,7 +357,7 @@ you call `tx.simulate()` again.
 built?: Transaction;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:285](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L285)
+**Source:** [src/contract/assembled_transaction.ts:286](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L286)
 
 ### `assembledTransaction.options`
 
@@ -365,7 +365,7 @@ built?: Transaction;
 options: AssembledTransactionOptions<T>;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:542](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L542)
+**Source:** [src/contract/assembled_transaction.ts:543](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L543)
 
 ### `assembledTransaction.raw`
 
@@ -386,7 +386,7 @@ await tx.simulate();
 raw?: TransactionBuilder;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:272](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L272)
+**Source:** [src/contract/assembled_transaction.ts:273](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L273)
 
 ### `assembledTransaction.signed`
 
@@ -396,7 +396,7 @@ The signed transaction.
 signed?: Transaction;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:331](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L331)
+**Source:** [src/contract/assembled_transaction.ts:332](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L332)
 
 ### `assembledTransaction.simulation`
 
@@ -410,7 +410,7 @@ logic.
 simulation?: SimulateTransactionResponse;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:294](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L294)
+**Source:** [src/contract/assembled_transaction.ts:295](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L295)
 
 ### `assembledTransaction.isReadCall`
 
@@ -423,7 +423,7 @@ returns `false`, then you need to call `signAndSend` on this transaction.
 readonly isReadCall: boolean;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:1089](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1089)
+**Source:** [src/contract/assembled_transaction.ts:1086](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1086)
 
 ### `assembledTransaction.result`
 
@@ -431,7 +431,7 @@ readonly isReadCall: boolean;
 readonly result: T;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:738](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L738)
+**Source:** [src/contract/assembled_transaction.ts:739](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L739)
 
 ### `assembledTransaction.simulationData`
 
@@ -439,7 +439,7 @@ readonly result: T;
 readonly simulationData: { result: SimulateHostFunctionResult; transactionData: SorobanTransactionData };
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:695](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L695)
+**Source:** [src/contract/assembled_transaction.ts:696](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L696)
 
 ### `assembledTransaction.needsNonInvokerSigningBy(__namedParameters)`
 
@@ -469,7 +469,7 @@ needsNonInvokerSigningBy(__namedParameters: { includeAlreadySigned?: boolean } =
 
 - **`__namedParameters`** — `{ includeAlreadySigned?: boolean }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:924](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L924)
+**Source:** [src/contract/assembled_transaction.ts:925](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L925)
 
 ### `assembledTransaction.restoreFootprint(restorePreamble, account)`
 
@@ -504,7 +504,7 @@ Client initialization.
 - - Throws a custom error if the
 restore transaction fails, providing the details of the failure.
 
-**Source:** [src/contract/assembled_transaction.ts:1118](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1118)
+**Source:** [src/contract/assembled_transaction.ts:1115](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1115)
 
 ### `assembledTransaction.send(watcher)`
 
@@ -521,7 +521,7 @@ send(watcher?: Watcher): Promise<SentTransaction<T>>;
 
 - **`watcher`** — `Watcher` (optional)
 
-**Source:** [src/contract/assembled_transaction.ts:853](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L853)
+**Source:** [src/contract/assembled_transaction.ts:854](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L854)
 
 ### `assembledTransaction.sign(__namedParameters)`
 
@@ -536,7 +536,7 @@ sign(__namedParameters: { force?: boolean; signTransaction?: SignTransaction } =
 
 - **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransaction }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:766](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L766)
+**Source:** [src/contract/assembled_transaction.ts:767](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L767)
 
 ### `assembledTransaction.signAndSend(__namedParameters)`
 
@@ -555,7 +555,7 @@ signAndSend(__namedParameters: { force?: boolean; signTransaction?: SignTransact
 
 - **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransaction; watcher?: Watcher }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:871](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L871)
+**Source:** [src/contract/assembled_transaction.ts:872](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L872)
 
 ### `assembledTransaction.signAuthEntries(__namedParameters)`
 
@@ -582,7 +582,7 @@ signAuthEntries(__namedParameters: { address?: string; authorizeEntry?: (entry: 
 
 - **`__namedParameters`** — `{ address?: string; authorizeEntry?: (entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string) => Promise<SorobanAuthorizationEntry>; expiration?: number | Promise<number>; signAuthEntry?: SignAuthEntry }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:985](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L985)
+**Source:** [src/contract/assembled_transaction.ts:982](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L982)
 
 ### `assembledTransaction.simulate(__namedParameters)`
 
@@ -594,7 +594,7 @@ simulate(__namedParameters: { restore?: boolean } = {}): Promise<AssembledTransa
 
 - **`__namedParameters`** — `{ restore?: boolean }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:642](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L642)
+**Source:** [src/contract/assembled_transaction.ts:643](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L643)
 
 ### `assembledTransaction.toJSON()`
 
@@ -607,7 +607,7 @@ transaction. This only works with transactions that have been simulated.
 toJSON(): string;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:360](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L360)
+**Source:** [src/contract/assembled_transaction.ts:361](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L361)
 
 ### `assembledTransaction.toXDR()`
 
@@ -617,7 +617,7 @@ Serialize the AssembledTransaction to a base64-encoded XDR string.
 toXDR(): string;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:480](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L480)
+**Source:** [src/contract/assembled_transaction.ts:481](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L481)
 
 ## contract.Client
 

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -423,7 +423,7 @@ returns `false`, then you need to call `signAndSend` on this transaction.
 readonly isReadCall: boolean;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:1086](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1086)
+**Source:** [src/contract/assembled_transaction.ts:1090](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1090)
 
 ### `assembledTransaction.result`
 
@@ -504,7 +504,7 @@ Client initialization.
 - - Throws a custom error if the
 restore transaction fails, providing the details of the failure.
 
-**Source:** [src/contract/assembled_transaction.ts:1115](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1115)
+**Source:** [src/contract/assembled_transaction.ts:1119](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1119)
 
 ### `assembledTransaction.send(watcher)`
 
@@ -582,7 +582,7 @@ signAuthEntries(__namedParameters: { address?: string; authorizeEntry?: (entry: 
 
 - **`__namedParameters`** — `{ address?: string; authorizeEntry?: (entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string) => Promise<SorobanAuthorizationEntry>; expiration?: number | Promise<number>; signAuthEntry?: SignAuthEntry }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:982](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L982)
+**Source:** [src/contract/assembled_transaction.ts:986](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L986)
 
 ### `assembledTransaction.simulate(__namedParameters)`
 

--- a/docs/reference/core-soroban-primitives.md
+++ b/docs/reference/core-soroban-primitives.md
@@ -875,6 +875,42 @@ buildWithDelegatesEntry(params: BuildWithDelegatesParams): SorobanAuthorizationE
 
 **Source:** [src/base/auth.ts:467](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L467)
 
+## checkAuthEntryReadiness
+
+Reports whether an authorization entry is ready to submit at a given ledger:
+fully signed and not yet expired.
+
+Source-account entries are always ready — they carry no signature or
+expiration of their own and are instead covered by the transaction envelope
+signature.
+
+The current ledger sequence is taken as a parameter (fetch it from a source
+you trust, e.g. `rpc.Server.getLatestLedger`) rather than looked up here, so
+this stays a pure decode with no network dependency.
+
+For `SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES`, this conservatively
+requires *every* node (top-level and all delegates) to be signed. An
+account's policy may accept an unsigned top-level node when its delegates
+have signed (CAP-71-01); if you support that, check
+`inspectAuthEntry`'s `signers` yourself.
+
+```ts
+checkAuthEntryReadiness(entry: SorobanAuthorizationEntry, currentLedgerSeq: number): AuthEntryReadiness
+```
+
+**Parameters**
+
+- **`entry`** — `SorobanAuthorizationEntry` (required) — the authorization entry to check
+- **`currentLedgerSeq`** — `number` (required) — the network's current ledger sequence, compared
+     (exclusively) against the entry's `signatureExpirationLedger`
+
+**Returns**
+
+a `AuthEntryReadiness`: `ready`, `expired`, and which
+   addresses are still `unsignedBy`
+
+**Source:** [src/base/auth.ts:819](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L819)
+
 ## humanizeEvents
 
 Converts raw diagnostic or contract events into something with a flatter,
@@ -896,6 +932,47 @@ humanizeEvents(events: ContractEvent[] | DiagnosticEvent[]): SorobanEvent[]
      friendly format
 
 **Source:** [src/base/events.ts:48](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/events.ts#L48)
+
+## inspectAuthEntry
+
+Decodes a `xdr.SorobanAuthorizationEntry` into a plain, typed summary:
+which credential variant it uses, which address authorizes it, its nonce and
+expiration ledger, and — for every node that can carry a signature (the
+top-level credentials plus any CAP-71 delegates) — whether it is signed and,
+when the payload uses the SDK's standard ed25519 format, by which keys.
+
+This is the read-side complement to `authorizeEntry` /
+`authorizeInvocation`: those fill entries with signatures, this
+inspects what an entry (e.g. one returned by transaction simulation, or
+received from a counterparty in a multi-party signing flow) requires and
+already carries, without reaching into raw XDR accessors.
+
+```ts
+inspectAuthEntry(entry: SorobanAuthorizationEntry): AuthEntryInfo
+```
+
+**Parameters**
+
+- **`entry`** — `SorobanAuthorizationEntry` (required) — the authorization entry to inspect
+
+**Returns**
+
+a `AuthEntryInfo` summary of the entry
+
+**Example**
+
+```ts
+const info = inspectAuthEntry(entry);
+if (!info.signed && info.address !== null) {
+  console.log(`${info.address} still needs to sign`, info.signers);
+}
+```
+
+**See also**
+
+- checkAuthEntryReadiness
+
+**Source:** [src/base/auth.ts:741](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L741)
 
 ## nativeToScVal
 
@@ -1124,6 +1201,255 @@ walkInvocationTree(root: SorobanAuthorizedInvocation, callback: InvocationWalker
 **Source:** [src/base/invocation.ts:229](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/invocation.ts#L229)
 
 ## Types
+
+### AuthEntryCredentialType
+
+The credential arm of a `xdr.SorobanAuthorizationEntry`.
+
+```ts
+type AuthEntryCredentialType = "sourceAccount" | "address" | "addressV2" | "addressWithDelegates"
+```
+
+**Source:** [src/base/auth.ts:624](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L624)
+
+### AuthEntryInfo
+
+A structured, read-only view of a `xdr.SorobanAuthorizationEntry`,
+returned by `inspectAuthEntry`.
+
+```ts
+interface AuthEntryInfo {
+  address: string | null;
+  credentialType: AuthEntryCredentialType;
+  invocation: SorobanAuthorizedInvocation;
+  nonce: bigint | null;
+  signatureExpirationLedger: number | null;
+  signed: boolean;
+  signers: AuthEntrySigner[];
+}
+```
+
+**Source:** [src/base/auth.ts:671](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L671)
+
+#### `authEntryInfo.address`
+
+the authorizing address, or `null` for source-account credentials.
+
+```ts
+address: string | null;
+```
+
+**Source:** [src/base/auth.ts:674](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L674)
+
+#### `authEntryInfo.credentialType`
+
+```ts
+credentialType: AuthEntryCredentialType;
+```
+
+**Source:** [src/base/auth.ts:672](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L672)
+
+#### `authEntryInfo.invocation`
+
+the invocation tree this entry authorizes.
+
+```ts
+invocation: SorobanAuthorizedInvocation;
+```
+
+**Source:** [src/base/auth.ts:700](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L700)
+
+#### `authEntryInfo.nonce`
+
+the credential nonce, or `null` for source-account credentials.
+
+```ts
+nonce: bigint | null;
+```
+
+**Source:** [src/base/auth.ts:676](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L676)
+
+#### `authEntryInfo.signatureExpirationLedger`
+
+the (exclusive) ledger sequence until which the signature is valid, or
+`null` for source-account credentials. Note that unsigned entries commonly
+carry a placeholder (often `0`) until `authorizeEntry` sets it.
+
+```ts
+signatureExpirationLedger: number | null;
+```
+
+**Source:** [src/base/auth.ts:682](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L682)
+
+#### `authEntryInfo.signed`
+
+whether every signer node carries a signature payload. Always `false` for
+source-account credentials (which have no signature nodes — they are
+instead covered by the transaction envelope signature; use
+`checkAuthEntryReadiness` for a submit check). For the delegates
+variant note that an account's policy may accept an unsigned top-level
+node when its delegates have signed (CAP-71-01) — consult `signers` if you
+support that.
+
+```ts
+signed: boolean;
+```
+
+**Source:** [src/base/auth.ts:698](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L698)
+
+#### `authEntryInfo.signers`
+
+every node that can carry a signature: the top-level credentials first,
+then (for the delegates variant) each delegate, depth-first. Empty for
+source-account credentials.
+
+```ts
+signers: AuthEntrySigner[];
+```
+
+**Source:** [src/base/auth.ts:688](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L688)
+
+### AuthEntryReadiness
+
+The result of `checkAuthEntryReadiness`.
+
+```ts
+interface AuthEntryReadiness {
+  expired: boolean;
+  ready: boolean;
+  unsignedBy: string[];
+}
+```
+
+**Source:** [src/base/auth.ts:704](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L704)
+
+#### `authEntryReadiness.expired`
+
+`true` when `currentLedgerSeq >= signatureExpirationLedger` (expiration is
+exclusive). Always `false` for source-account credentials.
+
+```ts
+expired: boolean;
+```
+
+**Source:** [src/base/auth.ts:711](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L711)
+
+#### `authEntryReadiness.ready`
+
+`true` when the entry is fully signed and not expired.
+
+```ts
+ready: boolean;
+```
+
+**Source:** [src/base/auth.ts:706](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L706)
+
+#### `authEntryReadiness.unsignedBy`
+
+addresses of signer nodes that carry no signature payload.
+
+```ts
+unsignedBy: string[];
+```
+
+**Source:** [src/base/auth.ts:713](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L713)
+
+### AuthEntrySignature
+
+A single ed25519 signature parsed out of a credential node's signature
+value, in the map format written by `authorizeEntry`.
+
+```ts
+interface AuthEntrySignature {
+  publicKey: string;
+  signature: Buffer;
+}
+```
+
+**Source:** [src/base/auth.ts:634](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L634)
+
+#### `authEntrySignature.publicKey`
+
+the signer's public key, as a `G…` strkey.
+
+```ts
+publicKey: string;
+```
+
+**Source:** [src/base/auth.ts:636](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L636)
+
+#### `authEntrySignature.signature`
+
+the raw 64-byte ed25519 signature.
+
+```ts
+signature: Buffer;
+```
+
+**Source:** [src/base/auth.ts:638](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L638)
+
+### AuthEntrySigner
+
+One node of an authorization entry that can carry a signature: the top-level
+address credentials and, for `SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES`,
+each (possibly nested) delegate.
+
+```ts
+interface AuthEntrySigner {
+  address: string;
+  rawSignature: ScVal;
+  signatures: AuthEntrySignature[] | null;
+  signed: boolean;
+}
+```
+
+**Source:** [src/base/auth.ts:646](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L646)
+
+#### `authEntrySigner.address`
+
+the node's address (`G…` account or `C…` contract).
+
+```ts
+address: string;
+```
+
+**Source:** [src/base/auth.ts:648](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L648)
+
+#### `authEntrySigner.rawSignature`
+
+the raw signature value, whatever its shape.
+
+```ts
+rawSignature: ScVal;
+```
+
+**Source:** [src/base/auth.ts:664](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L664)
+
+#### `authEntrySigner.signatures`
+
+the signature payload parsed as the SDK's standard ed25519 format (a vec
+of `{public_key, signature}` maps, see `authorizeEntry`), or `null`
+when the payload has some other, signer-defined shape (as custom accounts
+such as WebAuthn/passkey wallets use). An unsigned node parses as `[]`.
+
+```ts
+signatures: AuthEntrySignature[] | null;
+```
+
+**Source:** [src/base/auth.ts:662](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L662)
+
+#### `authEntrySigner.signed`
+
+whether a signature payload is present on this node (i.e. its signature is
+neither `scvVoid` nor an empty `scvVec`). For contract (`C…`) addresses
+this only means *something* is attached — whether it satisfies the
+contract's `__check_auth` cannot be verified client-side.
+
+```ts
+signed: boolean;
+```
+
+**Source:** [src/base/auth.ts:655](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L655)
 
 ### AuthorizeInvocationParams
 

--- a/docs/reference/core-soroban-primitives.md
+++ b/docs/reference/core-soroban-primitives.md
@@ -909,7 +909,13 @@ checkAuthEntryReadiness(entry: SorobanAuthorizationEntry, currentLedgerSeq: numb
 a `AuthEntryReadiness`: `ready`, `expired`, and which
    addresses are still `unsignedBy`
 
-**Source:** [src/base/auth.ts:819](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L819)
+**Throws**
+
+- `Error` if `currentLedgerSeq` cannot represent a uint32 ledger
+   sequence (non-integer, negative, or above 2^32 - 1), which would make the
+   expiration comparison unreliable
+
+**Source:** [src/base/auth.ts:825](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L825)
 
 ## humanizeEvents
 
@@ -972,7 +978,7 @@ if (!info.signed && info.address !== null) {
 
 - checkAuthEntryReadiness
 
-**Source:** [src/base/auth.ts:741](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L741)
+**Source:** [src/base/auth.ts:744](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L744)
 
 ## nativeToScVal
 
@@ -1229,7 +1235,7 @@ interface AuthEntryInfo {
 }
 ```
 
-**Source:** [src/base/auth.ts:671](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L671)
+**Source:** [src/base/auth.ts:674](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L674)
 
 #### `authEntryInfo.address`
 
@@ -1239,7 +1245,7 @@ the authorizing address, or `null` for source-account credentials.
 address: string | null;
 ```
 
-**Source:** [src/base/auth.ts:674](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L674)
+**Source:** [src/base/auth.ts:677](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L677)
 
 #### `authEntryInfo.credentialType`
 
@@ -1247,7 +1253,7 @@ address: string | null;
 credentialType: AuthEntryCredentialType;
 ```
 
-**Source:** [src/base/auth.ts:672](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L672)
+**Source:** [src/base/auth.ts:675](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L675)
 
 #### `authEntryInfo.invocation`
 
@@ -1257,7 +1263,7 @@ the invocation tree this entry authorizes.
 invocation: SorobanAuthorizedInvocation;
 ```
 
-**Source:** [src/base/auth.ts:700](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L700)
+**Source:** [src/base/auth.ts:703](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L703)
 
 #### `authEntryInfo.nonce`
 
@@ -1267,7 +1273,7 @@ the credential nonce, or `null` for source-account credentials.
 nonce: bigint | null;
 ```
 
-**Source:** [src/base/auth.ts:676](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L676)
+**Source:** [src/base/auth.ts:679](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L679)
 
 #### `authEntryInfo.signatureExpirationLedger`
 
@@ -1279,7 +1285,7 @@ carry a placeholder (often `0`) until `authorizeEntry` sets it.
 signatureExpirationLedger: number | null;
 ```
 
-**Source:** [src/base/auth.ts:682](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L682)
+**Source:** [src/base/auth.ts:685](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L685)
 
 #### `authEntryInfo.signed`
 
@@ -1295,7 +1301,7 @@ support that.
 signed: boolean;
 ```
 
-**Source:** [src/base/auth.ts:698](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L698)
+**Source:** [src/base/auth.ts:701](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L701)
 
 #### `authEntryInfo.signers`
 
@@ -1307,7 +1313,7 @@ source-account credentials.
 signers: AuthEntrySigner[];
 ```
 
-**Source:** [src/base/auth.ts:688](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L688)
+**Source:** [src/base/auth.ts:691](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L691)
 
 ### AuthEntryReadiness
 
@@ -1321,7 +1327,7 @@ interface AuthEntryReadiness {
 }
 ```
 
-**Source:** [src/base/auth.ts:704](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L704)
+**Source:** [src/base/auth.ts:707](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L707)
 
 #### `authEntryReadiness.expired`
 
@@ -1332,7 +1338,7 @@ exclusive). Always `false` for source-account credentials.
 expired: boolean;
 ```
 
-**Source:** [src/base/auth.ts:711](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L711)
+**Source:** [src/base/auth.ts:714](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L714)
 
 #### `authEntryReadiness.ready`
 
@@ -1342,7 +1348,7 @@ expired: boolean;
 ready: boolean;
 ```
 
-**Source:** [src/base/auth.ts:706](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L706)
+**Source:** [src/base/auth.ts:709](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L709)
 
 #### `authEntryReadiness.unsignedBy`
 
@@ -1352,7 +1358,7 @@ addresses of signer nodes that carry no signature payload.
 unsignedBy: string[];
 ```
 
-**Source:** [src/base/auth.ts:713](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L713)
+**Source:** [src/base/auth.ts:716](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L716)
 
 ### AuthEntrySignature
 
@@ -1423,20 +1429,23 @@ the raw signature value, whatever its shape.
 rawSignature: ScVal;
 ```
 
-**Source:** [src/base/auth.ts:664](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L664)
+**Source:** [src/base/auth.ts:667](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L667)
 
 #### `authEntrySigner.signatures`
 
 the signature payload parsed as the SDK's standard ed25519 format (a vec
 of `{public_key, signature}` maps, see `authorizeEntry`), or `null`
 when the payload has some other, signer-defined shape (as custom accounts
-such as WebAuthn/passkey wallets use). An unsigned node parses as `[]`.
+such as WebAuthn/passkey wallets use). Of the two unsigned placeholder
+forms, an empty `scvVec` parses as `[]` while `scvVoid` (not a vec at all)
+parses as `null` — check `signed` rather than this field to tell whether a
+node is unsigned.
 
 ```ts
 signatures: AuthEntrySignature[] | null;
 ```
 
-**Source:** [src/base/auth.ts:662](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L662)
+**Source:** [src/base/auth.ts:665](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L665)
 
 #### `authEntrySigner.signed`
 

--- a/src/base/auth.ts
+++ b/src/base/auth.ts
@@ -657,7 +657,10 @@ export interface AuthEntrySigner {
    * the signature payload parsed as the SDK's standard ed25519 format (a vec
    * of `{public_key, signature}` maps, see {@link authorizeEntry}), or `null`
    * when the payload has some other, signer-defined shape (as custom accounts
-   * such as WebAuthn/passkey wallets use). An unsigned node parses as `[]`.
+   * such as WebAuthn/passkey wallets use). Of the two unsigned placeholder
+   * forms, an empty `scvVec` parses as `[]` while `scvVoid` (not a vec at all)
+   * parses as `null` — check `signed` rather than this field to tell whether a
+   * node is unsigned.
    */
   signatures: AuthEntrySignature[] | null;
   /** the raw signature value, whatever its shape. */
@@ -815,11 +818,24 @@ export function inspectAuthEntry(
  *    (exclusively) against the entry's `signatureExpirationLedger`
  * @returns a {@link AuthEntryReadiness}: `ready`, `expired`, and which
  *    addresses are still `unsignedBy`
+ * @throws `Error` if `currentLedgerSeq` cannot represent a uint32 ledger
+ *    sequence (non-integer, negative, or above 2^32 - 1), which would make the
+ *    expiration comparison unreliable
  */
 export function checkAuthEntryReadiness(
   entry: xdr.SorobanAuthorizationEntry,
   currentLedgerSeq: number,
 ): AuthEntryReadiness {
+  if (
+    !Number.isInteger(currentLedgerSeq) ||
+    currentLedgerSeq < 0 ||
+    currentLedgerSeq > 0xffffffff
+  ) {
+    throw new Error(
+      `currentLedgerSeq must be a uint32 ledger sequence, got ${currentLedgerSeq}`,
+    );
+  }
+
   const info = inspectAuthEntry(entry);
   if (info.credentialType === "sourceAccount") {
     return { ready: true, expired: false, unsignedBy: [] };
@@ -889,7 +905,12 @@ function parseEd25519Signatures(
           return null;
       }
     }
-    if (publicKey === null || sig === null || publicKey.length !== 32) {
+    if (
+      publicKey === null ||
+      sig === null ||
+      publicKey.length !== 32 ||
+      sig.length !== 64
+    ) {
       return null;
     }
     parsed.push({

--- a/src/base/auth.ts
+++ b/src/base/auth.ts
@@ -620,6 +620,287 @@ function collectSignatureNodes(
   }
 }
 
+/** The credential arm of a {@link xdr.SorobanAuthorizationEntry}. */
+export type AuthEntryCredentialType =
+  | "sourceAccount"
+  | "address"
+  | "addressV2"
+  | "addressWithDelegates";
+
+/**
+ * A single ed25519 signature parsed out of a credential node's signature
+ * value, in the map format written by {@link authorizeEntry}.
+ */
+export interface AuthEntrySignature {
+  /** the signer's public key, as a `G…` strkey. */
+  publicKey: string;
+  /** the raw 64-byte ed25519 signature. */
+  signature: Buffer;
+}
+
+/**
+ * One node of an authorization entry that can carry a signature: the top-level
+ * address credentials and, for `SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES`,
+ * each (possibly nested) delegate.
+ */
+export interface AuthEntrySigner {
+  /** the node's address (`G…` account or `C…` contract). */
+  address: string;
+  /**
+   * whether a signature payload is present on this node (i.e. its signature is
+   * neither `scvVoid` nor an empty `scvVec`). For contract (`C…`) addresses
+   * this only means *something* is attached — whether it satisfies the
+   * contract's `__check_auth` cannot be verified client-side.
+   */
+  signed: boolean;
+  /**
+   * the signature payload parsed as the SDK's standard ed25519 format (a vec
+   * of `{public_key, signature}` maps, see {@link authorizeEntry}), or `null`
+   * when the payload has some other, signer-defined shape (as custom accounts
+   * such as WebAuthn/passkey wallets use). An unsigned node parses as `[]`.
+   */
+  signatures: AuthEntrySignature[] | null;
+  /** the raw signature value, whatever its shape. */
+  rawSignature: xdr.ScVal;
+}
+
+/**
+ * A structured, read-only view of a {@link xdr.SorobanAuthorizationEntry},
+ * returned by {@link inspectAuthEntry}.
+ */
+export interface AuthEntryInfo {
+  credentialType: AuthEntryCredentialType;
+  /** the authorizing address, or `null` for source-account credentials. */
+  address: string | null;
+  /** the credential nonce, or `null` for source-account credentials. */
+  nonce: bigint | null;
+  /**
+   * the (exclusive) ledger sequence until which the signature is valid, or
+   * `null` for source-account credentials. Note that unsigned entries commonly
+   * carry a placeholder (often `0`) until {@link authorizeEntry} sets it.
+   */
+  signatureExpirationLedger: number | null;
+  /**
+   * every node that can carry a signature: the top-level credentials first,
+   * then (for the delegates variant) each delegate, depth-first. Empty for
+   * source-account credentials.
+   */
+  signers: AuthEntrySigner[];
+  /**
+   * whether every signer node carries a signature payload. Always `false` for
+   * source-account credentials (which have no signature nodes — they are
+   * instead covered by the transaction envelope signature; use
+   * {@link checkAuthEntryReadiness} for a submit check). For the delegates
+   * variant note that an account's policy may accept an unsigned top-level
+   * node when its delegates have signed (CAP-71-01) — consult `signers` if you
+   * support that.
+   */
+  signed: boolean;
+  /** the invocation tree this entry authorizes. */
+  invocation: xdr.SorobanAuthorizedInvocation;
+}
+
+/** The result of {@link checkAuthEntryReadiness}. */
+export interface AuthEntryReadiness {
+  /** `true` when the entry is fully signed and not expired. */
+  ready: boolean;
+  /**
+   * `true` when `currentLedgerSeq >= signatureExpirationLedger` (expiration is
+   * exclusive). Always `false` for source-account credentials.
+   */
+  expired: boolean;
+  /** addresses of signer nodes that carry no signature payload. */
+  unsignedBy: string[];
+}
+
+/**
+ * Decodes a {@link xdr.SorobanAuthorizationEntry} into a plain, typed summary:
+ * which credential variant it uses, which address authorizes it, its nonce and
+ * expiration ledger, and — for every node that can carry a signature (the
+ * top-level credentials plus any CAP-71 delegates) — whether it is signed and,
+ * when the payload uses the SDK's standard ed25519 format, by which keys.
+ *
+ * This is the read-side complement to {@link authorizeEntry} /
+ * {@link authorizeInvocation}: those fill entries with signatures, this
+ * inspects what an entry (e.g. one returned by transaction simulation, or
+ * received from a counterparty in a multi-party signing flow) requires and
+ * already carries, without reaching into raw XDR accessors.
+ *
+ * @param entry - the authorization entry to inspect
+ * @returns a {@link AuthEntryInfo} summary of the entry
+ *
+ * @see checkAuthEntryReadiness
+ * @example
+ * ```ts
+ * const info = inspectAuthEntry(entry);
+ * if (!info.signed && info.address !== null) {
+ *   console.log(`${info.address} still needs to sign`, info.signers);
+ * }
+ * ```
+ */
+export function inspectAuthEntry(
+  entry: xdr.SorobanAuthorizationEntry,
+): AuthEntryInfo {
+  const credentials = entry.credentials();
+  const addrAuth = getAddressCredentials(credentials);
+
+  let credentialType: AuthEntryCredentialType;
+  switch (credentials.switch().value) {
+    case xdr.SorobanCredentialsType.sorobanCredentialsSourceAccount().value:
+      credentialType = "sourceAccount";
+      break;
+    case xdr.SorobanCredentialsType.sorobanCredentialsAddress().value:
+      credentialType = "address";
+      break;
+    case xdr.SorobanCredentialsType.sorobanCredentialsAddressV2().value:
+      credentialType = "addressV2";
+      break;
+    case xdr.SorobanCredentialsType.sorobanCredentialsAddressWithDelegates()
+      .value:
+      credentialType = "addressWithDelegates";
+      break;
+    default:
+      throw new Error(
+        `unsupported credential type ${credentials.switch().name}`,
+      );
+  }
+
+  const signers = collectSignatureNodes(credentials).map(
+    (node): AuthEntrySigner => {
+      const rawSignature = node.signature();
+      return {
+        address: Address.fromScAddress(node.address()).toString(),
+        signed: signaturePresent(rawSignature),
+        signatures: parseEd25519Signatures(rawSignature),
+        rawSignature,
+      };
+    },
+  );
+
+  return {
+    credentialType,
+    address:
+      addrAuth === null
+        ? null
+        : Address.fromScAddress(addrAuth.address()).toString(),
+    nonce: addrAuth === null ? null : addrAuth.nonce().toBigInt(),
+    signatureExpirationLedger:
+      addrAuth === null ? null : addrAuth.signatureExpirationLedger(),
+    signers,
+    signed: signers.length > 0 && signers.every((signer) => signer.signed),
+    invocation: entry.rootInvocation(),
+  };
+}
+
+/**
+ * Reports whether an authorization entry is ready to submit at a given ledger:
+ * fully signed and not yet expired.
+ *
+ * Source-account entries are always ready — they carry no signature or
+ * expiration of their own and are instead covered by the transaction envelope
+ * signature.
+ *
+ * The current ledger sequence is taken as a parameter (fetch it from a source
+ * you trust, e.g. `rpc.Server.getLatestLedger`) rather than looked up here, so
+ * this stays a pure decode with no network dependency.
+ *
+ * For `SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES`, this conservatively
+ * requires *every* node (top-level and all delegates) to be signed. An
+ * account's policy may accept an unsigned top-level node when its delegates
+ * have signed (CAP-71-01); if you support that, check
+ * {@link inspectAuthEntry}'s `signers` yourself.
+ *
+ * @param entry - the authorization entry to check
+ * @param currentLedgerSeq - the network's current ledger sequence, compared
+ *    (exclusively) against the entry's `signatureExpirationLedger`
+ * @returns a {@link AuthEntryReadiness}: `ready`, `expired`, and which
+ *    addresses are still `unsignedBy`
+ */
+export function checkAuthEntryReadiness(
+  entry: xdr.SorobanAuthorizationEntry,
+  currentLedgerSeq: number,
+): AuthEntryReadiness {
+  const info = inspectAuthEntry(entry);
+  if (info.credentialType === "sourceAccount") {
+    return { ready: true, expired: false, unsignedBy: [] };
+  }
+
+  const expired = currentLedgerSeq >= (info.signatureExpirationLedger ?? 0);
+  const unsignedBy = info.signers
+    .filter((signer) => !signer.signed)
+    .map((signer) => signer.address);
+
+  return { ready: !expired && unsignedBy.length === 0, expired, unsignedBy };
+}
+
+/**
+ * Internal helper. A node counts as unsigned when its signature is `scvVoid`
+ * (the delegate/CAP-71 placeholder) or an empty `scvVec` (the placeholder
+ * {@link authorizeInvocation} writes); anything else is a signature payload.
+ */
+function signaturePresent(signature: xdr.ScVal): boolean {
+  switch (signature.switch().value) {
+    case xdr.ScValType.scvVoid().value:
+      return false;
+    case xdr.ScValType.scvVec().value:
+      return (signature.vec() ?? []).length > 0;
+    default:
+      return true;
+  }
+}
+
+/**
+ * Internal helper. Parses a signature value in the SDK's standard format — an
+ * `scvVec` of `scvMap`s with symbol keys `public_key` (32 raw ed25519 key
+ * bytes) and `signature` — back into typed pairs. Returns `null` when the
+ * value has any other shape (e.g. a custom account's signer-defined payload).
+ */
+function parseEd25519Signatures(
+  signature: xdr.ScVal,
+): AuthEntrySignature[] | null {
+  if (signature.switch().value !== xdr.ScValType.scvVec().value) {
+    return null;
+  }
+
+  const parsed: AuthEntrySignature[] = [];
+  for (const element of signature.vec() ?? []) {
+    if (element.switch().value !== xdr.ScValType.scvMap().value) {
+      return null;
+    }
+    let publicKey: Buffer | null = null;
+    let sig: Buffer | null = null;
+    for (const mapEntry of element.map() ?? []) {
+      const key = mapEntry.key();
+      const val = mapEntry.val();
+      if (
+        key.switch().value !== xdr.ScValType.scvSymbol().value ||
+        val.switch().value !== xdr.ScValType.scvBytes().value
+      ) {
+        return null;
+      }
+      switch (key.sym().toString()) {
+        case "public_key":
+          publicKey = val.bytes();
+          break;
+        case "signature":
+          sig = val.bytes();
+          break;
+        default:
+          return null;
+      }
+    }
+    if (publicKey === null || sig === null || publicKey.length !== 32) {
+      return null;
+    }
+    parsed.push({
+      publicKey: StrKey.encodeEd25519PublicKey(publicKey),
+      signature: sig,
+    });
+  }
+
+  return parsed;
+}
+
 function bytesToInt64(bytes: Uint8Array): bigint {
   const buf = bytes.subarray(0, 8);
   if (buf.length < 8) {

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -81,12 +81,19 @@ export {
   authorizeInvocation,
   buildAuthorizationEntryPreimage,
   buildWithDelegatesEntry,
+  inspectAuthEntry,
+  checkAuthEntryReadiness,
 } from "./auth.js";
 export type {
   SigningCallback,
   AuthorizeInvocationParams,
   DelegateSignature,
   BuildWithDelegatesParams,
+  AuthEntryCredentialType,
+  AuthEntrySignature,
+  AuthEntrySigner,
+  AuthEntryInfo,
+  AuthEntryReadiness,
 } from "./auth.js";
 export * from "./invocation.js";
 export * from "./numbers/index.js";

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -955,8 +955,12 @@ export class AssembledTransaction<T> {
           .filter(
             (info) =>
               // skip source-account credentials (no address payload), which
-              // are covered by the envelope signature on the source account
-              info.address !== null && (includeAlreadySigned || !info.signed),
+              // are covered by the envelope signature on the source account.
+              // Only the top-level credentials (signers[0]) matter here — this
+              // method reports (and signAuthEntries signs) the top-level
+              // address, so unsigned delegate nodes must not keep it listed.
+              info.address !== null &&
+              (includeAlreadySigned || !info.signers[0].signed),
           )
           .map((info) => info.address as string),
       ),

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -9,6 +9,7 @@ import {
   SorobanDataBuilder,
   TransactionBuilder,
   authorizeEntry as stellarBaseAuthorizeEntry,
+  inspectAuthEntry,
   xdr,
 } from "../base/index.js";
 // internal helper (not part of the public API), imported directly from auth.js
@@ -950,18 +951,14 @@ export class AssembledTransaction<T> {
     return [
       ...new Set(
         (rawInvokeHostFunctionOp.auth ?? [])
-          .map((entry) => getAddressCredentials(entry.credentials()))
+          .map((entry) => inspectAuthEntry(entry))
           .filter(
-            (addrAuth): addrAuth is xdr.SorobanAddressCredentials =>
+            (info) =>
               // skip source-account credentials (no address payload), which
               // are covered by the envelope signature on the source account
-              addrAuth !== null &&
-              (includeAlreadySigned ||
-                addrAuth.signature().switch().name === "scvVoid"),
+              info.address !== null && (includeAlreadySigned || !info.signed),
           )
-          .map((addrAuth) =>
-            Address.fromScAddress(addrAuth.address()).toString(),
-          ),
+          .map((info) => info.address as string),
       ),
     ];
   };

--- a/test/unit/base/auth.test.ts
+++ b/test/unit/base/auth.test.ts
@@ -1069,6 +1069,30 @@ describe("inspecting authorization entries", () => {
       expect(info.signers[0].rawSignature.switch().name).toBe("scvBytes");
     });
 
+    it("rejects non-64-byte signatures as non-standard payloads", () => {
+      const malformed = xdr.ScVal.scvVec([
+        xdr.ScVal.scvMap([
+          new xdr.ScMapEntry({
+            key: xdr.ScVal.scvSymbol("public_key"),
+            val: xdr.ScVal.scvBytes(Buffer.alloc(32)),
+          }),
+          new xdr.ScMapEntry({
+            key: xdr.ScVal.scvSymbol("signature"),
+            val: xdr.ScVal.scvBytes(Buffer.alloc(1)),
+          }),
+        ]),
+      ]);
+      const entry = makeEntry(
+        xdr.SorobanCredentials.sorobanCredentialsAddress(
+          makeAddressCredentials(malformed),
+        ),
+      );
+
+      const info = inspectAuthEntry(entry);
+      expect(info.signed).toBe(true);
+      expect(info.signers[0].signatures).toBeNull();
+    });
+
     it("treats scvVoid as unsigned", () => {
       const entry = makeEntry(
         xdr.SorobanCredentials.sorobanCredentialsAddress(
@@ -1120,6 +1144,18 @@ describe("inspecting authorization entries", () => {
       const readiness = checkAuthEntryReadiness(entry, 1);
       expect(readiness.ready).toBe(false);
       expect(readiness.unsignedBy).toEqual([kp.publicKey()]);
+    });
+
+    it("rejects a currentLedgerSeq that is not a uint32", () => {
+      const entry = makeEntry(
+        xdr.SorobanCredentials.sorobanCredentialsAddress(
+          makeAddressCredentials(xdr.ScVal.scvVec([])),
+        ),
+      );
+
+      [NaN, -1, 1.5, 2 ** 32].forEach((bad) => {
+        expect(() => checkAuthEntryReadiness(entry, bad)).toThrow(/uint32/);
+      });
     });
 
     it("source-account entries are always ready", () => {

--- a/test/unit/base/auth.test.ts
+++ b/test/unit/base/auth.test.ts
@@ -4,6 +4,8 @@ import {
   authorizeInvocation,
   buildAuthorizationEntryPreimage,
   buildWithDelegatesEntry,
+  inspectAuthEntry,
+  checkAuthEntryReadiness,
   SigningCallback,
 } from "../../../src/base/auth.js";
 import { Keypair } from "../../../src/base/keypair.js";
@@ -909,6 +911,225 @@ describe("building authorization entries", () => {
         expect(StrKey.encodeEd25519PublicKey(sig.public_key)).toBe(
           delegate.publicKey(),
         );
+      });
+    });
+  });
+});
+
+describe("inspecting authorization entries", () => {
+  const kp = Keypair.random();
+  const contractId = "CA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQGAXE";
+
+  const invocation = new xdr.SorobanAuthorizedInvocation({
+    function:
+      xdr.SorobanAuthorizedFunction.sorobanAuthorizedFunctionTypeContractFn(
+        new xdr.InvokeContractArgs({
+          contractAddress: new Address(contractId).toScAddress(),
+          functionName: "hello",
+          args: [xdr.ScVal.scvU64(new xdr.Uint64(1234n))],
+        }),
+      ),
+    subInvocations: [],
+  });
+
+  const makeEntry = (
+    credentials: xdr.SorobanCredentials,
+  ): xdr.SorobanAuthorizationEntry =>
+    new xdr.SorobanAuthorizationEntry({
+      rootInvocation: invocation,
+      credentials,
+    });
+
+  const makeAddressCredentials = (signature: xdr.ScVal) =>
+    new xdr.SorobanAddressCredentials({
+      address: new Address(kp.publicKey()).toScAddress(),
+      nonce: new xdr.Int64(123456789101112n),
+      signatureExpirationLedger: 100,
+      signature,
+    });
+
+  describe("inspectAuthEntry", () => {
+    it("decodes an unsigned ADDRESS entry", () => {
+      const entry = makeEntry(
+        xdr.SorobanCredentials.sorobanCredentialsAddress(
+          makeAddressCredentials(xdr.ScVal.scvVec([])),
+        ),
+      );
+
+      const info = inspectAuthEntry(entry);
+      expect(info.credentialType).toBe("address");
+      expect(info.address).toBe(kp.publicKey());
+      expect(info.nonce).toBe(123456789101112n);
+      expect(info.signatureExpirationLedger).toBe(100);
+      expect(info.signed).toBe(false);
+      expect(info.signers).toHaveLength(1);
+      expect(info.signers[0]).toMatchObject({
+        address: kp.publicKey(),
+        signed: false,
+        signatures: [],
+      });
+      expect(info.invocation.toXDR()).toEqual(invocation.toXDR());
+    });
+
+    it("decodes a signed entry, parsing the ed25519 signature format", async () => {
+      const entry = makeEntry(
+        xdr.SorobanCredentials.sorobanCredentialsAddress(
+          makeAddressCredentials(xdr.ScVal.scvVec([])),
+        ),
+      );
+      const signed = await authorizeEntry(entry, kp, 424242, Networks.TESTNET);
+
+      const info = inspectAuthEntry(signed);
+      expect(info.signed).toBe(true);
+      expect(info.signatureExpirationLedger).toBe(424242);
+      const sigs = expectDefined(info.signers[0].signatures);
+      expect(sigs).toHaveLength(1);
+      expect(sigs[0].publicKey).toBe(kp.publicKey());
+      expect(sigs[0].signature).toHaveLength(64);
+    });
+
+    it("decodes ADDRESS_V2 entries", () => {
+      const entry = makeEntry(
+        xdr.SorobanCredentials.sorobanCredentialsAddressV2(
+          makeAddressCredentials(xdr.ScVal.scvVec([])),
+        ),
+      );
+      expect(inspectAuthEntry(entry).credentialType).toBe("addressV2");
+    });
+
+    it("decodes source-account entries", () => {
+      const entry = makeEntry(
+        xdr.SorobanCredentials.sorobanCredentialsSourceAccount(),
+      );
+
+      const info = inspectAuthEntry(entry);
+      expect(info.credentialType).toBe("sourceAccount");
+      expect(info.address).toBeNull();
+      expect(info.nonce).toBeNull();
+      expect(info.signatureExpirationLedger).toBeNull();
+      expect(info.signers).toHaveLength(0);
+      expect(info.signed).toBe(false);
+    });
+
+    it("enumerates delegate signers depth-first", async () => {
+      const delegate = Keypair.random();
+      const nested = Keypair.random();
+
+      const base = makeEntry(
+        xdr.SorobanCredentials.sorobanCredentialsAddressV2(
+          makeAddressCredentials(xdr.ScVal.scvVec([])),
+        ),
+      );
+      const entry = buildWithDelegatesEntry({
+        entry: base,
+        validUntilLedgerSeq: 100,
+        delegates: [
+          {
+            address: delegate.publicKey(),
+            nestedDelegates: [{ address: nested.publicKey() }],
+          },
+        ],
+      });
+      const signed = await authorizeEntry(
+        entry,
+        delegate,
+        100,
+        Networks.TESTNET,
+        delegate.publicKey(),
+      );
+
+      const info = inspectAuthEntry(signed);
+      expect(info.credentialType).toBe("addressWithDelegates");
+      expect(info.address).toBe(kp.publicKey());
+      expect(info.signers.map((s) => s.address)).toEqual([
+        kp.publicKey(),
+        delegate.publicKey(),
+        nested.publicKey(),
+      ]);
+      // top-level (scvVoid) and nested delegate are unsigned; delegate signed
+      expect(info.signers.map((s) => s.signed)).toEqual([false, true, false]);
+      expect(info.signed).toBe(false);
+      expect(expectDefined(info.signers[1].signatures)[0].publicKey).toBe(
+        delegate.publicKey(),
+      );
+    });
+
+    it("returns null signatures (but signed=true) for non-standard payloads", () => {
+      const entry = makeEntry(
+        xdr.SorobanCredentials.sorobanCredentialsAddress(
+          makeAddressCredentials(
+            xdr.ScVal.scvBytes(Buffer.alloc(64)), // e.g. a custom-account payload
+          ),
+        ),
+      );
+
+      const info = inspectAuthEntry(entry);
+      expect(info.signed).toBe(true);
+      expect(info.signers[0].signatures).toBeNull();
+      expect(info.signers[0].rawSignature.switch().name).toBe("scvBytes");
+    });
+
+    it("treats scvVoid as unsigned", () => {
+      const entry = makeEntry(
+        xdr.SorobanCredentials.sorobanCredentialsAddress(
+          makeAddressCredentials(xdr.ScVal.scvVoid()),
+        ),
+      );
+      const info = inspectAuthEntry(entry);
+      expect(info.signed).toBe(false);
+      expect(info.signers[0].signatures).toBeNull();
+    });
+  });
+
+  describe("checkAuthEntryReadiness", () => {
+    it("is ready when signed and unexpired", async () => {
+      const entry = makeEntry(
+        xdr.SorobanCredentials.sorobanCredentialsAddress(
+          makeAddressCredentials(xdr.ScVal.scvVec([])),
+        ),
+      );
+      const signed = await authorizeEntry(entry, kp, 1000, Networks.TESTNET);
+
+      expect(checkAuthEntryReadiness(signed, 999)).toEqual({
+        ready: true,
+        expired: false,
+        unsignedBy: [],
+      });
+    });
+
+    it("expires exclusively at signatureExpirationLedger", async () => {
+      const entry = makeEntry(
+        xdr.SorobanCredentials.sorobanCredentialsAddress(
+          makeAddressCredentials(xdr.ScVal.scvVec([])),
+        ),
+      );
+      const signed = await authorizeEntry(entry, kp, 1000, Networks.TESTNET);
+
+      const atExpiry = checkAuthEntryReadiness(signed, 1000);
+      expect(atExpiry.expired).toBe(true);
+      expect(atExpiry.ready).toBe(false);
+    });
+
+    it("reports unsigned addresses", () => {
+      const entry = makeEntry(
+        xdr.SorobanCredentials.sorobanCredentialsAddress(
+          makeAddressCredentials(xdr.ScVal.scvVec([])),
+        ),
+      );
+
+      const readiness = checkAuthEntryReadiness(entry, 1);
+      expect(readiness.ready).toBe(false);
+      expect(readiness.unsignedBy).toEqual([kp.publicKey()]);
+    });
+
+    it("source-account entries are always ready", () => {
+      const entry = makeEntry(
+        xdr.SorobanCredentials.sorobanCredentialsSourceAccount(),
+      );
+      expect(checkAuthEntryReadiness(entry, 999999999)).toEqual({
+        ready: true,
+        expired: false,
+        unsignedBy: [],
       });
     });
   });

--- a/test/unit/server/soroban/assembled_transaction.test.ts
+++ b/test/unit/server/soroban/assembled_transaction.test.ts
@@ -495,6 +495,26 @@ describe("AssembledTransaction auth entry credential types (CAP-71)", () => {
       expect(assembled.needsNonInvokerSigningBy()).toEqual([kpA.publicKey()]);
     });
 
+    it("keeps top-level semantics for delegate entries: a signed top level is excluded even with unsigned delegates", () => {
+      const entry = authEntry(
+        xdr.SorobanCredentials.sorobanCredentialsAddressWithDelegates(
+          new xdr.SorobanAddressCredentialsWithDelegates({
+            addressCredentials: addrCreds(kpB.publicKey(), true),
+            delegates: [
+              new xdr.SorobanDelegateSignature({
+                address: new Address(kpC.publicKey()).toScAddress(),
+                signature: xdr.ScVal.scvVoid(), // unsigned delegate
+                nestedDelegates: [],
+              }),
+            ],
+          }),
+        ),
+      );
+      const assembled = assembledWith([entry]);
+
+      expect(assembled.needsNonInvokerSigningBy()).toEqual([]);
+    });
+
     it("deduplicates repeated addresses across credential types", () => {
       const assembled = assembledWith([
         authEntry(addressV2Cred(kpA.publicKey())),

--- a/test/unit/server/soroban/assembled_transaction.test.ts
+++ b/test/unit/server/soroban/assembled_transaction.test.ts
@@ -87,7 +87,6 @@ describe("AssembledTransaction", () => {
       .mockResolvedValueOnce({ data: { result: getTransactionResponse } }); // getTransaction
 
     const txn = await contract.AssembledTransaction[
-      // eslint-disable-next-line @typescript-eslint/dot-notation
       "buildFootprintRestoreTransaction"
     ](
       options,
@@ -366,8 +365,8 @@ describe("AssembledTransaction auth entry credential types (CAP-71)", () => {
     ).toXDR("base64"),
   ]);
 
-  // unsigned auth entries carry an scvVoid signature; an scvVec signature
-  // marks an entry as already signed
+  // unsigned auth entries carry an scvVoid (or empty scvVec) signature; a
+  // non-empty scvVec signature marks an entry as already signed
   function addrCreds(
     pk: string,
     signed = false,
@@ -376,7 +375,9 @@ describe("AssembledTransaction auth entry credential types (CAP-71)", () => {
       address: new Address(pk).toScAddress(),
       nonce: new xdr.Int64(1),
       signatureExpirationLedger: 0,
-      signature: signed ? xdr.ScVal.scvVec([]) : xdr.ScVal.scvVoid(),
+      signature: signed
+        ? xdr.ScVal.scvVec([xdr.ScVal.scvBytes(Buffer.alloc(64))])
+        : xdr.ScVal.scvVoid(),
     });
   }
 
@@ -482,6 +483,16 @@ describe("AssembledTransaction auth entry credential types (CAP-71)", () => {
           .needsNonInvokerSigningBy({ includeAlreadySigned: true })
           .sort(),
       ).toEqual([kpA.publicKey(), kpB.publicKey()].sort());
+    });
+
+    it("treats an empty scvVec signature (authorizeInvocation's placeholder) as unsigned", () => {
+      const creds = addrCreds(kpA.publicKey());
+      creds.signature(xdr.ScVal.scvVec([]));
+      const assembled = assembledWith([
+        authEntry(xdr.SorobanCredentials.sorobanCredentialsAddress(creds)),
+      ]);
+
+      expect(assembled.needsNonInvokerSigningBy()).toEqual([kpA.publicKey()]);
     });
 
     it("deduplicates repeated addresses across credential types", () => {


### PR DESCRIPTION
## What

Adds a read-side decoding API for Soroban authorization entries in `src/base/auth.ts`, the complement to the existing `authorizeEntry`/`authorizeInvocation` write path:

- **`inspectAuthEntry(entry)`** decodes a `xdr.SorobanAuthorizationEntry` into a typed `AuthEntryInfo`: the credential type (`sourceAccount` / `address` / `addressV2` / `addressWithDelegates`), authorizing address, nonce, `signatureExpirationLedger`, the invocation tree, and a `signers` list covering the top-level credentials plus any CAP-71 delegates, depth-first. Each `AuthEntrySigner` reports its address, whether a signature payload is present, the parsed `{publicKey, signature}` pairs when the payload uses the SDK's standard ed25519 vec-of-maps format, and the raw `ScVal` otherwise — so signer-defined payloads from custom accounts (e.g. WebAuthn/passkey wallets) remain accessible even though they can't be structurally parsed or verified client-side.
- **`checkAuthEntryReadiness(entry, currentLedgerSeq)`** answers "is this ready to submit?", returning `{ ready, expired, unsignedBy }`. Expiration is compared exclusively against a caller-supplied current ledger sequence rather than fetched internally, keeping the function a pure decode with no network dependency (and leaving the choice of a trusted ledger source to the caller). Source-account entries are always ready, since they're covered by the transaction envelope signature.

`AssembledTransaction.needsNonInvokerSigningBy` is rewired onto the new decoder, which also fixes a latent inconsistency: an empty `scvVec` signature — the exact placeholder `authorizeInvocation` writes on unsigned entries — was treated as *signed* (only `scvVoid` counted as unsigned), so such entries were wrongly omitted from the needs-to-sign list. A regression test covers this, alongside new unit tests for both functions across all four credential variants, nested delegates, and non-standard signature payloads.

## Why

Smart-account authorization entries are opaque XDR today: an app receiving one (from simulation, or from a counterparty in a multi-party signing flow) can't tell which signers it requires, whether it's already signed, or when it expires without reaching into raw XDR union accessors. That's exactly what an agent operating under scoped, time-limited, revocable authority needs to reason about before submitting. The SDK already had all the pieces internally — `getAddressCredentials`, delegate-node traversal, the ed25519 signature map format — but only on the write path or as private helpers; this exposes them as a small, typed, public read API.

Closes #1468