### PR TITLE
Event bindings review fixes

### DIFF
--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -980,7 +980,7 @@ class Spec {
   events(): ScSpecEventV0[];
   eventTopicFilter(name: string, topicValues?: Record<string, any>): string[];
   findEntry(name: string): ScSpecEntry;
-  findEvent(name: string): ScSpecEventV0;
+  findEvent(name: string): ScSpecEventV0 | undefined;
   funcArgsToScVals(name: string, args: object): ScVal[];
   funcResToNative(name: string, val_or_base64: string | ScVal): any;
   funcs(): ScSpecFunctionV0[];
@@ -1135,7 +1135,7 @@ a single topic filter row
 const topics = contractSpec.eventTopicFilter('transfer', { to: someAddress });
 ```
 
-**Source:** [src/contract/spec.ts:1293](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1293)
+**Source:** [src/contract/spec.ts:1303](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1303)
 
 ### `spec.findEntry(name)`
 
@@ -1163,8 +1163,12 @@ the entry
 
 Finds the XDR event spec for the given event name.
 
+Unlike `Spec.findEntry`, a missing event is not an error: this
+returns `undefined` so callers can probe a contract for an event without
+wrapping the call in a `try`.
+
 ```ts
-findEvent(name: string): ScSpecEventV0;
+findEvent(name: string): ScSpecEventV0 | undefined;
 ```
 
 **Parameters**
@@ -1173,13 +1177,18 @@ findEvent(name: string): ScSpecEventV0;
 
 **Returns**
 
-the event spec
+the event spec, or `undefined` if the contract declares no event
+         with that name
 
-**Throws**
+**Example**
 
-- if no event with the given name exists
+```ts
+if (contractSpec.findEvent("transfer")) {
+  // the contract declares a "transfer" event
+}
+```
 
-**Source:** [src/contract/spec.ts:1236](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1236)
+**Source:** [src/contract/spec.ts:1246](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1246)
 
 ### `spec.funcArgsToScVals(name, args)`
 
@@ -1302,7 +1311,7 @@ the converted JSON schema
 
 - if the contract spec is invalid
 
-**Source:** [src/contract/spec.ts:1307](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1307)
+**Source:** [src/contract/spec.ts:1317](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1317)
 
 ### `spec.nativeToScVal(val, ty)`
 
@@ -1366,7 +1375,7 @@ if (parsed) {
 }
 ```
 
-**Source:** [src/contract/spec.ts:1268](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1268)
+**Source:** [src/contract/spec.ts:1278](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1278)
 
 ### `spec.scValStrToNative(scv, typeDef)`
 

--- a/src/bindings/client.ts
+++ b/src/bindings/client.ts
@@ -172,7 +172,7 @@ ${eventMethods}
         const fieldName = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(rawParamName)
           ? rawParamName
           : `"${escapeStringLiteral(rawParamName)}"`;
-        const fieldType = parseTypeFromTypeDef(param.type());
+        const fieldType = parseTypeFromTypeDef(param.type(), true);
         return `${fieldName}?: ${fieldType}`;
       })
       .join("; ");

--- a/src/bindings/client.ts
+++ b/src/bindings/client.ts
@@ -16,6 +16,10 @@ import {
 export class ClientGenerator {
   private spec: Spec;
 
+  // rawEventName -> resolved (possibly disambiguated) filter method name.
+  // Lazily computed on first use; see resolveEventFilterMethodNames().
+  private eventFilterMethodNames: Map<string, string> | null = null;
+
   constructor(spec: Spec) {
     this.spec = spec;
   }
@@ -148,12 +152,79 @@ ${eventMethods}
   }
 
   /**
+   * The `<camelCase>EventFilter` method name derived from an event name is
+   * not injective (e.g. "FooBar" and "foo_bar" both produce
+   * "fooBarEventFilter"), and it can just as easily collide with a
+   * generated contract function name (e.g. an event "transfer" plus a
+   * function "transferEventFilter"). Since function member names are
+   * load-bearing (called directly by users) and event filter names are
+   * already synthetic, function names always win: they are reserved first,
+   * in spec-entry order. Events are then resolved in spec-entry order,
+   * appending the smallest integer 2 or greater needed to make the name unique (and
+   * reserving whatever name results, so later events see it too). This is
+   * deterministic for a given spec.
+   */
+  private resolveEventFilterMethodNames(): Map<string, string> {
+    if (this.eventFilterMethodNames !== null) {
+      return this.eventFilterMethodNames;
+    }
+
+    const reserved = new Set<string>();
+
+    this.spec
+      .funcs()
+      .filter((func) => func.name().toString() !== "__constructor")
+      .forEach((func) => {
+        reserved.add(sanitizeIdentifier(func.name().toString()));
+      });
+
+    const resolved = new Map<string, string>();
+
+    this.spec.events().forEach((event) => {
+      const rawName = event.name().toString();
+      const preferred = `${toCamelCase(sanitizeIdentifier(rawName))}EventFilter`;
+
+      let candidate = preferred;
+      let suffix = 2;
+      while (reserved.has(candidate)) {
+        candidate = `${preferred}${suffix}`;
+        suffix += 1;
+      }
+
+      reserved.add(candidate);
+      resolved.set(rawName, candidate);
+    });
+
+    this.eventFilterMethodNames = resolved;
+    return resolved;
+  }
+
+  /**
+   * Compute the resolved (possibly disambiguated) filter method name for an
+   * event; see {@link resolveEventFilterMethodNames}.
+   */
+  private eventFilterMethodName(event: xdr.ScSpecEventV0): string {
+    const rawName = event.name().toString();
+    const resolved = this.resolveEventFilterMethodNames().get(rawName);
+    /* istanbul ignore next -- every event in the spec is reserved a name */
+    if (resolved === undefined) {
+      return `${toCamelCase(sanitizeIdentifier(rawName))}EventFilter`;
+    }
+    return resolved;
+  }
+
+  /**
    * Generate a per-event helper that builds a topics-filter row for
    * `Api.EventFilter.topics`, suitable for passing to server.getEvents.
    */
   private generateEventFilterMethod(event: xdr.ScSpecEventV0): string {
     const rawName = event.name().toString();
-    const methodName = `${toCamelCase(sanitizeIdentifier(rawName))}EventFilter`;
+    const methodName = this.eventFilterMethodName(event);
+    const preferredMethodName = `${toCamelCase(sanitizeIdentifier(rawName))}EventFilter`;
+    const renameNote =
+      methodName !== preferredMethodName
+        ? ` Note: renamed from "${preferredMethodName}" to avoid a collision with another generated name.`
+        : "";
     const topicParams = event
       .params()
       .filter(
@@ -180,7 +251,7 @@ ${eventMethods}
     const doc = formatJSDocComment(
       `Build a topics filter row for the "${rawName}" event, for use in ` +
         `\`Api.EventFilter.topics\` when calling \`server.getEvents\`. ` +
-        `Omitted fields match any value.`,
+        `Omitted fields match any value.${renameNote}`,
       2,
     );
 

--- a/src/bindings/types.ts
+++ b/src/bindings/types.ts
@@ -44,6 +44,10 @@ export interface EnumCase {
 export class TypeGenerator {
   private spec: Spec;
 
+  // rawEventName -> resolved (possibly disambiguated) interface name.
+  // Lazily computed on first use; see resolveEventInterfaceNames().
+  private eventInterfaceNames: Map<string, string> | null = null;
+
   constructor(spec: Spec) {
     this.spec = spec;
   }
@@ -276,10 +280,98 @@ ${members}
   }
 
   /**
-   * Compute the exported TS interface name for an event, e.g. "transfer" becomes "TransferEvent"
+   * Compute the exported TS interface name for an event, e.g. "transfer"
+   * becomes "TransferEvent". Resolved (and disambiguated if necessary) via
+   * {@link resolveEventInterfaceNames}, so every call site agrees.
    */
   private eventInterfaceName(event: xdr.ScSpecEventV0): string {
-    return `${toPascalCase(sanitizeIdentifier(event.name().toString()))}Event`;
+    const rawName = event.name().toString();
+    const resolved = this.resolveEventInterfaceNames().get(rawName);
+    /* istanbul ignore next -- every event in the spec is reserved a name */
+    if (resolved === undefined) {
+      return `${toPascalCase(sanitizeIdentifier(rawName))}Event`;
+    }
+    return resolved;
+  }
+
+  /**
+   * True if the given event's resolved interface name differs from its
+   * preferred (unsuffixed) form, i.e. it was disambiguated away from a
+   * collision.
+   */
+  private eventInterfaceNameWasRenamed(event: xdr.ScSpecEventV0): boolean {
+    const rawName = event.name().toString();
+    const preferred = `${toPascalCase(sanitizeIdentifier(rawName))}Event`;
+    return this.eventInterfaceName(event) !== preferred;
+  }
+
+  /**
+   * The name-normalization used for event interface names (and UDT type
+   * names) is not injective — e.g. events "FooBar" and "foo_bar" both
+   * produce the interface name "FooBarEvent", and an event can just as
+   * easily collide with a UDT (struct/union/enum) of the same generated
+   * name. Since UDT/function names are load-bearing (referenced directly in
+   * signatures) and event-derived names are already synthetic, UDT names
+   * always win: they are reserved first, in spec-entry order. Events are
+   * then resolved in spec-entry order, appending the smallest integer 2 or greater
+   * needed to make the name unique (and reserving whatever name results, so
+   * later events see it too). This is deterministic for a given spec.
+   */
+  private resolveEventInterfaceNames(): Map<string, string> {
+    if (this.eventInterfaceNames !== null) {
+      return this.eventInterfaceNames;
+    }
+
+    const reserved = new Set<string>();
+
+    for (const entry of this.spec.entries) {
+      switch (entry.switch()) {
+        case xdr.ScSpecEntryKind.scSpecEntryUdtStructV0():
+          reserved.add(
+            sanitizeIdentifier(entry.udtStructV0().name().toString()),
+          );
+          break;
+        case xdr.ScSpecEntryKind.scSpecEntryUdtUnionV0():
+          reserved.add(
+            sanitizeIdentifier(entry.udtUnionV0().name().toString()),
+          );
+          break;
+        case xdr.ScSpecEntryKind.scSpecEntryUdtEnumV0():
+          reserved.add(sanitizeIdentifier(entry.udtEnumV0().name().toString()));
+          break;
+        case xdr.ScSpecEntryKind.scSpecEntryUdtErrorEnumV0():
+          reserved.add(
+            sanitizeIdentifier(entry.udtErrorEnumV0().name().toString()),
+          );
+          break;
+        default:
+          break;
+      }
+    }
+
+    const resolved = new Map<string, string>();
+
+    for (const entry of this.spec.entries) {
+      if (entry.switch() !== xdr.ScSpecEntryKind.scSpecEntryEventV0()) {
+        continue;
+      }
+      const event = entry.eventV0();
+      const rawName = event.name().toString();
+      const preferred = `${toPascalCase(sanitizeIdentifier(rawName))}Event`;
+
+      let candidate = preferred;
+      let suffix = 2;
+      while (reserved.has(candidate)) {
+        candidate = `${preferred}${suffix}`;
+        suffix += 1;
+      }
+
+      reserved.add(candidate);
+      resolved.set(rawName, candidate);
+    }
+
+    this.eventInterfaceNames = resolved;
+    return resolved;
   }
 
   /**
@@ -288,8 +380,12 @@ ${members}
   private generateEvent(event: xdr.ScSpecEventV0): string {
     const rawName = event.name().toString();
     const name = this.eventInterfaceName(event);
+    const preferred = `${toPascalCase(sanitizeIdentifier(rawName))}Event`;
+    const renameNote = this.eventInterfaceNameWasRenamed(event)
+      ? `\n\nNote: renamed from "${preferred}" to avoid a collision with another generated name.`
+      : "";
     const doc = formatJSDocComment(
-      event.doc().toString() || `Event: ${rawName}`,
+      (event.doc().toString() || `Event: ${rawName}`) + renameNote,
       0,
     );
 

--- a/src/bindings/types.ts
+++ b/src/bindings/types.ts
@@ -321,8 +321,8 @@ ${members}
     if (this.eventInterfaceNames !== null) {
       return this.eventInterfaceNames;
     }
-
-    const reserved = new Set<string>();
+    // Reserve names that are already taken by UDTs and other special entries. ContractEvent is a special entry for the discriminated union of all events.
+    const reserved = new Set<string>(["ContractEvent"]);
 
     for (const entry of this.spec.entries) {
       switch (entry.switch()) {

--- a/src/contract/event_spec.ts
+++ b/src/contract/event_spec.ts
@@ -41,19 +41,15 @@ export function events(entries: xdr.ScSpecEntry[]): xdr.ScSpecEventV0[] {
  *
  * @param entries - the contract's XDR spec entries
  * @param name - the name of the event to find
- * @returns the event spec
- * @throws if no event with the given name exists
+ * @returns the event spec, or `undefined` if the contract declares no event
+ *          with that name
  * @hidden
  */
 export function findEvent(
   entries: xdr.ScSpecEntry[],
   name: string,
-): xdr.ScSpecEventV0 {
-  const found = events(entries).find((e) => e.name().toString() === name);
-  if (!found) {
-    throw new Error(`no such event: ${name}`);
-  }
-  return found;
+): xdr.ScSpecEventV0 | undefined {
+  return events(entries).find((e) => e.name().toString() === name);
 }
 
 /**
@@ -265,6 +261,9 @@ export function eventTopicFilter(
   topicValues?: Record<string, any>,
 ): string[] {
   const event = findEvent(entries, name);
+  if (!event) {
+    throw new Error(`no such event: ${name}`);
+  }
   const filter: string[] = event
     .prefixTopics()
     .map((topic) => xdr.ScVal.scvSymbol(topic.toString()).toXDR("base64"));

--- a/src/contract/event_spec.ts
+++ b/src/contract/event_spec.ts
@@ -176,7 +176,11 @@ export function parseEvent(
     // Treat any decode failure as a non-match and try the next candidate.
     try {
       const prefixLen = event.prefixTopics().length;
-      const dataOut: Record<string, any> = {};
+      // Param names come from an untrusted, on-chain contract spec, so a
+      // param literally named "__proto__" must not be able to reach the
+      // object's prototype via normal property assignment. A null-prototype
+      // object stores it as a plain own property instead.
+      const dataOut: Record<string, any> = Object.create(null);
       tlParams.forEach((param, i) => {
         const val = topicVals[prefixLen + i];
         dataOut[param.name().toString()] = spec.scValToNative(

--- a/src/contract/index.ts
+++ b/src/contract/index.ts
@@ -1,7 +1,7 @@
 export * from "./assembled_transaction.js";
 export * from "./basic_node_signer.js";
 export * from "./client.js";
-export * from "./event_spec.js";
+export type { ParsedEvent } from "./event_spec.js";
 export * from "./rust_result.js";
 export * from "./sent_transaction.js";
 export * from "./spec.js";

--- a/src/contract/spec.ts
+++ b/src/contract/spec.ts
@@ -1228,12 +1228,22 @@ export class Spec {
   /**
    * Finds the XDR event spec for the given event name.
    *
-   * @param name - the name of the event
-   * @returns the event spec
+   * Unlike {@link Spec.findEntry}, a missing event is not an error: this
+   * returns `undefined` so callers can probe a contract for an event without
+   * wrapping the call in a `try`.
    *
-   * @throws if no event with the given name exists
+   * @param name - the name of the event
+   * @returns the event spec, or `undefined` if the contract declares no event
+   *          with that name
+   *
+   * @example
+   * ```ts
+   * if (contractSpec.findEvent("transfer")) {
+   *   // the contract declares a "transfer" event
+   * }
+   * ```
    */
-  findEvent(name: string): xdr.ScSpecEventV0 {
+  findEvent(name: string): xdr.ScSpecEventV0 | undefined {
     return findEventImpl(this.entries, name);
   }
 

--- a/test/e2e/src/__snapshots__/bindings.test.ts.snap
+++ b/test/e2e/src/__snapshots__/bindings.test.ts.snap
@@ -85,7 +85,7 @@ export class Client extends ContractClient {
   /**
    * Build a topics filter row for the "SwapEvent" event, for use in \`Api.EventFilter.topics\` when calling \`server.getEvents\`. Omitted fields match any value.
    */
-  swapEventEventFilter(topicValues?: { from?: string; card?: RoyalCard }): string[] {
+  swapEventEventFilter(topicValues?: { from?: string | Address; card?: RoyalCard }): string[] {
     return this.spec.eventTopicFilter("SwapEvent", topicValues);
   }
   /**

--- a/test/e2e/src/non-sim-sac-transfer.test.ts
+++ b/test/e2e/src/non-sim-sac-transfer.test.ts
@@ -107,10 +107,18 @@ describe("Non-simulated SAC Transfer", () => {
       issuer,
       Operation.createStellarAssetContract({ asset: customAsset }),
     );
-    await submitTx(
-      issuer,
-      Operation.createStellarAssetContract({ asset: Asset.native() }),
-    );
+    // The native SAC has a fixed contract ID per network, so a previous run
+    // against the same network may have already deployed it.
+    try {
+      await submitTx(
+        issuer,
+        Operation.createStellarAssetContract({ asset: Asset.native() }),
+      );
+    } catch (e) {
+      if (!String(e).includes("ExistingValue")) {
+        throw e;
+      }
+    }
 
     context = { sender, receiver, issuer, customAsset };
   });

--- a/test/integration/bindings.test.ts
+++ b/test/integration/bindings.test.ts
@@ -1409,7 +1409,7 @@ describe("BindingGenerator", () => {
       expect(result.client).toContain("transferEventFilter(");
       expect(result.client).toContain("mintEventFilter(");
       expect(result.client).toContain(
-        "mintEventFilter(topicValues?: { to?: string })",
+        "mintEventFilter(topicValues?: { to?: string | Address })",
       );
 
       // Metadata is only used by a data-located param, so it appears in

--- a/test/unit/bindings/collisions.test.ts
+++ b/test/unit/bindings/collisions.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import { xdr, contract } from "../../../src/index.js";
+import { TypeGenerator } from "../../../src/bindings/types.js";
+import { ClientGenerator } from "../../../src/bindings/client.js";
+
+const { Spec } = contract;
+
+function param(
+  name: string,
+  type: xdr.ScSpecTypeDef,
+  location: xdr.ScSpecEventParamLocationV0,
+): xdr.ScSpecEventParamV0 {
+  return new xdr.ScSpecEventParamV0({ doc: "", name, type, location });
+}
+
+const TOPIC =
+  xdr.ScSpecEventParamLocationV0.scSpecEventParamLocationTopicList();
+const u32Type = xdr.ScSpecTypeDef.scSpecTypeU32();
+
+function eventEntry(name: string, prefixTopics: string[]): xdr.ScSpecEntry {
+  const event = new xdr.ScSpecEventV0({
+    doc: "",
+    lib: "",
+    name,
+    prefixTopics,
+    params: [param("value", u32Type, TOPIC)],
+    dataFormat: xdr.ScSpecEventDataFormat.scSpecEventDataFormatSingleValue(),
+  });
+  return xdr.ScSpecEntry.scSpecEntryEventV0(event);
+}
+
+function funcEntry(name: string): xdr.ScSpecEntry {
+  return xdr.ScSpecEntry.scSpecEntryFunctionV0(
+    new xdr.ScSpecFunctionV0({ doc: "", name, inputs: [], outputs: [] }),
+  );
+}
+
+function structEntry(name: string): xdr.ScSpecEntry {
+  return xdr.ScSpecEntry.scSpecEntryUdtStructV0(
+    new xdr.ScSpecUdtStructV0({
+      doc: "",
+      lib: "",
+      name,
+      fields: [
+        new xdr.ScSpecUdtStructFieldV0({
+          doc: "",
+          name: "value",
+          type: u32Type,
+        }),
+      ],
+    }),
+  );
+}
+
+describe("bindings generated-name collision resolution", () => {
+  it("disambiguates an event interface name that collides with a UDT name, keeping the UDT's name", () => {
+    const spec = new Spec([
+      structEntry("TransferEvent"),
+      eventEntry("transfer", ["transfer"]),
+    ]);
+    const generator = new TypeGenerator(spec);
+    const output = generator.generate();
+
+    // The UDT keeps its natural name.
+    expect(output).toMatch(/export interface TransferEvent \{/);
+    // The event is disambiguated to the next free suffix.
+    expect(output).toMatch(/export interface TransferEvent2 \{/);
+
+    // No duplicate/merged declarations.
+    const declMatches = output.match(/export interface (\w+) \{/g) ?? [];
+    const declNames = declMatches.map((m: string) =>
+      m.replace(/export interface (\w+) \{/, "$1"),
+    );
+    expect(new Set(declNames).size).toBe(declNames.length);
+    expect(declNames.sort()).toEqual(["TransferEvent", "TransferEvent2"]);
+
+    // The ContractEvent union references the renamed event interface.
+    expect(output).toMatch(/export type ContractEvent = TransferEvent2;/);
+
+    // The renamed event carries a JSDoc note explaining the rename.
+    expect(output).toMatch(/renamed from "TransferEvent" to avoid a collision/);
+  });
+
+  it("disambiguates two events that normalize to the same interface name, deterministically by spec order", () => {
+    const spec = new Spec([
+      eventEntry("FooBar", ["FooBar"]),
+      eventEntry("foo_bar", ["foo_bar"]),
+    ]);
+    const generator = new TypeGenerator(spec);
+    const output = generator.generate();
+
+    expect(output).toMatch(/export interface FooBarEvent \{/);
+    expect(output).toMatch(/export interface FooBarEvent2 \{/);
+
+    const declMatches = output.match(/export interface (\w+) \{/g) ?? [];
+    const declNames = declMatches.map((m: string) =>
+      m.replace(/export interface (\w+) \{/, "$1"),
+    );
+    expect(new Set(declNames).size).toBe(declNames.length);
+
+    expect(output).toMatch(/renamed from "FooBarEvent" to avoid a collision/);
+  });
+
+  it("disambiguates an event filter method that collides with a contract function member name, keeping the function's name", () => {
+    const spec = new Spec([
+      funcEntry("transferEventFilter"),
+      eventEntry("transfer", ["transfer"]),
+    ]);
+    const generator = new ClientGenerator(spec);
+    const output = generator.generate();
+
+    // The function keeps its natural name.
+    expect(output).toMatch(/transferEventFilter\(/);
+    // The event's filter method is disambiguated.
+    expect(output).toMatch(/transferEventFilter2\(/);
+
+    expect(output).toMatch(
+      /renamed from "transferEventFilter" to avoid a collision/,
+    );
+  });
+
+  it("disambiguates two events whose filter method names collide with each other", () => {
+    const spec = new Spec([
+      eventEntry("FooBar", ["FooBar"]),
+      eventEntry("foo_bar", ["foo_bar"]),
+    ]);
+    const generator = new ClientGenerator(spec);
+    const output = generator.generate();
+
+    expect(output).toMatch(/fooBarEventFilter\(/);
+    expect(output).toMatch(/fooBarEventFilter2\(/);
+  });
+
+  it("does not gratuitously rename when there is no collision", () => {
+    const spec = new Spec([
+      funcEntry("doThing"),
+      structEntry("SomeStruct"),
+      eventEntry("transfer", ["transfer"]),
+      eventEntry("mint", ["mint"]),
+    ]);
+
+    const typesOutput = new TypeGenerator(spec).generate();
+    expect(typesOutput).toMatch(/export interface TransferEvent \{/);
+    expect(typesOutput).toMatch(/export interface MintEvent \{/);
+    expect(typesOutput).not.toMatch(/renamed from/);
+    expect(typesOutput).not.toMatch(/TransferEvent2/);
+    expect(typesOutput).not.toMatch(/MintEvent2/);
+
+    const clientOutput = new ClientGenerator(spec).generate();
+    expect(clientOutput).toMatch(/transferEventFilter\(/);
+    expect(clientOutput).toMatch(/mintEventFilter\(/);
+    expect(clientOutput).not.toMatch(/renamed from/);
+  });
+
+  it("produces byte-identical output across repeated generation from the same spec", () => {
+    const spec = new Spec([
+      structEntry("TransferEvent"),
+      funcEntry("transferEventFilter"),
+      eventEntry("transfer", ["transfer"]),
+      eventEntry("FooBar", ["FooBar"]),
+      eventEntry("foo_bar", ["foo_bar"]),
+    ]);
+
+    const typeGen1 = new TypeGenerator(spec).generate();
+    const typeGen2 = new TypeGenerator(spec).generate();
+    expect(typeGen1).toBe(typeGen2);
+
+    const clientGen1 = new ClientGenerator(spec).generate();
+    const clientGen2 = new ClientGenerator(spec).generate();
+    expect(clientGen1).toBe(clientGen2);
+
+    // Also stable within a single generator instance (memoized resolution).
+    const generator = new TypeGenerator(spec);
+    expect(generator.generate()).toBe(generator.generate());
+  });
+});

--- a/test/unit/spec/event_spec.test.ts
+++ b/test/unit/spec/event_spec.test.ts
@@ -407,6 +407,32 @@ describe("Spec events", () => {
     });
   });
 
+  it("does not pollute the prototype for a param named __proto__", () => {
+    // Param names come from an untrusted on-chain contract spec; a param
+    // literally named "__proto__" must be stored as an own property, not
+    // interpreted as a prototype assignment.
+    const event = new xdr.ScSpecEventV0({
+      doc: "",
+      lib: "",
+      name: "evil",
+      prefixTopics: ["evil"],
+      params: [param("__proto__", u32Type, DATA)],
+      dataFormat: xdr.ScSpecEventDataFormat.scSpecEventDataFormatSingleValue(),
+    });
+    const spec = new Spec([entryFor(event)]);
+
+    const topics = [xdr.ScVal.scvSymbol("evil")];
+    const data = xdr.ScVal.scvU32(1337);
+
+    const parsed = spec.parseEvent(topics, data);
+    expect(parsed).toBeDefined();
+    expect(
+      Object.prototype.hasOwnProperty.call(parsed!.data, "__proto__"),
+    ).toBe(true);
+    expect((parsed!.data as any).__proto__).toBe(1337);
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
   it("builds eventTopicFilter with and without provided values", () => {
     const event = new xdr.ScSpecEventV0({
       doc: "",

--- a/test/unit/spec/event_spec.test.ts
+++ b/test/unit/spec/event_spec.test.ts
@@ -57,8 +57,28 @@ describe("Spec events", () => {
 
     expect(spec.events().length).toBe(1);
     expect(spec.events()[0].name().toString()).toBe("transfer");
-    expect(spec.findEvent("transfer").name().toString()).toBe("transfer");
-    expect(() => spec.findEvent("nope")).toThrow();
+    expect(spec.findEvent("transfer")?.name().toString()).toBe("transfer");
+  });
+
+  it("findEvent returns undefined for an undeclared event", () => {
+    // Unlike findEntry, probing for an absent event is not an error — callers
+    // filtering a mixed event stream shouldn't need a try/catch.
+    const event = new xdr.ScSpecEventV0({
+      doc: "",
+      lib: "",
+      name: "transfer",
+      prefixTopics: ["transfer"],
+      params: [param("from", addrType, TOPIC)],
+      dataFormat: xdr.ScSpecEventDataFormat.scSpecEventDataFormatSingleValue(),
+    });
+    const spec = new Spec([entryFor(event)]);
+
+    expect(spec.findEvent("nope")).toBeUndefined();
+    expect(() => spec.findEvent("nope")).not.toThrow();
+
+    // eventTopicFilter still throws: it builds a value, and there is no
+    // meaningful filter row for an event the contract doesn't declare.
+    expect(() => spec.eventTopicFilter("nope")).toThrow(/no such event: nope/);
   });
 
   it("parses singleValue data format events, round-tripping natives", () => {


### PR DESCRIPTION
## What

- `findEvent` now returns `undefined` for an unmatched event instead of throwing.
- Generated event names that collide after case conversion are disambiguated in the bindings output.
- Event filter topic values in generated bindings now use the input (encode-side) types.
- Parsed event data is stored on a null-prototype object, so keys like `constructor` can't collide with `Object.prototype`.
- The `event_spec` barrel now exports only `ParsedEvent`.
- The e2e SAC transfer test tolerates an already-deployed native SAC on reruns.