### PR TITLE
Add useUpgradedAuth simulation flag for CAP-71 v2 address credentials

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,17 +18,18 @@ jobs:
         job: ["test:e2e"]
     services:
       rpc:
-        # This image's core supports up to protocol 25. guides_pr.yml pins a
-        # newer digest running protocol 27 (the guides document protocol-27
-        # behavior) — when bumping either workflow's image, check the other.
-        image: stellar/quickstart:testing@sha256:e09b46445243c966557073e4947642153e515bb3fa0c8b26d92ed3b7cdce3ba2
+        # This image runs core v27.1.0 (protocol 27) and stellar-rpc 27.1.1,
+        # which supports the `useUpgradedAuth` simulation flag (CAP-71) that
+        # use-upgraded-auth.test.ts exercises. guides_pr.yml pins its own
+        # digest — when bumping either workflow's image, check the other.
+        image: stellar/quickstart:testing@sha256:c8f1a95e43f5c0ff0b3d2ce6c3db008ccb0754ffa50175c4e0ef06b9d643b490
         ports:
           - 8000:8000
         env:
           ENABLE_LOGS: true
           NETWORK: local
           ENABLE_SOROBAN_RPC: true
-          PROTOCOL_VERSION: 25
+          PROTOCOL_VERSION: 27
         options: >-
           --health-cmd "curl --no-progress-meter --fail-with-body -X POST
           \"http://localhost:8000/soroban/rpc\" -H 'Content-Type:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Added
+- `rpc.Server.simulateTransaction` accepts an optional `useUpgradedAuth` flag, and `contract.AssembledTransaction` accepts it as a method option (`useUpgradedAuth`) or per-call (`tx.simulate({ useUpgradedAuth: true })`). When set, RPC simulation records v2 address credentials (CAP-71) instead of the legacy v1 credentials. It only affects the recording auth modes and is silently ignored on hosts that cannot emit v2 credentials. The flag is deprecated from the start: it is transitional and becomes a no-op once the network returns v2 credentials by default (protocol 28) ([#1562](https://github.com/stellar/js-stellar-sdk/issues/1562)).
 - `@stellar/stellar-sdk/base` subpath export: import offline primitives like `StrKey` and `Keypair` without loading Horizon, RPC, or the SEP helpers and their networking dependencies([#1550](https://github.com/stellar/js-stellar-sdk/pull/1550)).
 
 ## Unreleased

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -230,7 +230,7 @@ class AssembledTransaction<T> {
   sign(__namedParameters: { force?: boolean; signTransaction?: SignTransaction } = {}): Promise<void>;
   signAndSend(__namedParameters: { force?: boolean; signTransaction?: SignTransaction; watcher?: Watcher } = {}): Promise<SentTransaction<T>>;
   signAuthEntries(__namedParameters: { address?: string; authorizeEntry?: (entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string) => Promise<SorobanAuthorizationEntry>; expiration?: number | Promise<number>; signAuthEntry?: SignAuthEntry } = {}): Promise<void>;
-  simulate(__namedParameters: { restore?: boolean } = {}): Promise<AssembledTransaction<T>>;
+  simulate(__namedParameters: { restore?: boolean; useUpgradedAuth?: boolean } = {}): Promise<AssembledTransaction<T>>;
   toJSON(): string;
   toXDR(): string;
 }
@@ -423,7 +423,7 @@ returns `false`, then you need to call `signAndSend` on this transaction.
 readonly isReadCall: boolean;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:1090](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1090)
+**Source:** [src/contract/assembled_transaction.ts:1099](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1099)
 
 ### `assembledTransaction.result`
 
@@ -431,7 +431,7 @@ readonly isReadCall: boolean;
 readonly result: T;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:739](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L739)
+**Source:** [src/contract/assembled_transaction.ts:748](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L748)
 
 ### `assembledTransaction.simulationData`
 
@@ -439,7 +439,7 @@ readonly result: T;
 readonly simulationData: { result: SimulateHostFunctionResult; transactionData: SorobanTransactionData };
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:696](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L696)
+**Source:** [src/contract/assembled_transaction.ts:705](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L705)
 
 ### `assembledTransaction.needsNonInvokerSigningBy(__namedParameters)`
 
@@ -469,7 +469,7 @@ needsNonInvokerSigningBy(__namedParameters: { includeAlreadySigned?: boolean } =
 
 - **`__namedParameters`** — `{ includeAlreadySigned?: boolean }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:925](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L925)
+**Source:** [src/contract/assembled_transaction.ts:934](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L934)
 
 ### `assembledTransaction.restoreFootprint(restorePreamble, account)`
 
@@ -504,7 +504,7 @@ Client initialization.
 - - Throws a custom error if the
 restore transaction fails, providing the details of the failure.
 
-**Source:** [src/contract/assembled_transaction.ts:1119](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1119)
+**Source:** [src/contract/assembled_transaction.ts:1128](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1128)
 
 ### `assembledTransaction.send(watcher)`
 
@@ -521,7 +521,7 @@ send(watcher?: Watcher): Promise<SentTransaction<T>>;
 
 - **`watcher`** — `Watcher` (optional)
 
-**Source:** [src/contract/assembled_transaction.ts:854](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L854)
+**Source:** [src/contract/assembled_transaction.ts:863](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L863)
 
 ### `assembledTransaction.sign(__namedParameters)`
 
@@ -536,7 +536,7 @@ sign(__namedParameters: { force?: boolean; signTransaction?: SignTransaction } =
 
 - **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransaction }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:767](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L767)
+**Source:** [src/contract/assembled_transaction.ts:776](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L776)
 
 ### `assembledTransaction.signAndSend(__namedParameters)`
 
@@ -555,7 +555,7 @@ signAndSend(__namedParameters: { force?: boolean; signTransaction?: SignTransact
 
 - **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransaction; watcher?: Watcher }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:872](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L872)
+**Source:** [src/contract/assembled_transaction.ts:881](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L881)
 
 ### `assembledTransaction.signAuthEntries(__namedParameters)`
 
@@ -582,17 +582,17 @@ signAuthEntries(__namedParameters: { address?: string; authorizeEntry?: (entry: 
 
 - **`__namedParameters`** — `{ address?: string; authorizeEntry?: (entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string) => Promise<SorobanAuthorizationEntry>; expiration?: number | Promise<number>; signAuthEntry?: SignAuthEntry }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:986](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L986)
+**Source:** [src/contract/assembled_transaction.ts:995](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L995)
 
 ### `assembledTransaction.simulate(__namedParameters)`
 
 ```ts
-simulate(__namedParameters: { restore?: boolean } = {}): Promise<AssembledTransaction<T>>;
+simulate(__namedParameters: { restore?: boolean; useUpgradedAuth?: boolean } = {}): Promise<AssembledTransaction<T>>;
 ```
 
 **Parameters**
 
-- **`__namedParameters`** — `{ restore?: boolean }` (optional) (default: `{}`)
+- **`__namedParameters`** — `{ restore?: boolean; useUpgradedAuth?: boolean }` (optional) (default: `{}`)
 
 **Source:** [src/contract/assembled_transaction.ts:643](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L643)
 
@@ -825,7 +825,7 @@ _before_ transaction signing.
 const DEFAULT_TIMEOUT: number
 ```
 
-**Source:** [src/contract/types.ts:293](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L293)
+**Source:** [src/contract/types.ts:306](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L306)
 
 ## contract.NULL_ACCOUNT
 
@@ -835,7 +835,7 @@ An impossible account on the Stellar network
 const NULL_ACCOUNT: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
 ```
 
-**Source:** [src/contract/types.ts:299](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L299)
+**Source:** [src/contract/types.ts:312](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L312)
 
 ## contract.SentTransaction
 
@@ -1498,7 +1498,7 @@ basicNodeSigner(keypair: Keypair, networkPassphrase: string): { signAuthEntry: S
 type AssembledTransactionOptions<T = string> = MethodOptions & ClientOptions & { address?: string; args?: any[]; method: string; parseResultXdr: (xdr: xdr.ScVal) => T; submit?: boolean; submitUrl?: string }
 ```
 
-**Source:** [src/contract/types.ts:261](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L261)
+**Source:** [src/contract/types.ts:274](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L274)
 
 ### contract.ClientOptions
 
@@ -1549,7 +1549,7 @@ message: string;
 Options for a smart contract method invocation.
 
 ```ts
-type MethodOptions = { fee?: string; publicKey?: string; restore?: boolean; signAuthEntry?: SignAuthEntry; signTransaction?: SignTransaction; simulate?: boolean; timeoutInSeconds?: number }
+type MethodOptions = { fee?: string; publicKey?: string; restore?: boolean; signAuthEntry?: SignAuthEntry; signTransaction?: SignTransaction; simulate?: boolean; timeoutInSeconds?: number; useUpgradedAuth?: boolean }
 ```
 
 **Source:** [src/contract/types.ts:204](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L204)

--- a/docs/reference/network-rpc.md
+++ b/docs/reference/network-rpc.md
@@ -110,7 +110,7 @@ class Server {
   _getTransaction(hash: string): Promise<RawGetTransactionResponse>;
   _getTransactions(request: GetTransactionsRequest): Promise<RawGetTransactionsResponse>;
   _sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<RawSendTransactionResponse>;
-  _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode): Promise<RawSimulateTransactionResponse>;
+  _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, useUpgradedAuth?: boolean): Promise<RawSimulateTransactionResponse>;
   fundAddress(address: string, friendbotUrl?: string): Promise<GetSuccessfulTransactionResponse>;
   getAccount(address: string): Promise<Account>;
   getAccountEntry(address: string): Promise<AccountEntry>;
@@ -139,7 +139,7 @@ class Server {
   queryContract<T = any>(contractId: string, method: string, args: Record<string, unknown> = {}, networkPassphrase?: string): Promise<{ isReadCall: boolean; result: T }>;
   requestAirdrop(address: string | Pick<Account, "accountId">, friendbotUrl?: string): Promise<Account>;
   sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<SendTransactionResponse>;
-  simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode): Promise<SimulateTransactionResponse>;
+  simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, useUpgradedAuth?: boolean): Promise<SimulateTransactionResponse>;
 }
 ```
 
@@ -236,7 +236,7 @@ _getLedgers(request: GetLedgersRequest): Promise<RawGetLedgersResponse>;
 
 - **`request`** — `GetLedgersRequest` (required)
 
-**Source:** [src/rpc/server.ts:1773](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1773)
+**Source:** [src/rpc/server.ts:1788](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1788)
 
 ### `server._getTransaction(hash)`
 
@@ -272,12 +272,12 @@ _sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<RawSend
 
 - **`transaction`** — `Transaction | FeeBumpTransaction` (required)
 
-**Source:** [src/rpc/server.ts:1409](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1409)
+**Source:** [src/rpc/server.ts:1424](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1424)
 
-### `server._simulateTransaction(transaction, addlResources, authMode)`
+### `server._simulateTransaction(transaction, addlResources, authMode, useUpgradedAuth)`
 
 ```ts
-_simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode): Promise<RawSimulateTransactionResponse>;
+_simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, useUpgradedAuth?: boolean): Promise<RawSimulateTransactionResponse>;
 ```
 
 **Parameters**
@@ -285,8 +285,9 @@ _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResource
 - **`transaction`** — `Transaction | FeeBumpTransaction` (required)
 - **`addlResources`** — `ResourceLeeway` (optional)
 - **`authMode`** — `SimulationAuthMode` (optional)
+- **`useUpgradedAuth`** — `boolean` (optional)
 
-**Source:** [src/rpc/server.ts:1256](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1256)
+**Source:** [src/rpc/server.ts:1269](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1269)
 
 ### `server.fundAddress(address, friendbotUrl)`
 
@@ -339,7 +340,7 @@ console.log("Contract funded! Hash:", tx.txHash);
 
 - `Friendbot docs`
 
-**Source:** [src/rpc/server.ts:1532](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1532)
+**Source:** [src/rpc/server.ts:1547](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1547)
 
 ### `server.getAccount(address)`
 
@@ -775,7 +776,7 @@ the fee stats
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getFeeStats
 
-**Source:** [src/rpc/server.ts:1578](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1578)
+**Source:** [src/rpc/server.ts:1593](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1593)
 
 ### `server.getHealth()`
 
@@ -961,7 +962,7 @@ const nextPage = await server.getLedgers({
 
 - `getLedgers docs`
 
-**Source:** [src/rpc/server.ts:1757](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1757)
+**Source:** [src/rpc/server.ts:1772](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1772)
 
 ### `server.getNetwork()`
 
@@ -1049,7 +1050,7 @@ console.log(
 - - getLedgerEntries
  - https://developers.stellar.org/docs/tokens/stellar-asset-contract
 
-**Source:** [src/rpc/server.ts:1642](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1642)
+**Source:** [src/rpc/server.ts:1657](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1657)
 
 ### `server.getTransaction(hash)`
 
@@ -1180,7 +1181,7 @@ the version info
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getVersionInfo
 
-**Source:** [src/rpc/server.ts:1592](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1592)
+**Source:** [src/rpc/server.ts:1607](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1607)
 
 ### `server.pollTransaction(hash, opts)`
 
@@ -1309,7 +1310,7 @@ server.sendTransaction(transaction).then(result => {
 - - module:rpc.assembleTransaction
  - `simulateTransaction docs`
 
-**Source:** [src/rpc/server.ts:1348](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1348)
+**Source:** [src/rpc/server.ts:1363](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1363)
 
 ### `server.queryContract(contractId, method, args, networkPassphrase)`
 
@@ -1417,7 +1418,7 @@ server
 - - `Friendbot docs`
  - `Friendbot.Api.Response`
 
-**Source:** [src/rpc/server.ts:1454](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1454)
+**Source:** [src/rpc/server.ts:1469](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1469)
 
 ### `server.sendTransaction(transaction)`
 
@@ -1478,15 +1479,15 @@ server.sendTransaction(transaction).then((result) => {
 - - `transaction docs`
  - `sendTransaction docs`
 
-**Source:** [src/rpc/server.ts:1403](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1403)
+**Source:** [src/rpc/server.ts:1418](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1418)
 
-### `server.simulateTransaction(tx, addlResources, authMode)`
+### `server.simulateTransaction(tx, addlResources, authMode, useUpgradedAuth)`
 
 Submit a trial contract invocation to get back return values, expected
 ledger footprint, expected authorizations, and expected costs.
 
 ```ts
-simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode): Promise<SimulateTransactionResponse>;
+simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, useUpgradedAuth?: boolean): Promise<SimulateTransactionResponse>;
 ```
 
 **Parameters**
@@ -1503,6 +1504,15 @@ simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: Resour
      auth mode to use for simulation: `enforce` for enforcement mode,
      `record` for recording mode, or `record_allow_nonroot` for recording
      mode that allows non-root authorization
+- **`useUpgradedAuth`** — `boolean` (optional) — (optional) opt simulation into recording
+     v2 address credentials (CAP-71) instead of the legacy v1 address
+     credentials. Best-effort: it only affects the recording auth modes and
+     is silently ignored on protocol versions whose host cannot emit v2
+     credentials.
+  
+     **Deprecated**: this flag is transitional. Once the network returns v2
+     credentials by default (protocol 28), it becomes a no-op — do not rely
+     on omitting it to keep receiving the legacy v1 format.
 
 **Returns**
 
@@ -1544,7 +1554,7 @@ server.simulateTransaction(transaction).then((sim) => {
  - module:rpc.Server#prepareTransaction
  - module:rpc.assembleTransaction
 
-**Source:** [src/rpc/server.ts:1246](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1246)
+**Source:** [src/rpc/server.ts:1255](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1255)
 
 ## rpc.assembleTransaction
 

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -640,7 +640,10 @@ export class AssembledTransaction<T> {
     return tx;
   }
 
-  simulate = async ({ restore }: { restore?: boolean } = {}): Promise<this> => {
+  simulate = async ({
+    restore,
+    useUpgradedAuth,
+  }: { restore?: boolean; useUpgradedAuth?: boolean } = {}): Promise<this> => {
     if (!this.built) {
       if (!this.raw) {
         throw new Error(
@@ -651,11 +654,17 @@ export class AssembledTransaction<T> {
       this.built = this.raw.build();
     }
     restore = restore ?? this.options.restore;
+    useUpgradedAuth = useUpgradedAuth ?? this.options.useUpgradedAuth;
 
     // need to force re-calculation of simulationData for new simulation
     delete this.simulationResult;
     delete this.simulationTransactionData;
-    this.simulation = await this.server.simulateTransaction(this.built);
+    this.simulation = await this.server.simulateTransaction(
+      this.built,
+      undefined,
+      undefined,
+      useUpgradedAuth,
+    );
 
     if (restore && Api.isSimulationRestore(this.simulation)) {
       const account = await getAccount(this.options, this.server);
@@ -678,7 +687,7 @@ export class AssembledTransaction<T> {
           .addOperation(op)
           .setTimeout(this.options.timeoutInSeconds ?? DEFAULT_TIMEOUT);
         delete this.built;
-        await this.simulate();
+        await this.simulate({ useUpgradedAuth });
         return this;
       }
       throw new AssembledTransaction.Errors.RestorationFailure(

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -230,6 +230,19 @@ export type MethodOptions = {
   restore?: boolean;
 
   /**
+   * If true, simulation records v2 address credentials (CAP-71) instead of
+   * the legacy v1 address credentials. Best-effort: it only affects the
+   * recording auth modes and is silently ignored on protocol versions whose
+   * host cannot emit v2 credentials.
+   *
+   * @deprecated This flag is transitional. Once the network returns v2
+   * credentials by default (protocol 28), it becomes a no-op — do not rely on
+   * omitting it to keep receiving the legacy v1 format.
+   * @defaultValue false
+   */
+  useUpgradedAuth?: boolean;
+
+  /**
    * The public key of the source account for this transaction.
    *
    * Default: the one provided to the {@link Client} in {@link ClientOptions}

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -1203,6 +1203,15 @@ export class RpcServer {
    *    auth mode to use for simulation: `enforce` for enforcement mode,
    *    `record` for recording mode, or `record_allow_nonroot` for recording
    *    mode that allows non-root authorization
+   * @param useUpgradedAuth - (optional) opt simulation into recording
+   *    v2 address credentials (CAP-71) instead of the legacy v1 address
+   *    credentials. Best-effort: it only affects the recording auth modes and
+   *    is silently ignored on protocol versions whose host cannot emit v2
+   *    credentials.
+   *
+   *    **Deprecated**: this flag is transitional. Once the network returns v2
+   *    credentials by default (protocol 28), it becomes a no-op — do not rely
+   *    on omitting it to keep receiving the legacy v1 format.
    *
    * @returns An object with the
    *    cost, footprint, result/auth requirements (if applicable), and error of
@@ -1247,16 +1256,21 @@ export class RpcServer {
     tx: Transaction | FeeBumpTransaction,
     addlResources?: RpcServer.ResourceLeeway,
     authMode?: Api.SimulationAuthMode,
+    useUpgradedAuth?: boolean,
   ): Promise<Api.SimulateTransactionResponse> {
-    return this._simulateTransaction(tx, addlResources, authMode).then(
-      parseRawSimulation,
-    );
+    return this._simulateTransaction(
+      tx,
+      addlResources,
+      authMode,
+      useUpgradedAuth,
+    ).then(parseRawSimulation);
   }
 
   public async _simulateTransaction(
     transaction: Transaction | FeeBumpTransaction,
     addlResources?: RpcServer.ResourceLeeway,
     authMode?: Api.SimulationAuthMode,
+    useUpgradedAuth?: boolean,
   ): Promise<Api.RawSimulateTransactionResponse> {
     return jsonrpc.postObject(
       this.httpClient,
@@ -1265,6 +1279,7 @@ export class RpcServer {
       {
         transaction: transaction.toXDR(),
         authMode,
+        ...(useUpgradedAuth !== undefined && { useUpgradedAuth }),
         ...(addlResources !== undefined && {
           resourceConfig: {
             instructionLeeway: addlResources.cpuInstructions,

--- a/test/e2e/src/use-upgraded-auth.test.ts
+++ b/test/e2e/src/use-upgraded-auth.test.ts
@@ -1,0 +1,64 @@
+import { expect, describe, it, beforeAll } from "vitest";
+import { inspectAuthEntry } from "../../../lib/esm/index.js";
+import { clientFor, generateFundedKeypair } from "./util.js";
+
+// TEMP (CAP-71 transition): verifies that the RPC honors the deprecated
+// `useUpgradedAuth` simulation flag and records v2 address credentials.
+// Requires an RPC built with stellar/stellar-rpc#783 on protocol >= 27; on
+// older hosts the flag is silently ignored and the v2 assertions fail.
+// Delete this file once protocol 28 activates and v2 becomes the default.
+
+let context: { client: any; userSigner: any; contractSigner: any };
+
+const credentialTypes = (tx: any): string[] =>
+  tx.simulationData.result.auth.map(
+    (entry: any) => inspectAuthEntry(entry).credentialType,
+  );
+
+describe("useUpgradedAuth simulation flag (temp, CAP-71)", () => {
+  beforeAll(async () => {
+    const { client } = await clientFor("needsSignature");
+    // recording-mode simulation does not run __check_auth, so plain funded
+    // accounts work for both signers; they only need to differ from the
+    // invoker so the recorded entries carry address (not source-account)
+    // credentials
+    const userSigner = await generateFundedKeypair();
+    const contractSigner = await generateFundedKeypair();
+    context = { client, userSigner, contractSigner };
+  });
+
+  const hello = (methodOptions?: object) =>
+    context.client.hello(
+      {
+        to: "world",
+        user_signer: context.userSigner.publicKey(),
+        contract_signer: context.contractSigner.publicKey(),
+      },
+      methodOptions,
+    );
+
+  it("records legacy v1 address credentials by default", async () => {
+    const tx = await hello();
+    const types = credentialTypes(tx);
+    expect(types.length).toBeGreaterThan(0);
+    expect(types).toEqual(types.map(() => "address"));
+  });
+
+  it("records v2 address credentials when set as a method option", async () => {
+    const tx = await hello({ useUpgradedAuth: true });
+    const types = credentialTypes(tx);
+    expect(types.length).toBeGreaterThan(0);
+    expect(types).toEqual(types.map(() => "addressV2"));
+  });
+
+  it("records v2 address credentials when set per simulate() call", async () => {
+    // skip the automatic simulation: once a simulation's auth entries are
+    // assembled onto the transaction, a re-simulation runs in enforce mode,
+    // where the flag has no effect
+    const tx = await hello({ simulate: false });
+    await tx.simulate({ useUpgradedAuth: true });
+    const types = credentialTypes(tx);
+    expect(types.length).toBeGreaterThan(0);
+    expect(types).toEqual(types.map(() => "addressV2"));
+  });
+});

--- a/test/unit/server/soroban/assembled_transaction.test.ts
+++ b/test/unit/server/soroban/assembled_transaction.test.ts
@@ -130,6 +130,49 @@ describe("AssembledTransaction", () => {
     expect(mockPost).toHaveBeenCalledTimes(3);
   });
 
+  it("passes useUpgradedAuth through to simulateTransaction", async () => {
+    const simulateTransactionResponse = {
+      transactionData: restoreTxnData,
+      minResourceFee: "52641",
+      cost: { cpuInsns: "0", memBytes: "0" },
+      latestLedger: 17027,
+    };
+    mockPost.mockResolvedValue({
+      data: { result: simulateTransactionResponse },
+    });
+
+    // set via options: flows through to every simulation
+    options.useUpgradedAuth = true;
+    const txn = await contract.AssembledTransaction[
+      "buildFootprintRestoreTransaction"
+    ](
+      options,
+      restoreTxnData,
+      new Account(
+        "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI",
+        "1",
+      ),
+      52641,
+    );
+    expect(mockPost).toHaveBeenLastCalledWith(
+      serverUrl,
+      expect.objectContaining({
+        method: "simulateTransaction",
+        params: expect.objectContaining({ useUpgradedAuth: true }),
+      }),
+    );
+
+    // per-call value overrides the option
+    await txn.simulate({ restore: false, useUpgradedAuth: false });
+    expect(mockPost).toHaveBeenLastCalledWith(
+      serverUrl,
+      expect.objectContaining({
+        method: "simulateTransaction",
+        params: expect.objectContaining({ useUpgradedAuth: false }),
+      }),
+    );
+  });
+
   it("throws an error if signing transaction without providing a public key", async () => {
     const simulateTransactionResponse = {
       id: "1",

--- a/test/unit/server/soroban/simulate_transaction.test.ts
+++ b/test/unit/server/soroban/simulate_transaction.test.ts
@@ -419,6 +419,31 @@ describe("Server#simulateTransaction", () => {
     expect(mockPost).toHaveBeenCalledTimes(1);
   });
 
+  it("simulates a transaction with useUpgradedAuth", async () => {
+    const mockResponse = { data: { id: 1, result: simulationResponse } };
+    mockPost.mockResolvedValue(mockResponse);
+
+    const response = await server.simulateTransaction(
+      transaction,
+      undefined,
+      undefined,
+      true,
+    );
+    const expected = cloneSimulation(parsedSimulationResponse);
+    assert.deepEqual(response, expected);
+    expect(mockPost).toHaveBeenCalledWith(serverUrl, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "simulateTransaction",
+      params: {
+        transaction: blob,
+        authMode: undefined,
+        useUpgradedAuth: true,
+      },
+    });
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
   it("simulates a transaction with add'l resource usage", async () => {
     const mockResponse = { data: { id: 1, result: simulationResponse } };
     mockPost.mockResolvedValue(mockResponse);


### PR DESCRIPTION
### What

Add an optional `useUpgradedAuth` flag to RPC transaction simulation, matching the request field added to `simulateTransaction` in [stellar-rpc#783](https://github.com/stellar/stellar-rpc/pull/783). When set, recording-mode simulation returns v2 address credentials (CAP-71, `SOROBAN_CREDENTIALS_ADDRESS_V2`) instead of the legacy v1 `SOROBAN_CREDENTIALS_ADDRESS`.

The flag is exposed at three levels:

- `rpc.Server.simulateTransaction(tx, addlResources?, authMode?, useUpgradedAuth?)` — sent in the request body only when set.
- `contract.Client` method options — `client.method(args, { useUpgradedAuth: true })`, via the new `MethodOptions.useUpgradedAuth`.
- `AssembledTransaction` per call — `tx.simulate({ useUpgradedAuth: true })`, falling back to the method option when not given.

The flag is deprecated from the start: it is transitional and becomes a no-op once protocol 28 activates and the network returns v2 credentials by default. The JSDoc on both the server parameter and the method option says so.

Also included:

- A temporary e2e test (`test/e2e/src/use-upgraded-auth.test.ts`) that runs against a real RPC and asserts the default simulation records v1 credentials while both opt-in paths record v2. Marked for deletion once protocol 28 activates.
- The e2e CI quickstart image is bumped to the current `testing` digest (core v27.1.0 / protocol 27, stellar-rpc 27.1.1), since the old pin ran protocol 25 and its RPC predates the flag. The full e2e suite passes on the new stack (91 tests).
- Unit tests for the request wiring and the option/per-call fallback, plus a changelog entry.

### Why

Closes the last checkbox of #1562: parsing and signing v2 credentials already landed, but there was no way to ask RPC for them. [rs-soroban-env#1689](https://github.com/stellar/rs-soroban-env/pull/1689) and stellar-rpc#783 made v2 credential recording a request-level opt-in precisely so SDKs and wallets can exercise the v2 signing path end to end before the protocol boundary forces it. This wires that opt-in through the JS SDK so integrators can test their CAP-71 handling on protocol 27 networks today.

A note on re-simulation: the flag only matters in the recording auth modes. Once a simulation's auth entries have been assembled onto a transaction, re-simulating it runs in enforce mode, where the flag has no effect — the e2e test documents this by building with `simulate: false` before the flagged `simulate()` call.
