### PR TITLE
Accept a Signer or Keypair wherever signTransaction is accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,19 @@ A breaking change will get clearly marked in this log.
 
 ### Added
 - `@stellar/stellar-sdk/base` subpath export: import offline primitives like `StrKey` and `Keypair` without loading Horizon, RPC, or the SEP helpers and their networking dependencies([#1550](https://github.com/stellar/js-stellar-sdk/pull/1550)).
-- `contract.Signer`, an interface pairing a signing capability with the identity it signs as (`address`, plus the SEP-43 `signTransaction` and optional `signAuthEntry` shapes the SDK already accepted), and `contract.KeypairSigner`, a `Keypair`-backed implementation. `signTransaction` and `signAuthEntry` — on `ClientOptions`, on `MethodOptions`, and on `AssembledTransaction`'s `sign` / `signAndSend` / `signAuthEntries` — now accept a `Signer` or a bare `Keypair` in addition to a callback, so signing with a local key no longer means finding `basicNodeSigner` and spreading two functions. Existing callbacks are unaffected, and `publicKey` is still required: it is never inferred from the signer ([#1462](https://github.com/stellar/js-stellar-sdk/issues/1462), [#1063](https://github.com/stellar/js-stellar-sdk/issues/1063)).
-
-## Unreleased
-
-### Added
 - `authorizeEntry` / `authorizeInvocation` signing callbacks now receive the 32-byte signing payload (`hash(preimage.toXDR())`) as a second argument alongside the preimage, so signers — including HSMs and remote signers that only accept a digest — never have to re-derive it. Existing single-argument callbacks are unaffected ([#1532](https://github.com/stellar/js-stellar-sdk/issues/1532)).
 - `authorizeEntry` / `authorizeInvocation` now support non-Ed25519 signers: the signing callback may return `{ signatureScVal: xdr.ScVal, address?: string }`, and the given `ScVal` is written verbatim as the credentials' signature — no Ed25519 verification, no `{public_key, signature}` map, no `scvVec` wrapping. This lets smart-wallet / custom-account contracts (whose `__check_auth` expects its own signature structure) use the helper instead of hand-rolling preimage construction and credential assembly. The optional `address` routes the signature to a specific credential node, like `forAddress` ([#1530](https://github.com/stellar/js-stellar-sdk/issues/1530)).
+- `contract.Signer`, an interface pairing a signing capability with the identity it signs as (`address`, plus the SEP-43 `signTransaction` and optional `signAuthEntry` shapes the SDK already accepted), and `contract.KeypairSigner`, a `Keypair`-backed implementation. `signTransaction` and `signAuthEntry` — on `ClientOptions`, on `MethodOptions`, and on `AssembledTransaction`'s `sign` / `signAndSend` / `signAuthEntries` — now accept a `Signer` or a bare `Keypair` in addition to a callback, so signing with a local key no longer means finding `basicNodeSigner` and spreading two functions. A `Signer` may be implemented as a class with ordinary prototype methods. Also adds the `contract.SignTransactionLike` and `contract.SignAuthEntryLike` types, naming everything those options accept. Existing callbacks are unaffected, and `publicKey` is still required: it is never inferred from the signer ([#1567](https://github.com/stellar/js-stellar-sdk/pull/1567), closes [#1462](https://github.com/stellar/js-stellar-sdk/issues/1462) and [#1063](https://github.com/stellar/js-stellar-sdk/issues/1063)).
+
+  Not a breaking change: no runtime behavior changed, every previously accepted value is still accepted, and `basicNodeSigner`'s signature and output are unchanged. One **type-only** caveat — because these options are no longer exclusively function types, a type expression that derived the callback's shape from the option field needs updating:
+
+```diff
+-type SignOpts = Parameters<NonNullable<contract.ClientOptions["signTransaction"]>>[1]
++type SignOpts = Parameters<contract.SignTransaction>[1]
+```
+
+  Name `contract.SignTransaction` / `contract.SignAuthEntry` directly instead of deriving from the option field.
+
 ### Fixed
 - `Spec.scValToNative` now handles contract values typed as `Val`
   (`scSpecTypeVal`) by delegating to the generic `scValToNative` converter,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ A breaking change will get clearly marked in this log.
 
 ### Added
 - `@stellar/stellar-sdk/base` subpath export: import offline primitives like `StrKey` and `Keypair` without loading Horizon, RPC, or the SEP helpers and their networking dependencies([#1550](https://github.com/stellar/js-stellar-sdk/pull/1550)).
+- `contract.Signer`, an interface pairing a signing capability with the identity it signs as (`address`, plus the SEP-43 `signTransaction` and optional `signAuthEntry` shapes the SDK already accepted), and `contract.KeypairSigner`, a `Keypair`-backed implementation. `signTransaction` and `signAuthEntry` — on `ClientOptions`, on `MethodOptions`, and on `AssembledTransaction`'s `sign` / `signAndSend` / `signAuthEntries` — now accept a `Signer` or a bare `Keypair` in addition to a callback, so signing with a local key no longer means finding `basicNodeSigner` and spreading two functions. Existing callbacks are unaffected, and `publicKey` is still required: it is never inferred from the signer ([#1462](https://github.com/stellar/js-stellar-sdk/issues/1462), [#1063](https://github.com/stellar/js-stellar-sdk/issues/1063)).
 
 ## Unreleased
 

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -860,7 +860,7 @@ const client = await Client.from({
 });
 ```
 
-**Source:** [src/contract/signer.ts:62](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L62)
+**Source:** [src/contract/signer.ts:58](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L58)
 
 ### `new KeypairSigner(keypair, networkPassphrase)`
 
@@ -870,23 +870,22 @@ constructor(keypair: Keypair, networkPassphrase: string);
 
 **Parameters**
 
-- **`keypair`** — `Keypair` (required)
-- **`networkPassphrase`** — `string` (required)
+- **`keypair`** — `Keypair` (required) — the `Keypair` to sign with. Signing throws
+     `cannot sign: no secret key available` if it holds only a public key.
+- **`networkPassphrase`** — `string` (required) — passphrase of the network to sign for, used
+     whenever the caller does not pass one at signing time
 
-**Source:** [src/contract/signer.ts:71](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L71)
+**Source:** [src/contract/signer.ts:70](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L70)
 
 ### `keypairSigner.address`
 
-The keypair's Ed25519 account address (`G…`).
-
-Always `keypair.publicKey()`. `Signer.address` is broader — it may be
-a `C…` contract address — but a keypair-backed signer never is.
+The keypair's Ed25519 account address (`G…`), always `keypair.publicKey()`.
 
 ```ts
 readonly address: string;
 ```
 
-**Source:** [src/contract/signer.ts:69](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L69)
+**Source:** [src/contract/signer.ts:62](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L62)
 
 ### `keypairSigner.signAuthEntry`
 
@@ -896,7 +895,7 @@ Signs an auth entry preimage. Matches `signAuthEntry` from Freighter.
 signAuthEntry: SignAuthEntry;
 ```
 
-**Source:** [src/contract/signer.ts:97](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L97)
+**Source:** [src/contract/signer.ts:101](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L101)
 
 ### `keypairSigner.signTransaction`
 
@@ -906,7 +905,7 @@ Signs a transaction envelope. Matches `signTransaction` from Freighter.
 signTransaction: SignTransaction;
 ```
 
-**Source:** [src/contract/signer.ts:84](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L84)
+**Source:** [src/contract/signer.ts:88](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L88)
 
 ## contract.NULL_ACCOUNT
 
@@ -1770,13 +1769,14 @@ type SignAuthEntry = (authEntry: string, opts?: { address?: string; networkPassp
 
 ### contract.SignAuthEntryLike
 
-Anything accepted where a `signAuthEntry` callback is expected.
+Anything accepted where a `signAuthEntry` callback is expected: the raw
+SEP-43 callback, a `Signer`, or a `Keypair`.
 
 ```ts
 type SignAuthEntryLike = SignAuthEntry | Signer | Keypair
 ```
 
-**Source:** [src/contract/signer.ts:117](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L117)
+**Source:** [src/contract/signer.ts:122](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L122)
 
 ### contract.SignTransaction
 
@@ -1801,7 +1801,7 @@ SEP-43 callback, a `Signer`, or a `Keypair`.
 type SignTransactionLike = SignTransaction | Signer | Keypair
 ```
 
-**Source:** [src/contract/signer.ts:112](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L112)
+**Source:** [src/contract/signer.ts:116](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L116)
 
 ### contract.Signer
 
@@ -1819,13 +1819,13 @@ contract address for smart accounts, whose signatures are not Ed25519 at all.
 accepts (those of SEP-43 wallets such as Freighter), so an existing wallet
 object becomes a `Signer` by gaining an `address`.
 
-`signAuthEntry` is optional because not every wallet implements it; it is only
-needed for multi-party (non-invoker) auth entry signing.
+`signAuthEntry` is optional because not every wallet implements it; it is
+only needed for multi-party (non-invoker) auth entry signing.
 
-Accepted anywhere a `signTransaction` callback is, i.e. in
-`ClientOptions`, `MethodOptions`,
-`sign`, and
-`signAndSend`.
+Accepted wherever the SDK takes a signing callback: the `signTransaction` and
+`signAuthEntry` options on `ClientOptions` and `MethodOptions`, and the
+per-call overrides on `AssembledTransaction`'s `sign`, `signAndSend`, and
+`signAuthEntries`.
 
 ```ts
 interface Signer {

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -873,17 +873,20 @@ constructor(keypair: Keypair, networkPassphrase: string);
 - **`keypair`** — `Keypair` (required)
 - **`networkPassphrase`** — `string` (required)
 
-**Source:** [src/contract/signer.ts:65](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L65)
+**Source:** [src/contract/signer.ts:71](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L71)
 
 ### `keypairSigner.address`
 
-The address this signer signs as: `G…` for accounts, `C…` for contracts.
+The keypair's Ed25519 account address (`G…`).
+
+Always `keypair.publicKey()`. `Signer.address` is broader — it may be
+a `C…` contract address — but a keypair-backed signer never is.
 
 ```ts
 readonly address: string;
 ```
 
-**Source:** [src/contract/signer.ts:63](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L63)
+**Source:** [src/contract/signer.ts:69](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L69)
 
 ### `keypairSigner.signAuthEntry`
 
@@ -893,7 +896,7 @@ Signs an auth entry preimage. Matches `signAuthEntry` from Freighter.
 signAuthEntry: SignAuthEntry;
 ```
 
-**Source:** [src/contract/signer.ts:91](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L91)
+**Source:** [src/contract/signer.ts:97](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L97)
 
 ### `keypairSigner.signTransaction`
 
@@ -903,7 +906,7 @@ Signs a transaction envelope. Matches `signTransaction` from Freighter.
 signTransaction: SignTransaction;
 ```
 
-**Source:** [src/contract/signer.ts:78](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L78)
+**Source:** [src/contract/signer.ts:84](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L84)
 
 ## contract.NULL_ACCOUNT
 
@@ -1773,7 +1776,7 @@ Anything accepted where a `signAuthEntry` callback is expected.
 type SignAuthEntryLike = SignAuthEntry | Signer | Keypair
 ```
 
-**Source:** [src/contract/signer.ts:111](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L111)
+**Source:** [src/contract/signer.ts:117](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L117)
 
 ### contract.SignTransaction
 
@@ -1798,7 +1801,7 @@ SEP-43 callback, a `Signer`, or a `Keypair`.
 type SignTransactionLike = SignTransaction | Signer | Keypair
 ```
 
-**Source:** [src/contract/signer.ts:106](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L106)
+**Source:** [src/contract/signer.ts:112](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L112)
 
 ### contract.Signer
 

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -895,7 +895,7 @@ Signs an auth entry preimage. Matches `signAuthEntry` from Freighter.
 signAuthEntry: SignAuthEntry;
 ```
 
-**Source:** [src/contract/signer.ts:101](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L101)
+**Source:** [src/contract/signer.ts:103](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L103)
 
 ### `keypairSigner.signTransaction`
 
@@ -1776,7 +1776,7 @@ SEP-43 callback, a `Signer`, or a `Keypair`.
 type SignAuthEntryLike = SignAuthEntry | Signer | Keypair
 ```
 
-**Source:** [src/contract/signer.ts:122](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L122)
+**Source:** [src/contract/signer.ts:125](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L125)
 
 ### contract.SignTransaction
 
@@ -1801,7 +1801,7 @@ SEP-43 callback, a `Signer`, or a `Keypair`.
 type SignTransactionLike = SignTransaction | Signer | Keypair
 ```
 
-**Source:** [src/contract/signer.ts:116](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L116)
+**Source:** [src/contract/signer.ts:119](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L119)
 
 ### contract.Signer
 

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -227,16 +227,16 @@ class AssembledTransaction<T> {
   needsNonInvokerSigningBy(__namedParameters: { includeAlreadySigned?: boolean } = {}): string[];
   restoreFootprint(restorePreamble: { minResourceFee: string; transactionData: SorobanDataBuilder }, account?: Account): Promise<GetTransactionResponse>;
   send(watcher?: Watcher): Promise<SentTransaction<T>>;
-  sign(__namedParameters: { force?: boolean; signTransaction?: SignTransaction } = {}): Promise<void>;
-  signAndSend(__namedParameters: { force?: boolean; signTransaction?: SignTransaction; watcher?: Watcher } = {}): Promise<SentTransaction<T>>;
-  signAuthEntries(__namedParameters: { address?: string; authorizeEntry?: (entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string) => Promise<SorobanAuthorizationEntry>; expiration?: number | Promise<number>; signAuthEntry?: SignAuthEntry } = {}): Promise<void>;
+  sign(__namedParameters: { force?: boolean; signTransaction?: SignTransactionLike } = {}): Promise<void>;
+  signAndSend(__namedParameters: { force?: boolean; signTransaction?: SignTransactionLike; watcher?: Watcher } = {}): Promise<SentTransaction<T>>;
+  signAuthEntries(__namedParameters: { address?: string; authorizeEntry?: (entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string) => Promise<SorobanAuthorizationEntry>; expiration?: number | Promise<number>; signAuthEntry?: SignAuthEntryLike } = {}): Promise<void>;
   simulate(__namedParameters: { restore?: boolean } = {}): Promise<AssembledTransaction<T>>;
   toJSON(): string;
   toXDR(): string;
 }
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:258](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L258)
+**Source:** [src/contract/assembled_transaction.ts:261](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L261)
 
 ### `AssembledTransaction.Errors`
 
@@ -248,7 +248,7 @@ logic.
 static Errors: { ExpiredState: typeof ExpiredStateError; ExternalServiceError: typeof ExternalServiceError; FakeAccount: typeof FakeAccountError; InternalWalletError: typeof InternalWalletError; InvalidClientRequest: typeof InvalidClientRequestError; NeedsMoreSignatures: typeof NeedsMoreSignaturesError; NoSignatureNeeded: typeof NoSignatureNeededError; NoSigner: typeof NoSignerError; NotYetSimulated: typeof NotYetSimulatedError; NoUnsignedNonInvokerAuthEntries: typeof NoUnsignedNonInvokerAuthEntriesError; RestorationFailure: typeof RestoreFailureError; SimulationFailed: typeof SimulationFailedError; UserRejected: typeof UserRejectedError };
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:339](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L339)
+**Source:** [src/contract/assembled_transaction.ts:342](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L342)
 
 ### `AssembledTransaction.build(options)`
 
@@ -284,7 +284,7 @@ const tx = await AssembledTransaction.build({
 })
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:573](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L573)
+**Source:** [src/contract/assembled_transaction.ts:576](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L576)
 
 ### `AssembledTransaction.buildWithOp(operation, options)`
 
@@ -316,7 +316,7 @@ const tx = await AssembledTransaction.buildWithOp(
 )
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:602](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L602)
+**Source:** [src/contract/assembled_transaction.ts:605](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L605)
 
 ### `AssembledTransaction.fromJSON(options, __namedParameters)`
 
@@ -329,7 +329,7 @@ static fromJSON<T>(options: Omit<AssembledTransactionOptions<T>, "args">, __name
 - **`options`** — `Omit<AssembledTransactionOptions<T>, "args">` (required)
 - **`__namedParameters`** — `{ simulationResult: { auth: string[]; retval: string }; simulationTransactionData: string; tx: string }` (required)
 
-**Source:** [src/contract/assembled_transaction.ts:434](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L434)
+**Source:** [src/contract/assembled_transaction.ts:437](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L437)
 
 ### `AssembledTransaction.fromXDR(options, encodedXDR, spec)`
 
@@ -345,7 +345,7 @@ static fromXDR<T>(options: Omit<AssembledTransactionOptions<T>, "args" | "method
 - **`encodedXDR`** — `string` (required)
 - **`spec`** — `Spec` (required)
 
-**Source:** [src/contract/assembled_transaction.ts:493](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L493)
+**Source:** [src/contract/assembled_transaction.ts:496](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L496)
 
 ### `assembledTransaction.built`
 
@@ -357,7 +357,7 @@ you call `tx.simulate()` again.
 built?: Transaction;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:286](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L286)
+**Source:** [src/contract/assembled_transaction.ts:289](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L289)
 
 ### `assembledTransaction.options`
 
@@ -365,7 +365,7 @@ built?: Transaction;
 options: AssembledTransactionOptions<T>;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:543](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L543)
+**Source:** [src/contract/assembled_transaction.ts:546](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L546)
 
 ### `assembledTransaction.raw`
 
@@ -386,7 +386,7 @@ await tx.simulate();
 raw?: TransactionBuilder;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:273](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L273)
+**Source:** [src/contract/assembled_transaction.ts:276](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L276)
 
 ### `assembledTransaction.signed`
 
@@ -396,7 +396,7 @@ The signed transaction.
 signed?: Transaction;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:332](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L332)
+**Source:** [src/contract/assembled_transaction.ts:335](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L335)
 
 ### `assembledTransaction.simulation`
 
@@ -410,7 +410,7 @@ logic.
 simulation?: SimulateTransactionResponse;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:295](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L295)
+**Source:** [src/contract/assembled_transaction.ts:298](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L298)
 
 ### `assembledTransaction.isReadCall`
 
@@ -423,7 +423,7 @@ returns `false`, then you need to call `signAndSend` on this transaction.
 readonly isReadCall: boolean;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:1090](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1090)
+**Source:** [src/contract/assembled_transaction.ts:1108](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1108)
 
 ### `assembledTransaction.result`
 
@@ -431,7 +431,7 @@ readonly isReadCall: boolean;
 readonly result: T;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:739](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L739)
+**Source:** [src/contract/assembled_transaction.ts:742](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L742)
 
 ### `assembledTransaction.simulationData`
 
@@ -439,7 +439,7 @@ readonly result: T;
 readonly simulationData: { result: SimulateHostFunctionResult; transactionData: SorobanTransactionData };
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:696](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L696)
+**Source:** [src/contract/assembled_transaction.ts:699](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L699)
 
 ### `assembledTransaction.needsNonInvokerSigningBy(__namedParameters)`
 
@@ -469,7 +469,7 @@ needsNonInvokerSigningBy(__namedParameters: { includeAlreadySigned?: boolean } =
 
 - **`__namedParameters`** — `{ includeAlreadySigned?: boolean }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:925](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L925)
+**Source:** [src/contract/assembled_transaction.ts:935](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L935)
 
 ### `assembledTransaction.restoreFootprint(restorePreamble, account)`
 
@@ -504,7 +504,7 @@ Client initialization.
 - - Throws a custom error if the
 restore transaction fails, providing the details of the failure.
 
-**Source:** [src/contract/assembled_transaction.ts:1119](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1119)
+**Source:** [src/contract/assembled_transaction.ts:1137](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1137)
 
 ### `assembledTransaction.send(watcher)`
 
@@ -521,7 +521,7 @@ send(watcher?: Watcher): Promise<SentTransaction<T>>;
 
 - **`watcher`** — `Watcher` (optional)
 
-**Source:** [src/contract/assembled_transaction.ts:854](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L854)
+**Source:** [src/contract/assembled_transaction.ts:860](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L860)
 
 ### `assembledTransaction.sign(__namedParameters)`
 
@@ -529,14 +529,14 @@ Sign the transaction with the signTransaction function included previously.
 If you did not previously include one, you need to include one now.
 
 ```ts
-sign(__namedParameters: { force?: boolean; signTransaction?: SignTransaction } = {}): Promise<void>;
+sign(__namedParameters: { force?: boolean; signTransaction?: SignTransactionLike } = {}): Promise<void>;
 ```
 
 **Parameters**
 
-- **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransaction }` (optional) (default: `{}`)
+- **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransactionLike }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:767](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L767)
+**Source:** [src/contract/assembled_transaction.ts:770](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L770)
 
 ### `assembledTransaction.signAndSend(__namedParameters)`
 
@@ -548,14 +548,14 @@ the transaction. You may pass a `Watcher` to keep
 track of this progress.
 
 ```ts
-signAndSend(__namedParameters: { force?: boolean; signTransaction?: SignTransaction; watcher?: Watcher } = {}): Promise<SentTransaction<T>>;
+signAndSend(__namedParameters: { force?: boolean; signTransaction?: SignTransactionLike; watcher?: Watcher } = {}): Promise<SentTransaction<T>>;
 ```
 
 **Parameters**
 
-- **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransaction; watcher?: Watcher }` (optional) (default: `{}`)
+- **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransactionLike; watcher?: Watcher }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:872](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L872)
+**Source:** [src/contract/assembled_transaction.ts:878](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L878)
 
 ### `assembledTransaction.signAuthEntries(__namedParameters)`
 
@@ -575,14 +575,14 @@ Sending to all `needsNonInvokerSigningBy` owners in parallel is not
 currently supported!
 
 ```ts
-signAuthEntries(__namedParameters: { address?: string; authorizeEntry?: (entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string) => Promise<SorobanAuthorizationEntry>; expiration?: number | Promise<number>; signAuthEntry?: SignAuthEntry } = {}): Promise<void>;
+signAuthEntries(__namedParameters: { address?: string; authorizeEntry?: (entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string) => Promise<SorobanAuthorizationEntry>; expiration?: number | Promise<number>; signAuthEntry?: SignAuthEntryLike } = {}): Promise<void>;
 ```
 
 **Parameters**
 
-- **`__namedParameters`** — `{ address?: string; authorizeEntry?: (entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string) => Promise<SorobanAuthorizationEntry>; expiration?: number | Promise<number>; signAuthEntry?: SignAuthEntry }` (optional) (default: `{}`)
+- **`__namedParameters`** — `{ address?: string; authorizeEntry?: (entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string) => Promise<SorobanAuthorizationEntry>; expiration?: number | Promise<number>; signAuthEntry?: SignAuthEntryLike }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:986](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L986)
+**Source:** [src/contract/assembled_transaction.ts:996](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L996)
 
 ### `assembledTransaction.simulate(__namedParameters)`
 
@@ -594,7 +594,7 @@ simulate(__namedParameters: { restore?: boolean } = {}): Promise<AssembledTransa
 
 - **`__namedParameters`** — `{ restore?: boolean }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:643](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L643)
+**Source:** [src/contract/assembled_transaction.ts:646](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L646)
 
 ### `assembledTransaction.toJSON()`
 
@@ -607,7 +607,7 @@ transaction. This only works with transactions that have been simulated.
 toJSON(): string;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:361](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L361)
+**Source:** [src/contract/assembled_transaction.ts:364](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L364)
 
 ### `assembledTransaction.toXDR()`
 
@@ -617,7 +617,7 @@ Serialize the AssembledTransaction to a base64-encoded XDR string.
 toXDR(): string;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:481](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L481)
+**Source:** [src/contract/assembled_transaction.ts:484](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L484)
 
 ## contract.Client
 
@@ -825,7 +825,85 @@ _before_ transaction signing.
 const DEFAULT_TIMEOUT: number
 ```
 
-**Source:** [src/contract/types.ts:293](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L293)
+**Source:** [src/contract/types.ts:298](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L298)
+
+## contract.KeypairSigner
+
+A `Signer` backed by a local `Keypair`.
+
+Suitable for Node applications, scripts, and tests — anywhere the secret key
+lives in the same process. For browser applications, use the SEP-43 wallet's
+own `signTransaction`, or wrap it in an object satisfying `Signer`.
+
+```ts
+class KeypairSigner implements Signer {
+  constructor(keypair: Keypair, networkPassphrase: string);
+  readonly address: string;
+  signAuthEntry: SignAuthEntry;
+  signTransaction: SignTransaction;
+}
+```
+
+**Example**
+
+```ts
+import { Keypair } from "@stellar/stellar-sdk";
+import { Client, KeypairSigner } from "@stellar/stellar-sdk/contract";
+
+const keypair = Keypair.fromSecret(secret);
+const client = await Client.from({
+  contractId,
+  networkPassphrase,
+  rpcUrl,
+  publicKey: keypair.publicKey(),
+  signTransaction: new KeypairSigner(keypair, networkPassphrase),
+});
+```
+
+**Source:** [src/contract/signer.ts:62](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L62)
+
+### `new KeypairSigner(keypair, networkPassphrase)`
+
+```ts
+constructor(keypair: Keypair, networkPassphrase: string);
+```
+
+**Parameters**
+
+- **`keypair`** — `Keypair` (required)
+- **`networkPassphrase`** — `string` (required)
+
+**Source:** [src/contract/signer.ts:65](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L65)
+
+### `keypairSigner.address`
+
+The address this signer signs as: `G…` for accounts, `C…` for contracts.
+
+```ts
+readonly address: string;
+```
+
+**Source:** [src/contract/signer.ts:63](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L63)
+
+### `keypairSigner.signAuthEntry`
+
+Signs an auth entry preimage. Matches `signAuthEntry` from Freighter.
+
+```ts
+signAuthEntry: SignAuthEntry;
+```
+
+**Source:** [src/contract/signer.ts:91](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L91)
+
+### `keypairSigner.signTransaction`
+
+Signs a transaction envelope. Matches `signTransaction` from Freighter.
+
+```ts
+signTransaction: SignTransaction;
+```
+
+**Source:** [src/contract/signer.ts:78](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L78)
 
 ## contract.NULL_ACCOUNT
 
@@ -835,7 +913,7 @@ An impossible account on the Stellar network
 const NULL_ACCOUNT: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
 ```
 
-**Source:** [src/contract/types.ts:299](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L299)
+**Source:** [src/contract/types.ts:304](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L304)
 
 ## contract.SentTransaction
 
@@ -1470,6 +1548,10 @@ those classes. This is useful for testing and maybe some simple Node
 applications. Feel free to use this as a starting point for your own
 Wallet/TransactionSigner implementation.
 
+Prefer `KeypairSigner`, which does the same thing and also carries the
+signer's address, so you can pass one object instead of spreading two
+functions. You can also pass a `Keypair` directly as `signTransaction`.
+
 ```ts
 basicNodeSigner(keypair: Keypair, networkPassphrase: string): { signAuthEntry: SignAuthEntry; signTransaction: SignTransaction }
 ```
@@ -1479,7 +1561,7 @@ basicNodeSigner(keypair: Keypair, networkPassphrase: string): { signAuthEntry: S
 - **`keypair`** — `Keypair` (required) — `Keypair` to use to sign the transaction or auth entry
 - **`networkPassphrase`** — `string` (required) — passphrase of network to sign for
 
-**Source:** [src/contract/basic_node_signer.ts:16](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/basic_node_signer.ts#L16)
+**Source:** [src/contract/basic_node_signer.ts:20](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/basic_node_signer.ts#L20)
 
 ## Types
 
@@ -1489,17 +1571,17 @@ basicNodeSigner(keypair: Keypair, networkPassphrase: string): { signAuthEntry: S
 type AssembledTransactionOptions<T = string> = MethodOptions & ClientOptions & { address?: string; args?: any[]; method: string; parseResultXdr: (xdr: xdr.ScVal) => T; submit?: boolean; submitUrl?: string }
 ```
 
-**Source:** [src/contract/types.ts:261](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L261)
+**Source:** [src/contract/types.ts:266](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L266)
 
 ### contract.ClientOptions
 
 Options for a smart contract client.
 
 ```ts
-type ClientOptions = { allowHttp?: boolean; contractId: string; errorTypes?: Record<number, { message: string }>; headers?: Record<string, string>; networkPassphrase: string; publicKey?: string; rpcUrl: string; server?: Server; signAuthEntry?: SignAuthEntry; signTransaction?: SignTransaction }
+type ClientOptions = { allowHttp?: boolean; contractId: string; errorTypes?: Record<number, { message: string }>; headers?: Record<string, string>; networkPassphrase: string; publicKey?: string; rpcUrl: string; server?: Server; signAuthEntry?: SignAuthEntryLike; signTransaction?: SignTransactionLike }
 ```
 
-**Source:** [src/contract/types.ts:128](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L128)
+**Source:** [src/contract/types.ts:129](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L129)
 
 ### contract.Duration
 
@@ -1509,7 +1591,7 @@ An unsigned 64-bit integer.
 type Duration = bigint
 ```
 
-**Source:** [src/contract/types.ts:54](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L54)
+**Source:** [src/contract/types.ts:55](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L55)
 
 ### contract.ErrorMessage
 
@@ -1540,10 +1622,10 @@ message: string;
 Options for a smart contract method invocation.
 
 ```ts
-type MethodOptions = { fee?: string; publicKey?: string; restore?: boolean; signAuthEntry?: SignAuthEntry; signTransaction?: SignTransaction; simulate?: boolean; timeoutInSeconds?: number }
+type MethodOptions = { fee?: string; publicKey?: string; restore?: boolean; signAuthEntry?: SignAuthEntryLike; signTransaction?: SignTransactionLike; simulate?: boolean; timeoutInSeconds?: number }
 ```
 
-**Source:** [src/contract/types.ts:204](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L204)
+**Source:** [src/contract/types.ts:207](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L207)
 
 ### contract.Option
 
@@ -1551,7 +1633,7 @@ type MethodOptions = { fee?: string; publicKey?: string; restore?: boolean; sign
 type Option<T> = T | undefined
 ```
 
-**Source:** [src/contract/types.ts:42](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L42)
+**Source:** [src/contract/types.ts:43](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L43)
 
 ### contract.ParsedEvent
 
@@ -1681,7 +1763,17 @@ It returns a signed hash of the same authorization entry and the signer address 
 type SignAuthEntry = (authEntry: string, opts?: { address?: string; networkPassphrase?: string }) => Promise<{ signedAuthEntry: string; signerAddress?: string } & { error?: WalletError }>
 ```
 
-**Source:** [src/contract/types.ts:112](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L112)
+**Source:** [src/contract/types.ts:113](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L113)
+
+### contract.SignAuthEntryLike
+
+Anything accepted where a `signAuthEntry` callback is expected.
+
+```ts
+type SignAuthEntryLike = SignAuthEntry | Signer | Keypair
+```
+
+**Source:** [src/contract/signer.ts:111](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L111)
 
 ### contract.SignTransaction
 
@@ -1695,7 +1787,82 @@ and the signer address back to the requester.
 type SignTransaction = (xdr: string, opts?: { address?: string; networkPassphrase?: string; submit?: boolean; submitUrl?: string }) => Promise<{ signedTxXdr: string; signerAddress?: string } & { error?: WalletError }>
 ```
 
-**Source:** [src/contract/types.ts:83](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L83)
+**Source:** [src/contract/types.ts:84](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L84)
+
+### contract.SignTransactionLike
+
+Anything accepted where a `signTransaction` callback is expected: the raw
+SEP-43 callback, a `Signer`, or a `Keypair`.
+
+```ts
+type SignTransactionLike = SignTransaction | Signer | Keypair
+```
+
+**Source:** [src/contract/signer.ts:106](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L106)
+
+### contract.Signer
+
+A signing identity: something that can sign, and that knows who it is.
+
+A bare `SignTransaction` callback carries no identity, so callers have
+to pass the signer's address alongside it and keep the two in sync. A
+`Signer` bundles them.
+
+`address` is deliberately a plain string rather than an Ed25519 public key:
+it is a `G…` account address for keypair-backed signers, but may be a `C…`
+contract address for smart accounts, whose signatures are not Ed25519 at all.
+
+`signTransaction` and `signAuthEntry` keep the exact shapes the SDK already
+accepts (those of SEP-43 wallets such as Freighter), so an existing wallet
+object becomes a `Signer` by gaining an `address`.
+
+`signAuthEntry` is optional because not every wallet implements it; it is only
+needed for multi-party (non-invoker) auth entry signing.
+
+Accepted anywhere a `signTransaction` callback is, i.e. in
+`ClientOptions`, `MethodOptions`,
+`sign`, and
+`signAndSend`.
+
+```ts
+interface Signer {
+  readonly address: string;
+  signAuthEntry?: SignAuthEntry;
+  signTransaction: SignTransaction;
+}
+```
+
+**Source:** [src/contract/signer.ts:27](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L27)
+
+#### `signer.address`
+
+The address this signer signs as: `G…` for accounts, `C…` for contracts.
+
+```ts
+readonly address: string;
+```
+
+**Source:** [src/contract/signer.ts:29](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L29)
+
+#### `signer.signAuthEntry`
+
+Signs an auth entry preimage. Matches `signAuthEntry` from Freighter.
+
+```ts
+signAuthEntry?: SignAuthEntry;
+```
+
+**Source:** [src/contract/signer.ts:33](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L33)
+
+#### `signer.signTransaction`
+
+Signs a transaction envelope. Matches `signTransaction` from Freighter.
+
+```ts
+signTransaction: SignTransaction;
+```
+
+**Source:** [src/contract/signer.ts:31](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/signer.ts#L31)
 
 ### contract.Timepoint
 
@@ -1705,7 +1872,7 @@ An unsigned 64-bit integer.
 type Timepoint = bigint
 ```
 
-**Source:** [src/contract/types.ts:50](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L50)
+**Source:** [src/contract/types.ts:51](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L51)
 
 ### contract.Tx
 
@@ -1715,7 +1882,7 @@ A "regular" transaction, as opposed to a FeeBumpTransaction.
 type Tx = Transaction
 ```
 
-**Source:** [src/contract/types.ts:59](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L59)
+**Source:** [src/contract/types.ts:60](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L60)
 
 ### contract.Typepoint
 
@@ -1725,7 +1892,7 @@ type Tx = Transaction
 type Typepoint = bigint
 ```
 
-**Source:** [src/contract/types.ts:46](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L46)
+**Source:** [src/contract/types.ts:47](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L47)
 
 ### contract.Union
 
@@ -1764,7 +1931,7 @@ interface WalletError {
 }
 ```
 
-**Source:** [src/contract/types.ts:61](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L61)
+**Source:** [src/contract/types.ts:62](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L62)
 
 #### `walletError.code`
 
@@ -1772,7 +1939,7 @@ interface WalletError {
 code: number;
 ```
 
-**Source:** [src/contract/types.ts:63](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L63)
+**Source:** [src/contract/types.ts:64](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L64)
 
 #### `walletError.ext`
 
@@ -1780,7 +1947,7 @@ code: number;
 ext?: string[];
 ```
 
-**Source:** [src/contract/types.ts:64](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L64)
+**Source:** [src/contract/types.ts:65](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L65)
 
 #### `walletError.message`
 
@@ -1788,7 +1955,7 @@ ext?: string[];
 message: string;
 ```
 
-**Source:** [src/contract/types.ts:62](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L62)
+**Source:** [src/contract/types.ts:63](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L63)
 
 ### contract.XDR_BASE64
 
@@ -1796,7 +1963,7 @@ message: string;
 type XDR_BASE64 = string
 ```
 
-**Source:** [src/contract/types.ts:9](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L9)
+**Source:** [src/contract/types.ts:10](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L10)
 
 ### contract.i128
 
@@ -1806,7 +1973,7 @@ A signed 128-bit integer.
 type i128 = bigint
 ```
 
-**Source:** [src/contract/types.ts:33](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L33)
+**Source:** [src/contract/types.ts:34](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L34)
 
 ### contract.i256
 
@@ -1816,7 +1983,7 @@ A signed 256-bit integer.
 type i256 = bigint
 ```
 
-**Source:** [src/contract/types.ts:41](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L41)
+**Source:** [src/contract/types.ts:42](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L42)
 
 ### contract.i32
 
@@ -1826,7 +1993,7 @@ A signed 32-bit integer.
 type i32 = number
 ```
 
-**Source:** [src/contract/types.ts:17](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L17)
+**Source:** [src/contract/types.ts:18](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L18)
 
 ### contract.i64
 
@@ -1836,7 +2003,7 @@ A signed 64-bit integer.
 type i64 = bigint
 ```
 
-**Source:** [src/contract/types.ts:25](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L25)
+**Source:** [src/contract/types.ts:26](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L26)
 
 ### contract.u128
 
@@ -1846,7 +2013,7 @@ An unsigned 128-bit integer.
 type u128 = bigint
 ```
 
-**Source:** [src/contract/types.ts:29](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L29)
+**Source:** [src/contract/types.ts:30](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L30)
 
 ### contract.u256
 
@@ -1856,7 +2023,7 @@ An unsigned 256-bit integer.
 type u256 = bigint
 ```
 
-**Source:** [src/contract/types.ts:37](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L37)
+**Source:** [src/contract/types.ts:38](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L38)
 
 ### contract.u32
 
@@ -1866,7 +2033,7 @@ An unsigned 32-bit integer.
 type u32 = number
 ```
 
-**Source:** [src/contract/types.ts:13](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L13)
+**Source:** [src/contract/types.ts:14](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L14)
 
 ### contract.u64
 
@@ -1876,4 +2043,4 @@ An unsigned 64-bit integer.
 type u64 = bigint
 ```
 
-**Source:** [src/contract/types.ts:21](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L21)
+**Source:** [src/contract/types.ts:22](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L22)

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -18,10 +18,13 @@ import type {
   AssembledTransactionOptions,
   ClientOptions,
   MethodOptions,
+  SignAuthEntry,
+  SignTransaction,
   Tx,
   WalletError,
   XDR_BASE64,
 } from "./types.js";
+import { toSignAuthEntry, toSignTransaction } from "./signer.js";
 import { Server } from "../rpc/index.js";
 import { Api } from "../rpc/api.js";
 import { assembleTransaction } from "../rpc/transaction.js";
@@ -821,9 +824,12 @@ export class AssembledTransaction<T> {
       .setTimeout(timeoutInSeconds)
       .build();
 
-    const signOpts: Parameters<
-      NonNullable<ClientOptions["signTransaction"]>
-    >[1] = {
+    const signTx = toSignTransaction(
+      signTransaction,
+      this.options.networkPassphrase,
+    );
+
+    const signOpts: Parameters<SignTransaction>[1] = {
       networkPassphrase: this.options.networkPassphrase,
     };
 
@@ -832,7 +838,7 @@ export class AssembledTransaction<T> {
       signOpts.submit = this.options.submit;
     if (this.options.submitUrl) signOpts.submitUrl = this.options.submitUrl;
 
-    const { signedTxXdr: signature, error } = await signTransaction(
+    const { signedTxXdr: signature, error } = await signTx(
       this.built.toXDR(),
       signOpts,
     );
@@ -891,8 +897,12 @@ export class AssembledTransaction<T> {
   } = {}): Promise<SentTransaction<T>> => {
     if (!this.signed) {
       // Wrap signTransaction to disable submit and prevent double submission,
-      // without mutating the shared this.options object
-      const signer = signTransaction || this.options.signTransaction;
+      // without mutating the shared this.options object. Reduce to a plain
+      // callback first, since the wrapper has to call it.
+      const signer = toSignTransaction(
+        signTransaction || this.options.signTransaction,
+        this.options.networkPassphrase,
+      );
       const wrappedSignTransaction: typeof signTransaction =
         this.options.submit && signer
           ? (tx, opts) => signer(tx, { ...opts, submit: false })
@@ -1016,6 +1026,14 @@ export class AssembledTransaction<T> {
     if (!this.built)
       throw new Error("Transaction has not yet been assembled or simulated");
 
+    // Reduced up front, not at the call site below, so that the `!signAuth`
+    // check reports a `Signer` that omits the optional `signAuthEntry` the same
+    // way it reports a missing option, rather than silently signing nothing.
+    const signAuth = toSignAuthEntry(
+      signAuthEntry,
+      this.options.networkPassphrase,
+    );
+
     // Likely if we're using a custom authorizeEntry then we know better than the `needsNonInvokerSigningBy` logic.
     if (authorizeEntry === stellarBaseAuthorizeEntry) {
       const needsNonInvokerSigningBy = this.needsNonInvokerSigningBy();
@@ -1029,7 +1047,7 @@ export class AssembledTransaction<T> {
           `No auth entries for public key "${address}"`,
         );
       }
-      if (!signAuthEntry) {
+      if (!signAuth) {
         throw new AssembledTransaction.Errors.NoSigner(
           "You must provide `signAuthEntry` or a custom `authorizeEntry`",
         );
@@ -1061,7 +1079,7 @@ export class AssembledTransaction<T> {
       // (or maybe already was!)
       if (authEntryAddress !== address) continue;
 
-      const sign: typeof signAuthEntry = signAuthEntry ?? Promise.resolve;
+      const sign: SignAuthEntry = signAuth ?? Promise.resolve;
 
       authEntries[i] = await authorizeEntry(
         entry,

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -791,7 +791,12 @@ export class AssembledTransaction<T> {
       );
     }
 
-    if (!signTransaction) {
+    const signTx = toSignTransaction(
+      signTransaction,
+      this.options.networkPassphrase,
+    );
+
+    if (!signTx) {
       throw new AssembledTransaction.Errors.NoSigner(
         "You must provide a signTransaction function, either when calling " +
           "`signAndSend` or when initializing your Client",
@@ -823,11 +828,6 @@ export class AssembledTransaction<T> {
     })
       .setTimeout(timeoutInSeconds)
       .build();
-
-    const signTx = toSignTransaction(
-      signTransaction,
-      this.options.networkPassphrase,
-    );
 
     const signOpts: Parameters<SignTransaction>[1] = {
       networkPassphrase: this.options.networkPassphrase,

--- a/src/contract/basic_node_signer.ts
+++ b/src/contract/basic_node_signer.ts
@@ -1,5 +1,6 @@
-import { Keypair, TransactionBuilder, hash } from "../base/index.js";
+import { Keypair } from "../base/index.js";
 import type { Client } from "./client.js";
+import { KeypairSigner } from "./signer.js";
 import type { SignAuthEntry, SignTransaction } from "./types.js";
 
 /**
@@ -9,6 +10,9 @@ import type { SignAuthEntry, SignTransaction } from "./types.js";
  * applications. Feel free to use this as a starting point for your own
  * Wallet/TransactionSigner implementation.
  *
+ * Prefer {@link KeypairSigner}, which does the same thing and also carries the
+ * signer's address, so you can pass one object instead of spreading two
+ * functions. You can also pass a {@link Keypair} directly as `signTransaction`.
  *
  * @param keypair - {@link Keypair} to use to sign the transaction or auth entry
  * @param networkPassphrase - passphrase of network to sign for
@@ -19,27 +23,10 @@ export const basicNodeSigner = (
 ): {
   signTransaction: SignTransaction;
   signAuthEntry: SignAuthEntry;
-} => ({
-  // eslint-disable-next-line @typescript-eslint/require-await
-  signTransaction: async (xdr, opts) => {
-    const t = TransactionBuilder.fromXDR(
-      xdr,
-      opts?.networkPassphrase || networkPassphrase,
-    );
-    t.sign(keypair);
-    return {
-      signedTxXdr: t.toXDR(),
-      signerAddress: keypair.publicKey(),
-    };
-  },
-  // eslint-disable-next-line @typescript-eslint/require-await
-  signAuthEntry: async (authEntry) => {
-    const signedAuthEntry = keypair
-      .sign(hash(Buffer.from(authEntry, "base64")))
-      .toString("base64");
-    return {
-      signedAuthEntry,
-      signerAddress: keypair.publicKey(),
-    };
-  },
-});
+} => {
+  const { signTransaction, signAuthEntry } = new KeypairSigner(
+    keypair,
+    networkPassphrase,
+  );
+  return { signTransaction, signAuthEntry };
+};

--- a/src/contract/index.ts
+++ b/src/contract/index.ts
@@ -4,5 +4,13 @@ export * from "./client.js";
 export * from "./event_spec.js";
 export * from "./rust_result.js";
 export * from "./sent_transaction.js";
+// Explicit (not `export *`) so the `toSign*` normalizers stay internal: they're
+// shared across this package but intentionally excluded from the public API.
+export { KeypairSigner } from "./signer.js";
+export type {
+  Signer,
+  SignTransactionLike,
+  SignAuthEntryLike,
+} from "./signer.js";
 export * from "./spec.js";
 export * from "./types.js";

--- a/src/contract/signer.ts
+++ b/src/contract/signer.ts
@@ -16,13 +16,13 @@ import type { SignAuthEntry, SignTransaction } from "./types.js";
  * accepts (those of SEP-43 wallets such as Freighter), so an existing wallet
  * object becomes a `Signer` by gaining an `address`.
  *
- * `signAuthEntry` is optional because not every wallet implements it; it is only
- * needed for multi-party (non-invoker) auth entry signing.
+ * `signAuthEntry` is optional because not every wallet implements it; it is
+ * only needed for multi-party (non-invoker) auth entry signing.
  *
- * Accepted anywhere a `signTransaction` callback is, i.e. in
- * {@link ClientOptions}, {@link MethodOptions},
- * {@link contract.AssembledTransaction.sign | sign}, and
- * {@link contract.AssembledTransaction.signAndSend | signAndSend}.
+ * Accepted wherever the SDK takes a signing callback: the `signTransaction` and
+ * `signAuthEntry` options on `ClientOptions` and `MethodOptions`, and the
+ * per-call overrides on `AssembledTransaction`'s `sign`, `signAndSend`, and
+ * `signAuthEntries`.
  */
 export interface Signer {
   /** The address this signer signs as: `G…` for accounts, `C…` for contracts. */
@@ -39,10 +39,6 @@ export interface Signer {
  * Suitable for Node applications, scripts, and tests — anywhere the secret key
  * lives in the same process. For browser applications, use the SEP-43 wallet's
  * own `signTransaction`, or wrap it in an object satisfying {@link Signer}.
- *
- * @param keypair - the {@link Keypair} to sign with; needs a secret key
- * @param networkPassphrase - passphrase of the network to sign for, used when
- *    the caller does not pass one at signing time
  *
  * @example
  * ```ts
@@ -61,13 +57,16 @@ export interface Signer {
  */
 export class KeypairSigner implements Signer {
   /**
-   * The keypair's Ed25519 account address (`G…`).
-   *
-   * Always `keypair.publicKey()`. {@link Signer.address} is broader — it may be
-   * a `C…` contract address — but a keypair-backed signer never is.
+   * The keypair's Ed25519 account address (`G…`), always `keypair.publicKey()`.
    */
   readonly address: string;
 
+  /**
+   * @param keypair - the {@link Keypair} to sign with. Signing throws
+   *    `cannot sign: no secret key available` if it holds only a public key.
+   * @param networkPassphrase - passphrase of the network to sign for, used
+   *    whenever the caller does not pass one at signing time
+   */
   constructor(
     private readonly keypair: Keypair,
     private readonly networkPassphrase: string,
@@ -75,10 +74,15 @@ export class KeypairSigner implements Signer {
     this.address = keypair.publicKey();
   }
 
-  /* These are arrow instance properties rather than prototype methods because
-     callers pull them off the instance as bare functions — `basicNodeSigner`
-     spreads them, and the normalizers below extract them — which would lose
-     `this` on a prototype method. */
+  /* Arrow instance properties rather than prototype methods because
+     `basicNodeSigner` destructures them into a plain object, which would lose
+     `this` on a prototype method. (The normalizers below tolerate either, since
+     they bind what they extract.)
+
+     They stay `async` despite having nothing to await (hence the rule
+     suppressions): that way a synchronous failure — malformed XDR, or a keypair
+     holding no secret key — rejects the returned promise instead of throwing,
+     preserving the behavior `basicNodeSigner` had before it delegated here. */
 
   // eslint-disable-next-line @typescript-eslint/require-await
   signTransaction: SignTransaction = async (xdr, opts) => {
@@ -86,7 +90,9 @@ export class KeypairSigner implements Signer {
       xdr,
       opts?.networkPassphrase || this.networkPassphrase,
     );
+
     t.sign(this.keypair);
+
     return {
       signedTxXdr: t.toXDR(),
       signerAddress: this.address,
@@ -98,6 +104,7 @@ export class KeypairSigner implements Signer {
     const signedAuthEntry = this.keypair
       .sign(hash(Buffer.from(authEntry, "base64")))
       .toString("base64");
+
     return {
       signedAuthEntry,
       signerAddress: this.address,
@@ -112,34 +119,65 @@ export class KeypairSigner implements Signer {
 export type SignTransactionLike = SignTransaction | Signer | Keypair;
 
 /**
- * Anything accepted where a `signAuthEntry` callback is expected.
+ * Anything accepted where a `signAuthEntry` callback is expected: the raw
+ * SEP-43 callback, a {@link Signer}, or a {@link Keypair}.
  */
 export type SignAuthEntryLike = SignAuthEntry | Signer | Keypair;
 
 /**
+ * Recognizes a {@link Keypair} by the two members {@link KeypairSigner} calls.
+ *
+ * Structural rather than `instanceof` on purpose: this package ships a CJS and
+ * an ESM build whose `Keypair` classes are distinct objects, so a keypair made
+ * through one entry point fails `instanceof` against the other despite working
+ * perfectly. Duplicate copies of the SDK in one dependency tree do the same.
+ *
+ * Only ever reached after a `Signer` has been ruled out, so an object carrying
+ * `signTransaction` can never be misrouted here.
+ */
+function isKeypairLike(value: object): value is Keypair {
+  return (
+    "publicKey" in value &&
+    typeof value.publicKey === "function" &&
+    "sign" in value &&
+    typeof value.sign === "function"
+  );
+}
+
+/**
  * Reduces the accepted signing shapes down to a plain callback.
+ *
+ * Anything that carries no usable callback yields `undefined` — including an
+ * absent value, or an object that does not match any accepted shape — so the
+ * caller decides how to report a missing signer. This is deliberately lenient:
+ * callers reaching the SDK from plain JavaScript are not held to the types, and
+ * a clear `NoSigner` beats a `TypeError` from deep inside a normalizer.
  *
  * Internal: called at the entry points that read a caller-supplied signer, so
  * the rest of the code only ever deals with a `SignTransaction`.
  */
 export function toSignTransaction(
-  value: SignTransactionLike,
-  networkPassphrase: string,
-): SignTransaction;
-export function toSignTransaction(
-  value: SignTransactionLike | undefined,
-  networkPassphrase: string,
-): SignTransaction | undefined;
-export function toSignTransaction(
   value: SignTransactionLike | undefined,
   networkPassphrase: string,
 ): SignTransaction | undefined {
-  if (value === undefined) return undefined;
-  if (value instanceof Keypair) {
+  // `== null` so an explicit `null` from a JS caller behaves like `undefined`.
+  if (value == null) return undefined;
+
+  if (typeof value === "function") return value;
+
+  // Guards the `in` checks below, which throw on primitives.
+  if (typeof value !== "object") return undefined;
+
+  // `signTransaction` is a `Signer`'s required member, so it identifies one.
+  // Bound because a `Signer` may implement it as a prototype method that relies
+  // on `this`; a bare reference would lose its receiver.
+  if ("signTransaction" in value) return value.signTransaction?.bind(value);
+
+  if (isKeypairLike(value)) {
     return new KeypairSigner(value, networkPassphrase).signTransaction;
   }
-  if (typeof value === "function") return value;
-  return value.signTransaction;
+
+  return undefined;
 }
 
 /**
@@ -154,10 +192,19 @@ export function toSignAuthEntry(
   value: SignAuthEntryLike | undefined,
   networkPassphrase: string,
 ): SignAuthEntry | undefined {
-  if (value === undefined) return undefined;
-  if (value instanceof Keypair) {
+  if (value == null) return undefined;
+
+  if (typeof value === "function") return value;
+
+  if (typeof value !== "object") return undefined;
+
+  // Identified and bound as in `toSignTransaction`; optional chaining keeps a
+  // `Signer` that omits the optional `signAuthEntry` reported as `undefined`.
+  if ("signTransaction" in value) return value.signAuthEntry?.bind(value);
+
+  if (isKeypairLike(value)) {
     return new KeypairSigner(value, networkPassphrase).signAuthEntry;
   }
-  if (typeof value === "function") return value;
-  return value.signAuthEntry;
+
+  return undefined;
 }

--- a/src/contract/signer.ts
+++ b/src/contract/signer.ts
@@ -60,6 +60,12 @@ export interface Signer {
  * ```
  */
 export class KeypairSigner implements Signer {
+  /**
+   * The keypair's Ed25519 account address (`G…`).
+   *
+   * Always `keypair.publicKey()`. {@link Signer.address} is broader — it may be
+   * a `C…` contract address — but a keypair-backed signer never is.
+   */
   readonly address: string;
 
   constructor(

--- a/src/contract/signer.ts
+++ b/src/contract/signer.ts
@@ -1,0 +1,157 @@
+import { Keypair, TransactionBuilder, hash } from "../base/index.js";
+import type { SignAuthEntry, SignTransaction } from "./types.js";
+
+/**
+ * A signing identity: something that can sign, and that knows who it is.
+ *
+ * A bare {@link SignTransaction} callback carries no identity, so callers have
+ * to pass the signer's address alongside it and keep the two in sync. A
+ * `Signer` bundles them.
+ *
+ * `address` is deliberately a plain string rather than an Ed25519 public key:
+ * it is a `G…` account address for keypair-backed signers, but may be a `C…`
+ * contract address for smart accounts, whose signatures are not Ed25519 at all.
+ *
+ * `signTransaction` and `signAuthEntry` keep the exact shapes the SDK already
+ * accepts (those of SEP-43 wallets such as Freighter), so an existing wallet
+ * object becomes a `Signer` by gaining an `address`.
+ *
+ * `signAuthEntry` is optional because not every wallet implements it; it is only
+ * needed for multi-party (non-invoker) auth entry signing.
+ *
+ * Accepted anywhere a `signTransaction` callback is, i.e. in
+ * {@link ClientOptions}, {@link MethodOptions},
+ * {@link contract.AssembledTransaction.sign | sign}, and
+ * {@link contract.AssembledTransaction.signAndSend | signAndSend}.
+ */
+export interface Signer {
+  /** The address this signer signs as: `G…` for accounts, `C…` for contracts. */
+  readonly address: string;
+  /** Signs a transaction envelope. Matches `signTransaction` from Freighter. */
+  signTransaction: SignTransaction;
+  /** Signs an auth entry preimage. Matches `signAuthEntry` from Freighter. */
+  signAuthEntry?: SignAuthEntry;
+}
+
+/**
+ * A {@link Signer} backed by a local {@link Keypair}.
+ *
+ * Suitable for Node applications, scripts, and tests — anywhere the secret key
+ * lives in the same process. For browser applications, use the SEP-43 wallet's
+ * own `signTransaction`, or wrap it in an object satisfying {@link Signer}.
+ *
+ * @param keypair - the {@link Keypair} to sign with; needs a secret key
+ * @param networkPassphrase - passphrase of the network to sign for, used when
+ *    the caller does not pass one at signing time
+ *
+ * @example
+ * ```ts
+ * import { Keypair } from "@stellar/stellar-sdk";
+ * import { Client, KeypairSigner } from "@stellar/stellar-sdk/contract";
+ *
+ * const keypair = Keypair.fromSecret(secret);
+ * const client = await Client.from({
+ *   contractId,
+ *   networkPassphrase,
+ *   rpcUrl,
+ *   publicKey: keypair.publicKey(),
+ *   signTransaction: new KeypairSigner(keypair, networkPassphrase),
+ * });
+ * ```
+ */
+export class KeypairSigner implements Signer {
+  readonly address: string;
+
+  constructor(
+    private readonly keypair: Keypair,
+    private readonly networkPassphrase: string,
+  ) {
+    this.address = keypair.publicKey();
+  }
+
+  /* These are arrow instance properties rather than prototype methods because
+     callers pull them off the instance as bare functions — `basicNodeSigner`
+     spreads them, and the normalizers below extract them — which would lose
+     `this` on a prototype method. */
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  signTransaction: SignTransaction = async (xdr, opts) => {
+    const t = TransactionBuilder.fromXDR(
+      xdr,
+      opts?.networkPassphrase || this.networkPassphrase,
+    );
+    t.sign(this.keypair);
+    return {
+      signedTxXdr: t.toXDR(),
+      signerAddress: this.address,
+    };
+  };
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  signAuthEntry: SignAuthEntry = async (authEntry) => {
+    const signedAuthEntry = this.keypair
+      .sign(hash(Buffer.from(authEntry, "base64")))
+      .toString("base64");
+    return {
+      signedAuthEntry,
+      signerAddress: this.address,
+    };
+  };
+}
+
+/**
+ * Anything accepted where a `signTransaction` callback is expected: the raw
+ * SEP-43 callback, a {@link Signer}, or a {@link Keypair}.
+ */
+export type SignTransactionLike = SignTransaction | Signer | Keypair;
+
+/**
+ * Anything accepted where a `signAuthEntry` callback is expected.
+ */
+export type SignAuthEntryLike = SignAuthEntry | Signer | Keypair;
+
+/**
+ * Reduces the accepted signing shapes down to a plain callback.
+ *
+ * Internal: called at the entry points that read a caller-supplied signer, so
+ * the rest of the code only ever deals with a `SignTransaction`.
+ */
+export function toSignTransaction(
+  value: SignTransactionLike,
+  networkPassphrase: string,
+): SignTransaction;
+export function toSignTransaction(
+  value: SignTransactionLike | undefined,
+  networkPassphrase: string,
+): SignTransaction | undefined;
+export function toSignTransaction(
+  value: SignTransactionLike | undefined,
+  networkPassphrase: string,
+): SignTransaction | undefined {
+  if (value === undefined) return undefined;
+  if (value instanceof Keypair) {
+    return new KeypairSigner(value, networkPassphrase).signTransaction;
+  }
+  if (typeof value === "function") return value;
+  return value.signTransaction;
+}
+
+/**
+ * Reduces the accepted signing shapes down to a plain callback.
+ *
+ * A {@link Signer} whose optional `signAuthEntry` is absent yields `undefined`,
+ * so the caller reports it the same way it reports a missing option.
+ *
+ * Internal: see {@link toSignTransaction}.
+ */
+export function toSignAuthEntry(
+  value: SignAuthEntryLike | undefined,
+  networkPassphrase: string,
+): SignAuthEntry | undefined {
+  if (value === undefined) return undefined;
+  if (value instanceof Keypair) {
+    return new KeypairSigner(value, networkPassphrase).signAuthEntry;
+  }
+  if (typeof value === "function") return value;
+  return value.signAuthEntry;
+}

--- a/src/contract/signer.ts
+++ b/src/contract/signer.ts
@@ -125,7 +125,11 @@ export type SignTransactionLike = SignTransaction | Signer | Keypair;
 export type SignAuthEntryLike = SignAuthEntry | Signer | Keypair;
 
 /**
- * Recognizes a {@link Keypair} by the two members {@link KeypairSigner} calls.
+ * Recognizes a {@link Keypair} by the three members {@link KeypairSigner} calls:
+ * `publicKey` for the address, `sign` for auth entries, and `signDecorated`,
+ * which `Transaction.sign` reaches for when signing an envelope. All three are
+ * required, so a partial object is refused here rather than yielding a callback
+ * that throws once it is actually used.
  *
  * Structural rather than `instanceof` on purpose: this package ships a CJS and
  * an ESM build whose `Keypair` classes are distinct objects, so a keypair made
@@ -140,7 +144,9 @@ function isKeypairLike(value: object): value is Keypair {
     "publicKey" in value &&
     typeof value.publicKey === "function" &&
     "sign" in value &&
-    typeof value.sign === "function"
+    typeof value.sign === "function" &&
+    "signDecorated" in value &&
+    typeof value.signDecorated === "function"
   );
 }
 
@@ -170,8 +176,12 @@ export function toSignTransaction(
 
   // `signTransaction` is a `Signer`'s required member, so it identifies one.
   // Bound because a `Signer` may implement it as a prototype method that relies
-  // on `this`; a bare reference would lose its receiver.
-  if ("signTransaction" in value) return value.signTransaction?.bind(value);
+  // on `this`; a bare reference would lose its receiver. The `typeof` check is
+  // for untyped callers: a present-but-non-function member has no `bind`.
+  if ("signTransaction" in value) {
+    const fn = value.signTransaction;
+    return typeof fn === "function" ? fn.bind(value) : undefined;
+  }
 
   if (isKeypairLike(value)) {
     return new KeypairSigner(value, networkPassphrase).signTransaction;
@@ -198,9 +208,13 @@ export function toSignAuthEntry(
 
   if (typeof value !== "object") return undefined;
 
-  // Identified and bound as in `toSignTransaction`; optional chaining keeps a
-  // `Signer` that omits the optional `signAuthEntry` reported as `undefined`.
-  if ("signTransaction" in value) return value.signAuthEntry?.bind(value);
+  // Identified and bound as in `toSignTransaction`. The `typeof` check also
+  // covers the ordinary case of a `Signer` that omits the optional
+  // `signAuthEntry`, which is reported as `undefined`.
+  if ("signTransaction" in value) {
+    const fn = value.signAuthEntry;
+    return typeof fn === "function" ? fn.bind(value) : undefined;
+  }
 
   if (isKeypairLike(value)) {
     return new KeypairSigner(value, networkPassphrase).signAuthEntry;

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -4,6 +4,7 @@
 import { Transaction, xdr } from "../base/index.js";
 import type { SentTransaction } from "./sent_transaction.js";
 import type { Client } from "./client.js";
+import type { SignAuthEntryLike, SignTransactionLike } from "./signer.js";
 import { Server } from "../rpc/index.js";
 
 export type XDR_BASE64 = string;
@@ -139,9 +140,10 @@ export type ClientOptions = {
    * method (see {@link MethodOptions}) or when you call
    * {@link contract.AssembledTransaction.signAndSend | signAndSend}.
    *
-   * Matches signature of `signTransaction` from Freighter.
+   * Matches signature of `signTransaction` from Freighter. May instead be a
+   * {@link Signer} or a {@link Keypair}, which are converted internally.
    */
-  signTransaction?: SignTransaction;
+  signTransaction?: SignTransactionLike;
   /**
    * A function to sign a specific auth entry for a transaction, using the
    * private key corresponding to the provided `publicKey`. This is only needed
@@ -150,9 +152,10 @@ export type ClientOptions = {
    * provide it later either when you initialize a method (see {@link MethodOptions})
    * or when you call {@link contract.AssembledTransaction.signAuthEntries | signAuthEntries}.
    *
-   * Matches signature of `signAuthEntry` from Freighter.
+   * Matches signature of `signAuthEntry` from Freighter. May instead be a
+   * {@link Signer} or a {@link Keypair}, which are converted internally.
    */
-  signAuthEntry?: SignAuthEntry;
+  signAuthEntry?: SignAuthEntryLike;
   /** The address of the contract the client will interact with. */
   contractId: string;
   /**
@@ -240,22 +243,24 @@ export type MethodOptions = {
    * the given `publicKey`. You do not need to provide this, for read-only
    * calls, which only need to be simulated.
    *
-   * Matches signature of `signTransaction` from Freighter.
+   * Matches signature of `signTransaction` from Freighter. May instead be a
+   * {@link Signer} or a {@link Keypair}, which are converted internally.
    *
    * Default: the one provided to the {@link Client} in {@link ClientOptions}
    */
-  signTransaction?: SignTransaction;
+  signTransaction?: SignTransactionLike;
   /**
    * A function to sign a specific auth entry for a transaction, using the
    * private key corresponding to the provided `publicKey`. This is only needed
    * for multi-auth transactions, in which one transaction is signed by
    * multiple parties.
    *
-   * Matches signature of `signAuthEntry` from Freighter.
+   * Matches signature of `signAuthEntry` from Freighter. May instead be a
+   * {@link Signer} or a {@link Keypair}, which are converted internally.
    *
    * Default: the one provided to the {@link Client} in {@link ClientOptions}
    */
-  signAuthEntry?: SignAuthEntry;
+  signAuthEntry?: SignAuthEntryLike;
 };
 
 export type AssembledTransactionOptions<T = string> = MethodOptions &

--- a/test/unit/contract/signer.test.ts
+++ b/test/unit/contract/signer.test.ts
@@ -225,7 +225,7 @@ describe("signer normalization", () => {
     expect(toSignAuthEntry(undefined, networkPassphrase)).toBeUndefined();
   });
 
-  it("recognizes a Keypair from a different copy of the module", () => {
+  it("recognizes a Keypair from a different copy of the module", async () => {
     // `instanceof` fails when a caller's Keypair comes from a different copy of
     // the module — the CJS and ESM builds have distinct `Keypair` classes, as do
     // duplicate installs — so the check is structural. Simulated here by a
@@ -234,6 +234,7 @@ describe("signer normalization", () => {
     const foreign = {
       publicKey: () => keypair.publicKey(),
       sign: (data: Buffer) => keypair.sign(data),
+      signDecorated: (data: Buffer) => keypair.signDecorated(data),
     };
     expect(foreign instanceof Keypair).toBe(false);
 
@@ -245,9 +246,57 @@ describe("signer normalization", () => {
       foreign as unknown as Keypair,
       networkPassphrase,
     );
+    if (!signTransaction)
+      throw new Error("expected a signTransaction callback");
+    if (!signAuthEntry) throw new Error("expected a signAuthEntry callback");
 
-    expect(signTransaction).toBeTypeOf("function");
-    expect(signAuthEntry).toBeTypeOf("function");
+    // Exercise both callbacks rather than just checking their type: a stand-in
+    // missing a member the signing path needs would otherwise pass this test.
+    const { signedTxXdr } = await signTransaction(buildTxXdr(keypair));
+    const signed = TransactionBuilder.fromXDR(signedTxXdr, networkPassphrase);
+    expect(
+      keypair.verify(signed.hash(), signed.signatures[0].signature()),
+    ).toBe(true);
+    expect(await signAuthEntry(preimage)).toHaveProperty(
+      "signerAddress",
+      keypair.publicKey(),
+    );
+  });
+
+  it("rejects a partial keypair that cannot sign an envelope", () => {
+    // `Transaction.sign` reaches for `signDecorated`, which `signAuthEntry`
+    // never needs. An object with only `publicKey`/`sign` therefore half-works,
+    // and must be refused up front rather than producing a `signTransaction`
+    // callback that throws `signDecorated is not a function` when used.
+    const keypair = Keypair.random();
+    const partial = {
+      publicKey: () => keypair.publicKey(),
+      sign: (data: Buffer) => keypair.sign(data),
+    };
+
+    expect(
+      toSignTransaction(partial as unknown as Keypair, networkPassphrase),
+    ).toBeUndefined();
+    expect(
+      toSignAuthEntry(partial as unknown as Keypair, networkPassphrase),
+    ).toBeUndefined();
+  });
+
+  it("treats a non-function signAuthEntry as absent", async () => {
+    // A valid `signTransaction` alongside a junk `signAuthEntry`: the usable
+    // callback must still come through, and the junk one must not throw.
+    const malformed = {
+      address: Keypair.random().publicKey(),
+      signTransaction: callback,
+      signAuthEntry: "nope",
+    } as unknown as Signer;
+
+    const signTransaction = toSignTransaction(malformed, networkPassphrase);
+    if (!signTransaction)
+      throw new Error("expected a signTransaction callback");
+
+    expect(await signTransaction("xdr")).toEqual(await callback("xdr"));
+    expect(toSignAuthEntry(malformed, networkPassphrase)).toBeUndefined();
   });
 
   it("prefers the Signer shape over the Keypair shape", async () => {
@@ -280,6 +329,11 @@ describe("signer normalization", () => {
     ["a null signTransaction", { address: "G...", signTransaction: null }],
     ["a string", "not a signer"],
     ["a number", 42],
+    // `?.bind` only guards null/undefined, so a present-but-non-function
+    // member would otherwise reach `.bind` and throw.
+    ["a string signTransaction", { address: "G...", signTransaction: "nope" }],
+    ["a number signTransaction", { address: "G...", signTransaction: 42 }],
+    ["an object signTransaction", { address: "G...", signTransaction: {} }],
   ])("degrades to undefined for %s", (_label, malformed) => {
     expect(
       toSignTransaction(malformed as never, networkPassphrase),

--- a/test/unit/contract/signer.test.ts
+++ b/test/unit/contract/signer.test.ts
@@ -98,8 +98,8 @@ describe("KeypairSigner", () => {
   });
 
   it("keeps working when its methods are pulled off the instance", async () => {
-    // `basicNodeSigner` spreads them and the normalizers extract them, so they
-    // must not depend on being called as methods.
+    // `basicNodeSigner` destructures them and the normalizers read them off the
+    // instance, so they must not depend on being called as methods.
     const keypair = Keypair.random();
     const { signTransaction, signAuthEntry } = new KeypairSigner(
       keypair,
@@ -144,15 +144,23 @@ describe("signer normalization", () => {
     expect(toSignAuthEntry(authCallback, networkPassphrase)).toBe(authCallback);
   });
 
-  it("unwraps a Signer's callbacks", () => {
+  it("unwraps a Signer's callbacks", async () => {
     const signer: Signer = {
       address: Keypair.random().publicKey(),
       signTransaction: callback,
       signAuthEntry: authCallback,
     };
 
-    expect(toSignTransaction(signer, networkPassphrase)).toBe(callback);
-    expect(toSignAuthEntry(signer, networkPassphrase)).toBe(authCallback);
+    // Delegation, not reference identity: the returned callbacks are bound to
+    // the signer, so they are wrappers rather than the originals.
+    const signTransaction = toSignTransaction(signer, networkPassphrase);
+    const signAuthEntry = toSignAuthEntry(signer, networkPassphrase);
+    if (!signTransaction)
+      throw new Error("expected a signTransaction callback");
+    if (!signAuthEntry) throw new Error("expected a signAuthEntry callback");
+
+    expect(await signTransaction("xdr")).toEqual(await callback("xdr"));
+    expect(await signAuthEntry("entry")).toEqual(await authCallback("entry"));
   });
 
   it("reports a Signer that omits signAuthEntry as absent", () => {
@@ -161,7 +169,7 @@ describe("signer normalization", () => {
       signTransaction: callback,
     };
 
-    expect(toSignTransaction(signer, networkPassphrase)).toBe(callback);
+    expect(toSignTransaction(signer, networkPassphrase)).toBeTypeOf("function");
     expect(toSignAuthEntry(signer, networkPassphrase)).toBeUndefined();
   });
 
@@ -171,6 +179,8 @@ describe("signer normalization", () => {
 
     const signTransaction = toSignTransaction(keypair, networkPassphrase);
     const signAuthEntry = toSignAuthEntry(keypair, networkPassphrase);
+    if (!signTransaction)
+      throw new Error("expected a signTransaction callback");
     if (!signAuthEntry) throw new Error("expected a signAuthEntry callback");
 
     expect(await signTransaction(xdr)).toEqual(
@@ -182,8 +192,100 @@ describe("signer normalization", () => {
     );
   });
 
+  it("keeps `this` for a Signer implemented with prototype methods", async () => {
+    // A class-based Signer is idiomatic, and TypeScript accepts a prototype
+    // method for `signTransaction: SignTransaction`. Extracting the bare
+    // function reference must not strip its receiver.
+    class ClassSigner implements Signer {
+      readonly address = Keypair.random().publicKey();
+      private secret = "kept";
+
+      async signTransaction() {
+        return Promise.resolve({ signedTxXdr: this.secret });
+      }
+
+      async signAuthEntry() {
+        return Promise.resolve({ signedAuthEntry: this.secret });
+      }
+    }
+    const signer = new ClassSigner();
+
+    const signTransaction = toSignTransaction(signer, networkPassphrase);
+    const signAuthEntry = toSignAuthEntry(signer, networkPassphrase);
+    if (!signTransaction)
+      throw new Error("expected a signTransaction callback");
+    if (!signAuthEntry) throw new Error("expected a signAuthEntry callback");
+
+    expect(await signTransaction("xdr")).toEqual({ signedTxXdr: "kept" });
+    expect(await signAuthEntry("entry")).toEqual({ signedAuthEntry: "kept" });
+  });
+
   it("passes undefined through", () => {
     expect(toSignTransaction(undefined, networkPassphrase)).toBeUndefined();
     expect(toSignAuthEntry(undefined, networkPassphrase)).toBeUndefined();
+  });
+
+  it("recognizes a Keypair from a different copy of the module", () => {
+    // `instanceof` fails when a caller's Keypair comes from a different copy of
+    // the module — the CJS and ESM builds have distinct `Keypair` classes, as do
+    // duplicate installs — so the check is structural. Simulated here by a
+    // distinct object exposing the two members KeypairSigner uses.
+    const keypair = Keypair.random();
+    const foreign = {
+      publicKey: () => keypair.publicKey(),
+      sign: (data: Buffer) => keypair.sign(data),
+    };
+    expect(foreign instanceof Keypair).toBe(false);
+
+    const signTransaction = toSignTransaction(
+      foreign as unknown as Keypair,
+      networkPassphrase,
+    );
+    const signAuthEntry = toSignAuthEntry(
+      foreign as unknown as Keypair,
+      networkPassphrase,
+    );
+
+    expect(signTransaction).toBeTypeOf("function");
+    expect(signAuthEntry).toBeTypeOf("function");
+  });
+
+  it("prefers the Signer shape over the Keypair shape", async () => {
+    // A Signer that also exposes `sign`/`publicKey` must still route through its
+    // own `signTransaction` rather than being mistaken for a keypair.
+    const keypair = Keypair.random();
+    const hybrid = {
+      address: keypair.publicKey(),
+      signTransaction: callback,
+      publicKey: () => keypair.publicKey(),
+      sign: (data: Buffer) => keypair.sign(data),
+    };
+
+    const signTransaction = toSignTransaction(hybrid, networkPassphrase);
+    if (!signTransaction)
+      throw new Error("expected a signTransaction callback");
+
+    // The Signer's own callback returns this sentinel; had it been treated as a
+    // keypair, signing would instead try to parse "xdr" as an envelope.
+    expect(await signTransaction("xdr")).toEqual({ signedTxXdr: "unused" });
+  });
+
+  // Malformed input cannot occur in TypeScript, but the SDK is consumed from
+  // plain JavaScript too. Each of these must degrade to `undefined` so the
+  // caller raises its own `NoSigner`, rather than throwing from the normalizer.
+  it.each([
+    ["null", null],
+    ["an empty object", {}],
+    ["an object with no callbacks", { address: "G..." }],
+    ["a null signTransaction", { address: "G...", signTransaction: null }],
+    ["a string", "not a signer"],
+    ["a number", 42],
+  ])("degrades to undefined for %s", (_label, malformed) => {
+    expect(
+      toSignTransaction(malformed as never, networkPassphrase),
+    ).toBeUndefined();
+    expect(
+      toSignAuthEntry(malformed as never, networkPassphrase),
+    ).toBeUndefined();
   });
 });

--- a/test/unit/contract/signer.test.ts
+++ b/test/unit/contract/signer.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import {
+  Account,
+  Asset,
+  BASE_FEE,
+  Keypair,
+  Networks,
+  Operation,
+  TransactionBuilder,
+  hash,
+} from "../../../src/index.js";
+import {
+  KeypairSigner,
+  toSignAuthEntry,
+  toSignTransaction,
+} from "../../../src/contract/signer.js";
+import type { Signer } from "../../../src/contract/signer.js";
+import { basicNodeSigner } from "../../../src/contract/basic_node_signer.js";
+import type {
+  SignAuthEntry,
+  SignTransaction,
+} from "../../../src/contract/types.js";
+
+const networkPassphrase = Networks.TESTNET;
+
+function buildTxXdr(source: Keypair): string {
+  return new TransactionBuilder(new Account(source.publicKey(), "1"), {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })
+    .addOperation(
+      Operation.payment({
+        destination: Keypair.random().publicKey(),
+        asset: Asset.native(),
+        amount: "1",
+      }),
+    )
+    .setTimeout(30)
+    .build()
+    .toXDR();
+}
+
+// A 32-byte stand-in for an auth entry preimage; `signAuthEntry` only hashes
+// the bytes, so it does not need to be valid XDR.
+const preimage = Buffer.alloc(32, 7).toString("base64");
+
+describe("KeypairSigner", () => {
+  it("exposes the keypair's address as its identity", () => {
+    const keypair = Keypair.random();
+    expect(new KeypairSigner(keypair, networkPassphrase).address).toEqual(
+      keypair.publicKey(),
+    );
+  });
+
+  it("signs a transaction with the keypair", async () => {
+    const keypair = Keypair.random();
+    const signer = new KeypairSigner(keypair, networkPassphrase);
+
+    const { signedTxXdr, signerAddress } = await signer.signTransaction(
+      buildTxXdr(keypair),
+    );
+
+    expect(signerAddress).toEqual(keypair.publicKey());
+    const signed = TransactionBuilder.fromXDR(signedTxXdr, networkPassphrase);
+    expect(signed.signatures).toHaveLength(1);
+    expect(
+      keypair.verify(signed.hash(), signed.signatures[0].signature()),
+    ).toBe(true);
+  });
+
+  it("prefers the passphrase passed at signing time over its own", async () => {
+    const keypair = Keypair.random();
+    // Constructed for PUBLIC, but asked to sign for TESTNET. The passphrase
+    // feeds into the signature payload, so only one of the two can verify.
+    const signer = new KeypairSigner(keypair, Networks.PUBLIC);
+
+    const { signedTxXdr } = await signer.signTransaction(buildTxXdr(keypair), {
+      networkPassphrase: Networks.TESTNET,
+    });
+
+    const signed = TransactionBuilder.fromXDR(signedTxXdr, Networks.TESTNET);
+    expect(
+      keypair.verify(signed.hash(), signed.signatures[0].signature()),
+    ).toBe(true);
+  });
+
+  it("signs an auth entry preimage's hash", async () => {
+    const keypair = Keypair.random();
+    const signer = new KeypairSigner(keypair, networkPassphrase);
+
+    const { signedAuthEntry, signerAddress } =
+      await signer.signAuthEntry(preimage);
+
+    expect(signerAddress).toEqual(keypair.publicKey());
+    expect(Buffer.from(signedAuthEntry, "base64")).toEqual(
+      keypair.sign(hash(Buffer.from(preimage, "base64"))),
+    );
+  });
+
+  it("keeps working when its methods are pulled off the instance", async () => {
+    // `basicNodeSigner` spreads them and the normalizers extract them, so they
+    // must not depend on being called as methods.
+    const keypair = Keypair.random();
+    const { signTransaction, signAuthEntry } = new KeypairSigner(
+      keypair,
+      networkPassphrase,
+    );
+
+    expect(await signTransaction(buildTxXdr(keypair))).toHaveProperty(
+      "signerAddress",
+      keypair.publicKey(),
+    );
+    expect(await signAuthEntry(preimage)).toHaveProperty(
+      "signerAddress",
+      keypair.publicKey(),
+    );
+  });
+});
+
+describe("basicNodeSigner", () => {
+  it("produces the same signatures as KeypairSigner", async () => {
+    const keypair = Keypair.random();
+    const xdr = buildTxXdr(keypair);
+    const legacy = basicNodeSigner(keypair, networkPassphrase);
+    const signer = new KeypairSigner(keypair, networkPassphrase);
+
+    expect(await legacy.signTransaction(xdr)).toEqual(
+      await signer.signTransaction(xdr),
+    );
+    expect(await legacy.signAuthEntry(preimage)).toEqual(
+      await signer.signAuthEntry(preimage),
+    );
+  });
+});
+
+describe("signer normalization", () => {
+  const callback: SignTransaction = () =>
+    Promise.resolve({ signedTxXdr: "unused" });
+  const authCallback: SignAuthEntry = () =>
+    Promise.resolve({ signedAuthEntry: "unused" });
+
+  it("passes a raw callback through untouched", () => {
+    expect(toSignTransaction(callback, networkPassphrase)).toBe(callback);
+    expect(toSignAuthEntry(authCallback, networkPassphrase)).toBe(authCallback);
+  });
+
+  it("unwraps a Signer's callbacks", () => {
+    const signer: Signer = {
+      address: Keypair.random().publicKey(),
+      signTransaction: callback,
+      signAuthEntry: authCallback,
+    };
+
+    expect(toSignTransaction(signer, networkPassphrase)).toBe(callback);
+    expect(toSignAuthEntry(signer, networkPassphrase)).toBe(authCallback);
+  });
+
+  it("reports a Signer that omits signAuthEntry as absent", () => {
+    const signer: Signer = {
+      address: Keypair.random().publicKey(),
+      signTransaction: callback,
+    };
+
+    expect(toSignTransaction(signer, networkPassphrase)).toBe(callback);
+    expect(toSignAuthEntry(signer, networkPassphrase)).toBeUndefined();
+  });
+
+  it("wraps a Keypair, signing as that keypair", async () => {
+    const keypair = Keypair.random();
+    const xdr = buildTxXdr(keypair);
+
+    const signTransaction = toSignTransaction(keypair, networkPassphrase);
+    const signAuthEntry = toSignAuthEntry(keypair, networkPassphrase);
+    if (!signAuthEntry) throw new Error("expected a signAuthEntry callback");
+
+    expect(await signTransaction(xdr)).toEqual(
+      await new KeypairSigner(keypair, networkPassphrase).signTransaction(xdr),
+    );
+    expect(await signAuthEntry(preimage)).toHaveProperty(
+      "signerAddress",
+      keypair.publicKey(),
+    );
+  });
+
+  it("passes undefined through", () => {
+    expect(toSignTransaction(undefined, networkPassphrase)).toBeUndefined();
+    expect(toSignAuthEntry(undefined, networkPassphrase)).toBeUndefined();
+  });
+});

--- a/test/unit/server/soroban/assembled_transaction.test.ts
+++ b/test/unit/server/soroban/assembled_transaction.test.ts
@@ -165,6 +165,60 @@ describe("AssembledTransaction", () => {
       contract.AssembledTransaction.Errors.FakeAccount,
     );
   });
+
+  it("sign accepts a Keypair, a Signer, or a raw callback interchangeably", async () => {
+    const simulateTransactionResponse = {
+      id: "1",
+      events: [],
+      latestLedger: 3,
+      minResourceFee: "15",
+      transactionData: new SorobanDataBuilder()
+        .setReadWrite([
+          xdr.LedgerKey.contractData(
+            new xdr.LedgerKeyContractData({
+              contract: Address.fromString(contractId).toScAddress(),
+              key: xdr.ScVal.scvU32(0),
+              durability: xdr.ContractDataDurability.persistent(),
+            }),
+          ),
+        ])
+        .build(),
+      results: [{ auth: [], xdr: xdr.ScVal.scvU32(0).toXDR("base64") }],
+      stateChanges: [],
+    };
+    mockPost.mockResolvedValue({
+      data: { result: simulateTransactionResponse },
+    });
+    // The source account lookup isn't what's under test here, and each shape
+    // rebuilds, so stub it rather than interleaving ledger-entry responses.
+    vi.spyOn(server, "getAccount").mockResolvedValue(
+      new Account(keypair.publicKey(), "1"),
+    );
+
+    options.method = "test";
+    options.args = [];
+
+    // Each shape rebuilds, so the timebounds (and therefore the signature)
+    // differ between runs; assert each envelope is validly signed by the
+    // keypair rather than comparing the envelopes to each other.
+    const expectSignedByKeypair = async (signTransaction: any) => {
+      const txn = await contract.AssembledTransaction.build(options);
+      await txn.sign({ force: true, signTransaction });
+
+      const signed = txn.signed;
+      if (!signed) throw new Error("expected the transaction to be signed");
+      expect(signed.signatures).toHaveLength(1);
+      expect(
+        keypair.verify(signed.hash(), signed.signatures[0].signature()),
+      ).toBe(true);
+    };
+
+    await expectSignedByKeypair(keypair);
+    await expectSignedByKeypair(
+      new contract.KeypairSigner(keypair, networkPassphrase),
+    );
+    await expectSignedByKeypair(wallet.signTransaction);
+  });
 });
 
 describe("Contract ID validation on deserialization", () => {
@@ -568,6 +622,50 @@ describe("AssembledTransaction auth entry credential types (CAP-71)", () => {
       // signature was filled in (no longer the scvVoid placeholder)
       expect(signed.signature().switch().name).toBe("scvVec");
       expect(signed.signature().vec()).toHaveLength(1);
+    });
+
+    it("accepts a Keypair, a Signer, or a raw callback interchangeably", async () => {
+      const signer = Keypair.random();
+
+      // Fixed nonce and expiration, and no rebuilt timebounds on this path, so
+      // Ed25519 determinism makes the three entries byte-identical.
+      const signedEntryWith = async (signAuthEntry: any) => {
+        const assembled = assembledWith(
+          [authEntry(addressV2Cred(signer.publicKey()))],
+          { signAuthEntry },
+        );
+        await assembled.signAuthEntries({
+          expiration: 1000,
+          address: signer.publicKey(),
+        });
+        return (assembled.built as any).operations[0].auth[0].toXDR("base64");
+      };
+
+      const viaKeypair = await signedEntryWith(signer);
+      const viaSigner = await signedEntryWith(
+        new contract.KeypairSigner(signer, networkPassphrase),
+      );
+      const viaCallback = await signedEntryWith(
+        contract.basicNodeSigner(signer, networkPassphrase).signAuthEntry,
+      );
+
+      expect(viaSigner).toEqual(viaKeypair);
+      expect(viaCallback).toEqual(viaKeypair);
+    });
+
+    it("rejects a Signer that omits the optional signAuthEntry", async () => {
+      const signer = Keypair.random();
+      const assembled = assembledWith(
+        [authEntry(addressV2Cred(signer.publicKey()))],
+        { signAuthEntry: { address: signer.publicKey() } },
+      );
+
+      await expect(
+        assembled.signAuthEntries({
+          expiration: 1000,
+          address: signer.publicKey(),
+        }),
+      ).rejects.toThrow(contract.AssembledTransaction.Errors.NoSigner);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **`Signer` / `KeypairSigner` — new signing interface:** `contract.Signer` pairs a signing capability with the identity it signs as (`address`, plus the SEP-43 `signTransaction` and optional `signAuthEntry` shapes the SDK already accepted). `address` is a plain string, not an Ed25519 key, so a smart account can present a `C…` contract address. `contract.KeypairSigner` is the `Keypair`-backed implementation. Also exported: the `SignTransactionLike` / `SignAuthEntryLike` unions naming everything the widened options accept.

- **`ClientOptions` / `MethodOptions` — widened signing options:** `signTransaction` and `signAuthEntry` now accept a `Signer` or a bare `Keypair` in addition to a callback. Previously the only way to sign with a local key was to find `basicNodeSigner`, which is documented as being for testing, and spread its two functions into the options.

- **`AssembledTransaction.sign()` / `signAndSend()` / `signAuthEntries()` — accept the same shapes:** each reduces the caller-supplied value to a plain callback at its entry point, so per-call overrides take a `Signer` or `Keypair` too. `signAuthEntries` reduces up front so that a `Signer` omitting the optional `signAuthEntry` raises `NoSigner` rather than silently signing nothing.

- **`basicNodeSigner()` — now delegates:** unchanged signature and behavior, but built on `KeypairSigner` so the signing logic exists once. Its docstring points at the new API.

`publicKey` is still required and is deliberately **not** inferred from the signer — omitting it stays a loud `FakeAccount` error rather than an assumed intent.

## Before / after

Before — you had to know `basicNodeSigner` existed, import it, repeat the passphrase the client already has, and spread two functions:

```ts
import { contract, Keypair, Networks } from "@stellar/stellar-sdk";

const keypair = Keypair.fromSecret(secret);

const client = await contract.Client.from({
  contractId,
  rpcUrl,
  networkPassphrase: Networks.TESTNET,
  publicKey: keypair.publicKey(),
  ...contract.basicNodeSigner(keypair, Networks.TESTNET),
});
```

After — hand it the keypair:

```ts
const client = await contract.Client.from({
  contractId,
  rpcUrl,
  networkPassphrase: Networks.TESTNET,
  publicKey: keypair.publicKey(),
  signTransaction: keypair,
});
```

Or pass a `Signer` when you need the identity alongside the capability — something a bare callback cannot report:

```ts
const signer = new contract.KeypairSigner(keypair, Networks.TESTNET);

signer.address; // the keypair's account address, always "G…"
await tx.sign({ signTransaction: signer });
```

Wallet-shaped signing is untouched, and an existing SEP-43 wallet object becomes a `Signer` by gaining an `address`:

```ts
import { signTransaction } from "@stellar/freighter-api";

const options = { contractId, rpcUrl, networkPassphrase, publicKey: address };

await contract.Client.from({ ...options, signTransaction });                                 // still works
await contract.Client.from({ ...options, signTransaction: { address, signTransaction } });   // now also works
```

A `Signer` may be a class with ordinary prototype methods — the SDK binds the callbacks it extracts, so `this` survives:

```ts
class WalletSigner implements contract.Signer {
  constructor(private wallet: Wallet, readonly address: string) {}
  async signTransaction(xdr: string) { return this.wallet.sign(xdr); }
}
```

## Compatibility

Not a breaking change: no runtime behavior changed, every previously accepted value is still accepted, and `basicNodeSigner`'s signature and output are unchanged.

One **type-only** caveat — the widened options are no longer exclusively function types, so a type expression that derived the callback's shape from the option field needs updating:

```diff
-type SignOpts = Parameters<NonNullable<contract.ClientOptions["signTransaction"]>>[1]
+type SignOpts = Parameters<contract.SignTransaction>[1]
```

Name `contract.SignTransaction` / `contract.SignAuthEntry` directly instead. This pattern appears in no example, guide, or generated binding — the SDK's own internal use was the only instance, and it's fixed here.

**Migrating off the `basicNodeSigner` spread:** that spread set *both* `signTransaction` and `signAuthEntry`, so `signTransaction: keypair` alone is not equivalent. If you sign auth entries (multi-party / non-invoker signing), set both:

```ts
signTransaction: keypair,
signAuthEntry: keypair,
```

## Implementation notes for reviewers

- A `Keypair` is recognized **structurally** (`sign` and `publicKey` are functions) rather than with `instanceof`. This package ships both a CJS and an ESM build whose `Keypair` classes are distinct objects, so `instanceof` rejects a working keypair that arrived through the other entry point; duplicate installs in one tree do the same. The check runs only after a `Signer` has been ruled out, so an object carrying `signTransaction` can never be misrouted to the keypair path.
- Anything that carries no usable callback — `null`, a primitive, an object matching no accepted shape — reduces to `undefined`, so the caller raises the SDK's own `NoSigner` instead of a `TypeError` escaping a normalizer. This matters because the options are reachable from plain JavaScript, where the types are not enforced.
