### PR TITLE
fix(xdr): emit SEP-51 key `type` instead of Rust-escaped `type_`

### DIFF
--- a/scripts/xdr-json-parity-monitor.ts
+++ b/scripts/xdr-json-parity-monitor.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 // Long-running XDR↔JSON parity monitor: pulls real XDR from Horizon and checks
 // that the new class-XDR layer's SEP-51 JSON matches the canonical reference
 // implementation — the Rust `stellar-xdr` crate compiled to WASM and published
@@ -157,6 +156,31 @@ function sortKeys(v: any): any {
   return v;
 }
 
+// stellar-xdr's serde output escapes the XDR field `type` as `type_`. The SDK
+// emits the SEP-51 field name, but this monitor still uses the Rust package as
+// its reference encoder/decoder, so adapt that legacy spelling at the boundary.
+function normalizeReferenceJson(v: any, toReference = false): any {
+  if (Array.isArray(v)) {
+    return v.map((item) => normalizeReferenceJson(item, toReference));
+  }
+  if (v && typeof v === "object") {
+    const out: Record<string, any> = {};
+    for (const [key, value] of Object.entries(v)) {
+      const normalizedKey = toReference
+        ? key === "type"
+          ? "type_"
+          : key
+        : key === "type_"
+          ? "type"
+          : key;
+      if (normalizedKey in out) return v;
+      out[normalizedKey] = normalizeReferenceJson(value, toReference);
+    }
+    return out;
+  }
+  return v;
+}
+
 const hex = (b: Uint8Array): string => Buffer.from(b).toString("hex");
 
 function checkParity(
@@ -212,7 +236,8 @@ function checkParity(
   }
 
   // Both decoded — compare JSON and both reconstruction directions.
-  const jsonEqual = canonical(ourJson) === canonical(refJson);
+  const jsonEqual =
+    canonical(ourJson) === canonical(normalizeReferenceJson(refJson));
 
   let weReadRef = false;
   try {
@@ -225,7 +250,13 @@ function checkParity(
   try {
     refReadsOurs =
       hex(
-        Buffer.from(refEncode(typeName, JSON.stringify(ourJson)), "base64"),
+        Buffer.from(
+          refEncode(
+            typeName,
+            JSON.stringify(normalizeReferenceJson(ourJson, true)),
+          ),
+          "base64",
+        ),
       ) === inputHex;
   } catch {
     refReadsOurs = false;

--- a/src/xdr/values/json-names.ts
+++ b/src/xdr/values/json-names.ts
@@ -44,8 +44,10 @@ function snakeCase(input: string): string {
 }
 
 // Rust keywords xdrgen-rust escapes with a trailing `_` when an XDR field name
-// collides; serde then keeps the escaped form. `type` is the one that occurs in
-// the Stellar XDR (ContractEvent, the SC-spec structs, …).
+// collides; serde then leaks the escaped form into the JSON (`type_`). That is
+// a bug in the Rust `stellar-xdr` JSON output — SEP-0051 keys come from the
+// XDR field name, so we emit the plain name (`type`). The keyword set is kept
+// only so fromJson can still accept the escaped legacy keys.
 const RUST_KEYWORD_FIELDS = new Set([
   "type",
   "ref",
@@ -62,8 +64,17 @@ const RUST_KEYWORD_FIELDS = new Set([
 
 /** Struct field → its SEP-0051 JSON key. */
 export function structFieldJsonName(field: string): string {
+  return snakeCase(field);
+}
+
+/**
+ * Legacy escaped JSON key for a struct field, if one exists. The Rust
+ * `stellar-xdr` crate emits keyword fields with a trailing `_` (`type_`);
+ * fromJson accepts that spelling for backwards compatibility.
+ */
+export function legacyStructFieldJsonName(field: string): string | undefined {
   const name = snakeCase(field);
-  return RUST_KEYWORD_FIELDS.has(name) ? `${name}_` : name;
+  return RUST_KEYWORD_FIELDS.has(name) ? `${name}_` : undefined;
 }
 
 // Name maps are derived purely from the (immutable) schema, and the walker

--- a/src/xdr/values/to-json.ts
+++ b/src/xdr/values/to-json.ts
@@ -20,6 +20,7 @@ import type {
 import type { JsonValue } from "./xdr-value.js";
 import { XdrString } from "./xdr-string.js";
 import {
+  legacyStructFieldJsonName,
   structFieldJsonName,
   enumJsonNames,
   unionCaseNames,
@@ -271,12 +272,21 @@ export function walkFromJson(
       }
       const rec = json as Record<string, JsonValue>;
       const out: Record<string, unknown> = {};
-      // Accept either the SEP-0051 snake_case key or the raw camelCase wire
-      // name (so internally-produced JSON round-trips even if a caller hands
-      // us camelCase).
+      // Accept the SEP-0051 snake_case key, the legacy Rust keyword-escaped
+      // key (`type_` from the `stellar-xdr` crate's buggy output), or the raw
+      // camelCase wire name (so internally-produced JSON round-trips even if
+      // a caller hands us camelCase).
       for (const [k, fieldSchema] of s.entries) {
         const snake = structFieldJsonName(k);
-        const lookupKey = snake in rec ? snake : k in rec ? k : undefined;
+        const legacy = legacyStructFieldJsonName(k);
+        const lookupKey =
+          snake in rec
+            ? snake
+            : legacy !== undefined && legacy in rec
+              ? legacy
+              : k in rec
+                ? k
+                : undefined;
         if (lookupKey === undefined) {
           // Match the serde-based Rust reference: an omitted optional field
           // is None, so JSON from tooling that skips nulls still parses.

--- a/test/unit/xdr/to_json.test.ts
+++ b/test/unit/xdr/to_json.test.ts
@@ -38,6 +38,11 @@ import {
   AssetCode,
   AssetCode12,
   MuxedEd25519Account,
+  ContractEvent,
+  ContractEventBody,
+  ContractEventType,
+  ContractEventV0,
+  ExtensionPoint,
 } from "../../../src/xdr/index.js";
 
 const ED = new Uint8Array(32);
@@ -291,6 +296,36 @@ describe("walker — structs (composite)", () => {
     });
     const round = Asset.fromJson(usd.toJson());
     expect(round.toXdr()).toEqual(usd.toXdr());
+  });
+});
+
+describe("walker — Rust-keyword struct fields (`type`)", () => {
+  const event = new ContractEvent({
+    ext: ExtensionPoint.v0(),
+    contractId: null,
+    type: ContractEventType.contract,
+    body: ContractEventBody.v0(
+      new ContractEventV0({ topics: [], data: ScVal.scvVoid() }),
+    ),
+  });
+
+  it("toJson emits `type`, not the Rust-escaped `type_`", () => {
+    const json = event.toJson() as Record<string, unknown>;
+    expect(json.type).toBe("contract");
+    expect(json).not.toHaveProperty("type_");
+  });
+
+  it("fromJson accepts the canonical `type` key", () => {
+    const round = ContractEvent.fromJson(event.toJson());
+    expect(round.toXdr()).toEqual(event.toXdr());
+  });
+
+  it("fromJson still accepts the legacy `type_` key", () => {
+    const json = event.toJson() as Record<string, unknown>;
+    json.type_ = json.type;
+    delete json.type;
+    const round = ContractEvent.fromJson(json as never);
+    expect(round.toXdr()).toEqual(event.toXdr());
   });
 });
 


### PR DESCRIPTION
## What

`toJson` now emits struct fields named `type` (and other Rust-keyword fields) with their plain SEP-51 name instead of the Rust-escaped `type_`. `fromJson` stays backwards compatible: it accepts the legacy `type_` key alongside the canonical `type`. The XDR↔JSON parity monitor normalizes the reference encoder's legacy spelling at the boundary so parity checks still pass against the current Rust package.

## Why

The trailing underscore came from mirroring `stellar-xdr-json`, but that escaping was a serde artifact in the Rust `stellar-xdr` crate, not part of SEP-51. stellar/rs-stellar-xdr#559 fixed it upstream, so we emit the correct key too. Accepting `type_` on parse keeps JSON produced by older tooling working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)