### PR TITLE
Support duplicate event names in generated bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ test-guides/
 .vuln-hunt/
 scratch/
 .docs-build/
+
+# Working data for scripts/test-event-bindings.mjs (contract-wasms clone +
+# generated bindings under test)
+.contract-wasms-test/

--- a/docs/reference/contracts-bindings.md
+++ b/docs/reference/contracts-bindings.md
@@ -53,7 +53,7 @@ const generator = BindingGenerator.fromSpec(spec);
 const bindings = generator.generate({ contractName: "my-contract" });
 ```
 
-**Source:** [src/bindings/generator.ts:78](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L78)
+**Source:** [src/bindings/generator.ts:105](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L105)
 
 ### `BindingGenerator.fromContractId(contractId, rpcServer)`
 
@@ -89,7 +89,7 @@ const generator = await BindingGenerator.fromContractId(
 );
 ```
 
-**Source:** [src/bindings/generator.ts:182](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L182)
+**Source:** [src/bindings/generator.ts:209](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L209)
 
 ### `BindingGenerator.fromSpec(spec)`
 
@@ -117,7 +117,7 @@ const spec = new Spec(specEntries);
 const generator = BindingGenerator.fromSpec(spec);
 ```
 
-**Source:** [src/bindings/generator.ts:105](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L105)
+**Source:** [src/bindings/generator.ts:132](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L132)
 
 ### `BindingGenerator.fromWasm(wasmBuffer)`
 
@@ -149,7 +149,7 @@ const wasmBuffer = fs.readFileSync("./target/wasm32-unknown-unknown/release/my_c
 const generator = await BindingGenerator.fromWasm(wasmBuffer);
 ```
 
-**Source:** [src/bindings/generator.ts:125](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L125)
+**Source:** [src/bindings/generator.ts:152](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L152)
 
 ### `BindingGenerator.fromWasmHash(wasmHash, rpcServer)`
 
@@ -186,7 +186,7 @@ const generator = await BindingGenerator.fromWasmHash(
 );
 ```
 
-**Source:** [src/bindings/generator.ts:151](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L151)
+**Source:** [src/bindings/generator.ts:178](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L178)
 
 ### `bindingGenerator.generate(options)`
 
@@ -233,4 +233,4 @@ fs.writeFileSync("./src/client.ts", bindings.client);
 fs.writeFileSync("./src/types.ts", bindings.types);
 ```
 
-**Source:** [src/bindings/generator.ts:226](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L226)
+**Source:** [src/bindings/generator.ts:253](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L253)

--- a/docs/reference/contracts-bindings.md
+++ b/docs/reference/contracts-bindings.md
@@ -53,7 +53,7 @@ const generator = BindingGenerator.fromSpec(spec);
 const bindings = generator.generate({ contractName: "my-contract" });
 ```
 
-**Source:** [src/bindings/generator.ts:105](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L105)
+**Source:** [src/bindings/generator.ts:107](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L107)
 
 ### `BindingGenerator.fromContractId(contractId, rpcServer)`
 
@@ -89,7 +89,7 @@ const generator = await BindingGenerator.fromContractId(
 );
 ```
 
-**Source:** [src/bindings/generator.ts:209](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L209)
+**Source:** [src/bindings/generator.ts:211](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L211)
 
 ### `BindingGenerator.fromSpec(spec)`
 
@@ -117,7 +117,7 @@ const spec = new Spec(specEntries);
 const generator = BindingGenerator.fromSpec(spec);
 ```
 
-**Source:** [src/bindings/generator.ts:132](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L132)
+**Source:** [src/bindings/generator.ts:134](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L134)
 
 ### `BindingGenerator.fromWasm(wasmBuffer)`
 
@@ -149,7 +149,7 @@ const wasmBuffer = fs.readFileSync("./target/wasm32-unknown-unknown/release/my_c
 const generator = await BindingGenerator.fromWasm(wasmBuffer);
 ```
 
-**Source:** [src/bindings/generator.ts:152](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L152)
+**Source:** [src/bindings/generator.ts:154](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L154)
 
 ### `BindingGenerator.fromWasmHash(wasmHash, rpcServer)`
 
@@ -186,7 +186,7 @@ const generator = await BindingGenerator.fromWasmHash(
 );
 ```
 
-**Source:** [src/bindings/generator.ts:178](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L178)
+**Source:** [src/bindings/generator.ts:180](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L180)
 
 ### `bindingGenerator.generate(options)`
 
@@ -233,4 +233,4 @@ fs.writeFileSync("./src/client.ts", bindings.client);
 fs.writeFileSync("./src/types.ts", bindings.types);
 ```
 
-**Source:** [src/bindings/generator.ts:253](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L253)
+**Source:** [src/bindings/generator.ts:255](https://github.com/stellar/js-stellar-sdk/blob/main/src/bindings/generator.ts#L255)

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -1058,7 +1058,7 @@ class Spec {
   entries: ScSpecEntry[];
   errorCases(): ScSpecUdtErrorEnumCaseV0[];
   events(): ScSpecEventV0[];
-  eventTopicFilter(name: string, topicValues?: Record<string, any>): string[];
+  eventTopicFilter(name: string, topicValues?: Record<string, any>, occurrence?: number): string[];
   findEntry(name: string): ScSpecEntry;
   findEvent(name: string): ScSpecEventV0 | undefined;
   funcArgsToScVals(name: string, args: object): ScVal[];
@@ -1184,7 +1184,7 @@ all contract events
 
 **Source:** [src/contract/spec.ts:1224](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1224)
 
-### `spec.eventTopicFilter(name, topicValues)`
+### `spec.eventTopicFilter(name, topicValues, occurrence)`
 
 Builds a `getEvents` topic filter (a single row of `Api.EventFilter.topics`)
 for the named event: base64-encoded `scvSymbol`s for the event's prefix
@@ -1193,13 +1193,16 @@ base64-encoded ScVal for a value supplied in `topicValues`, or the
 wildcard `"*"`.
 
 ```ts
-eventTopicFilter(name: string, topicValues?: Record<string, any>): string[];
+eventTopicFilter(name: string, topicValues?: Record<string, any>, occurrence?: number): string[];
 ```
 
 **Parameters**
 
 - **`name`** — `string` (required) — the name of the event
 - **`topicValues`** — `Record<string, any>` (optional) — (optional) native values for topic-list params, keyed by param name
+- **`occurrence`** — `number` (optional) — (optional) 0-based index among same-named events, in
+         declaration order, for contracts that declare the same event name
+         more than once (defaults to the first)
 
 **Returns**
 
@@ -1207,7 +1210,7 @@ a single topic filter row
 
 **Throws**
 
-- if no event with the given name exists
+- if no event with the given name (at the given occurrence) exists
 
 **Example**
 
@@ -1215,7 +1218,7 @@ a single topic filter row
 const topics = contractSpec.eventTopicFilter('transfer', { to: someAddress });
 ```
 
-**Source:** [src/contract/spec.ts:1303](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1303)
+**Source:** [src/contract/spec.ts:1306](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1306)
 
 ### `spec.findEntry(name)`
 
@@ -1391,7 +1394,7 @@ the converted JSON schema
 
 - if the contract spec is invalid
 
-**Source:** [src/contract/spec.ts:1317](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1317)
+**Source:** [src/contract/spec.ts:1330](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1330)
 
 ### `spec.nativeToScVal(val, ty)`
 

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -1210,7 +1210,8 @@ a single topic filter row
 
 **Throws**
 
-- if no event with the given name (at the given occurrence) exists
+- if no event with the given name (at the given occurrence) exists,
+        or if `occurrence` is not a non-negative integer
 
 **Example**
 
@@ -1218,7 +1219,7 @@ a single topic filter row
 const topics = contractSpec.eventTopicFilter('transfer', { to: someAddress });
 ```
 
-**Source:** [src/contract/spec.ts:1306](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1306)
+**Source:** [src/contract/spec.ts:1307](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1307)
 
 ### `spec.findEntry(name)`
 
@@ -1394,7 +1395,7 @@ the converted JSON schema
 
 - if the contract spec is invalid
 
-**Source:** [src/contract/spec.ts:1330](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1330)
+**Source:** [src/contract/spec.ts:1331](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/spec.ts#L1331)
 
 ### `spec.nativeToScVal(val, ty)`
 

--- a/scripts/test-event-bindings.mjs
+++ b/scripts/test-event-bindings.mjs
@@ -1,0 +1,471 @@
+#!/usr/bin/env node
+/**
+ * Event-bindings test harness.
+ *
+ * Uses https://github.com/stellar-experimental/contract-wasms (real mainnet
+ * contracts) to exercise the SDK's TypeScript bindings generator, focusing on
+ * event bindings. Pipeline:
+ *
+ *   1. Scan the repo's specs/*.json (stellar-cli JSON specs — an independent
+ *      source of truth, not produced by this SDK) for contracts that declare
+ *      events. Dedupe identical specs.
+ *   2. Fetch just those .wasm blobs via git sparse-checkout.
+ *   3. Generate bindings in-process for every contract (plus a control group
+ *      of no-event contracts).
+ *   4. Structural checks: compare generated client.ts/types.ts against what
+ *      the JSON spec says must exist (parseEvent, one filter method per
+ *      event, ContractEvent union arity, per-event `name:` discriminant,
+ *      param field keys, map-format optionality).
+ *   5. Typecheck all generated output with tsc against the local SDK build.
+ *
+ * Usage:
+ *   pnpm build && node scripts/test-event-bindings.mjs [--limit N] [--no-typecheck] [--controls N]
+ *
+ * Env:
+ *   WASMS_DIR path to contract-wasms clone (default: .contract-wasms-test/,
+ *             cloned there if missing; gitignored so reruns reuse the cache)
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SDK_DIR = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const WORK_DIR = path.join(SDK_DIR, ".contract-wasms-test");
+const WASMS_DIR =
+  process.env.WASMS_DIR ?? path.join(WORK_DIR, "contract-wasms");
+const WASMS_URL = "https://github.com/stellar-experimental/contract-wasms.git";
+const OUT_DIR = path.join(WORK_DIR, "event-bindings-out");
+
+const args = process.argv.slice(2);
+const flag = (name) => args.includes(name);
+const opt = (name, dflt) => {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : dflt;
+};
+const LIMIT = Number(opt("--limit", "Infinity"));
+const CONTROLS = Number(opt("--controls", "10"));
+const TYPECHECK = !flag("--no-typecheck");
+
+// ---------------------------------------------------------------- utilities
+
+const git = (...a) =>
+  execFileSync("git", ["-C", WASMS_DIR, ...a], { encoding: "utf8" });
+
+function fail(msg) {
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+}
+
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Mirrors escapeStringLiteral in the generator only for the discriminant
+// check; the raw JSON name is what the spec guarantees.
+const escapeStr = (s) => s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+// ------------------------------------------------------- step 0: preflight
+
+if (!fs.existsSync(path.join(SDK_DIR, "lib/esm/cli/util.js"))) {
+  fail(`SDK build missing — run 'pnpm build' in ${SDK_DIR} first`);
+}
+const { createGenerator } = await import(
+  pathToFileURL(path.join(SDK_DIR, "lib/esm/cli/util.js")).href
+);
+
+fs.mkdirSync(WORK_DIR, { recursive: true });
+if (!fs.existsSync(WASMS_DIR)) {
+  console.log("Cloning contract-wasms (sparse, specs only)...");
+  execFileSync("git", [
+    "clone",
+    "--filter=blob:none",
+    "--sparse",
+    "--depth=1",
+    WASMS_URL,
+    WASMS_DIR,
+  ]);
+  git("sparse-checkout", "set", "specs");
+}
+
+// ----------------------------------------------- step 1: scan + dedupe specs
+
+console.log("Scanning specs for event definitions...");
+const specFiles = fs
+  .readdirSync(path.join(WASMS_DIR, "specs"))
+  .filter((f) => f.endsWith(".json"));
+
+/** @type {Map<string, {hash: string, events: any[], entries: any[]}>} byContentHash */
+const uniqueWithEvents = new Map();
+const noEventHashes = [];
+
+for (const file of specFiles) {
+  const raw = fs.readFileSync(path.join(WASMS_DIR, "specs", file), "utf8");
+  let entries;
+  try {
+    entries = JSON.parse(raw);
+  } catch {
+    continue; // a handful of specs fail stellar-cli parsing too; skip
+  }
+  const hash = file.replace(/\.json$/, "");
+  const events = entries
+    .filter((e) => e && typeof e === "object" && "event_v0" in e)
+    .map((e) => e.event_v0);
+  if (events.length === 0) {
+    noEventHashes.push(hash);
+    continue;
+  }
+  const contentKey = createHash("sha256").update(raw).digest("hex");
+  if (!uniqueWithEvents.has(contentKey)) {
+    uniqueWithEvents.set(contentKey, { hash, events, entries });
+  }
+}
+
+let targets = [...uniqueWithEvents.values()];
+targets.sort((a, b) => a.hash.localeCompare(b.hash));
+if (Number.isFinite(LIMIT)) targets = targets.slice(0, LIMIT);
+
+// Control group: contracts with NO events must not grow event machinery.
+const controls = noEventHashes.sort().slice(0, CONTROLS);
+
+console.log(
+  `${specFiles.length} specs scanned; ${uniqueWithEvents.size} unique event-bearing ` +
+    `specs (testing ${targets.length}); ${controls.length} no-event controls`,
+);
+
+// ---------------------------------------------------- step 2: fetch wasms
+
+console.log("Fetching wasm blobs via sparse-checkout...");
+const wanted = [...targets.map((t) => t.hash), ...controls];
+const patterns = ["/specs/", ...wanted.map((h) => `/contracts/${h}.wasm`)];
+execFileSync(
+  "git",
+  ["-C", WASMS_DIR, "sparse-checkout", "set", "--no-cone", "--stdin"],
+  { input: patterns.join("\n"), encoding: "utf8" },
+);
+const missing = wanted.filter(
+  (h) => !fs.existsSync(path.join(WASMS_DIR, "contracts", `${h}.wasm`)),
+);
+if (missing.length) {
+  console.warn(`⚠ ${missing.length} wasms missing from repo, skipping them`);
+}
+
+// ------------------------------------------- step 3 + 4: generate + verify
+
+fs.rmSync(OUT_DIR, { recursive: true, force: true });
+fs.mkdirSync(path.join(OUT_DIR, "gen"), { recursive: true });
+
+const results = {
+  generated: 0,
+  genFailed: [], // {hash, error} — unexpected
+  dupRejected: [], // {hash, error} — duplicate event names, rejected by design
+  checkFailed: [], // {hash, problems: string[]}
+  renamed: 0, // outputs where a collision rename kicked in
+  census: {
+    map: 0,
+    vec: 0,
+    singleVal: 0,
+    dataParams: 0,
+    oddNames: 0,
+    zeroParam: 0,
+  },
+};
+
+function verifyContract(hash, events, clientSrc, typesSrc) {
+  const problems = [];
+  const n = events.length;
+
+  // client.ts: parseEvent delegate present exactly when events exist
+  const parseEventDefs = clientSrc.match(/^ {2}parseEvent\w*\(topics:/gm) ?? [];
+  if (n > 0 && parseEventDefs.length !== 1) {
+    problems.push(
+      `expected 1 parseEvent method, found ${parseEventDefs.length}`,
+    );
+  }
+  if (n === 0 && parseEventDefs.length !== 0) {
+    problems.push("parseEvent generated for event-less contract");
+  }
+
+  // client.ts: one filter method per event (names may carry rename suffixes,
+  // but every filter method name contains "EventFilter")
+  const filterDefs = (
+    clientSrc.match(/^ {2}[A-Za-z_$][\w$]*\(/gm) ?? []
+  ).filter((m) => m.includes("EventFilter"));
+  if (filterDefs.length !== n) {
+    problems.push(
+      `expected ${n} *EventFilter methods, found ${filterDefs.length}`,
+    );
+  }
+
+  // types.ts: ContractEvent union arity
+  const unionMatch = typesSrc.match(/^\s*export type ContractEvent = (.+);$/m);
+  if (n > 0) {
+    if (!unionMatch) {
+      problems.push("missing ContractEvent union");
+    } else {
+      const members = unionMatch[1].split("|").length;
+      if (members !== n) {
+        problems.push(`ContractEvent has ${members} members, expected ${n}`);
+      }
+    }
+  } else if (unionMatch) {
+    problems.push("ContractEvent union generated for event-less contract");
+  }
+
+  // types.ts: per-event discriminant + param field keys + map optionality
+  for (const ev of events) {
+    const disc = `name: "${escapeStr(ev.name)}";`;
+    if (!typesSrc.includes(disc)) {
+      problems.push(`missing event interface discriminant ${disc}`);
+      continue;
+    }
+    for (const p of ev.params ?? []) {
+      const key = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(p.name)
+        ? p.name
+        : `"${escapeStr(p.name)}"`;
+      const optional = ev.data_format === "map" && p.location === "data";
+      const fieldRe = new RegExp(
+        `^\\s*${escapeRe(key)}${optional ? "\\?" : ""}: `,
+        "m",
+      );
+      if (!fieldRe.test(typesSrc)) {
+        problems.push(
+          `event "${ev.name}": missing field ${key}${optional ? "?" : ""}`,
+        );
+      }
+    }
+  }
+
+  return problems;
+}
+
+function censusUpdate(events) {
+  for (const ev of events) {
+    if (ev.data_format === "map") results.census.map += 1;
+    if (ev.data_format === "vec") results.census.vec += 1;
+    if (
+      ev.data_format === "single_value" ||
+      ev.data_format === "single-value"
+    ) {
+      results.census.singleVal += 1;
+    }
+    if ((ev.params ?? []).some((p) => p.location === "data")) {
+      results.census.dataParams += 1;
+    }
+    if ((ev.params ?? []).length === 0) results.census.zeroParam += 1;
+    if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(ev.name))
+      results.census.oddNames += 1;
+  }
+}
+
+async function runOne(hash, events) {
+  const wasmPath = path.join(WASMS_DIR, "contracts", `${hash}.wasm`);
+  if (!fs.existsSync(wasmPath)) return;
+  let bindings;
+  try {
+    const { generator } = await createGenerator({ wasm: wasmPath });
+    bindings = generator.generate({ contractName: `c${hash.slice(0, 8)}` });
+  } catch (error) {
+    const msg = String(error?.message ?? error);
+    // The generator rejects duplicate event names by design; track those
+    // separately so unexpected failures stand out.
+    if (msg.includes("duplicate event name")) {
+      results.dupRejected.push({ hash, error: msg });
+    } else {
+      results.genFailed.push({ hash, error: msg });
+    }
+    return;
+  }
+  results.generated += 1;
+  censusUpdate(events);
+
+  const dir = path.join(OUT_DIR, "gen", hash);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "client.ts"), bindings.client);
+  fs.writeFileSync(path.join(dir, "index.ts"), bindings.index);
+  if (bindings.types.trim()) {
+    fs.writeFileSync(path.join(dir, "types.ts"), bindings.types);
+  }
+
+  if (/renamed from "/.test(bindings.client + bindings.types)) {
+    results.renamed += 1;
+  }
+
+  const problems = verifyContract(
+    hash,
+    events,
+    bindings.client,
+    bindings.types,
+  );
+  if (problems.length) results.checkFailed.push({ hash, problems });
+}
+
+console.log("Generating bindings + running structural checks...");
+let done = 0;
+for (const t of targets) {
+  await runOne(t.hash, t.events);
+  done += 1;
+  if (done % 100 === 0) console.log(`  ${done}/${targets.length}`);
+}
+for (const hash of controls) {
+  await runOne(hash, []); // no events expected
+}
+
+// --------------------------------------------------- step 5: typecheck all
+
+let tscOk = null;
+if (TYPECHECK) {
+  console.log("Typechecking all generated bindings with tsc...");
+  const nm = path.join(OUT_DIR, "node_modules");
+  fs.mkdirSync(path.join(nm, "@stellar"), { recursive: true });
+  const links = [
+    ["@stellar/stellar-sdk", SDK_DIR],
+    ["buffer", path.join(SDK_DIR, "node_modules/buffer")],
+    ["@types/node", path.join(SDK_DIR, "node_modules/@types/node")],
+  ];
+  for (const [name, target] of links) {
+    const dest = path.join(nm, name);
+    if (!fs.existsSync(dest)) {
+      if (!fs.existsSync(target)) {
+        console.warn(`⚠ cannot link ${name}: ${target} missing`);
+        continue;
+      }
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.symlinkSync(fs.realpathSync(target), dest);
+    }
+  }
+  fs.writeFileSync(
+    path.join(OUT_DIR, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          noEmit: true,
+          target: "es2022",
+          module: "esnext",
+          moduleResolution: "bundler",
+          skipLibCheck: true,
+          types: ["node"],
+        },
+        include: ["gen/**/*.ts"],
+      },
+      null,
+      2,
+    ),
+  );
+  const tsc = spawnSync(
+    path.join(SDK_DIR, "node_modules/.bin/tsc"),
+    ["-p", OUT_DIR],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  tscOk = tsc.status === 0;
+  if (!tscOk) {
+    const lines = (tsc.stdout + tsc.stderr).trim().split("\n");
+    fs.writeFileSync(path.join(OUT_DIR, "tsc-errors.txt"), lines.join("\n"));
+
+    // Classify: does the error touch event machinery (types.ts event
+    // interfaces / ContractEvent union, or an EventFilter/parseEvent line in
+    // client.ts), or is it unrelated generator output (e.g. error enums)?
+    const srcCache = new Map();
+    const errLine = /^(.+\.ts)\((\d+),\d+\): error (TS\d+): (.*)$/;
+    const byCode = new Map();
+    const eventErrors = [];
+    for (const line of lines) {
+      const m = line.match(errLine);
+      if (!m) continue;
+      const [, file, lineNo, code, msg] = m;
+      byCode.set(code, (byCode.get(code) ?? 0) + 1);
+      const abs = path.join(OUT_DIR, file);
+      if (!srcCache.has(abs)) {
+        srcCache.set(
+          abs,
+          fs.existsSync(abs) ? fs.readFileSync(abs, "utf8").split("\n") : [],
+        );
+      }
+      const src = srcCache.get(abs)[Number(lineNo) - 1] ?? "";
+      if (
+        /EventFilter|parseEvent|ContractEvent/.test(src) ||
+        (file.endsWith("types.ts") &&
+          /name: "|export interface \w*Event/.test(src))
+      ) {
+        eventErrors.push(line);
+      }
+    }
+    console.log(
+      `  tsc errors: ${lines.length} lines (${eventErrors.length} touch event code)` +
+        ` — full list in ${path.join(OUT_DIR, "tsc-errors.txt")}`,
+    );
+    console.log(
+      "  by code: " + [...byCode].map(([c, n]) => `${c}×${n}`).join(" "),
+    );
+    if (eventErrors.length) {
+      console.log("  event-related errors (first 10):");
+      console.log(
+        eventErrors
+          .slice(0, 10)
+          .map((l) => `    ${l}`)
+          .join("\n"),
+      );
+      fs.writeFileSync(
+        path.join(OUT_DIR, "tsc-event-errors.txt"),
+        eventErrors.join("\n"),
+      );
+    }
+    tscOk =
+      eventErrors.length === 0
+        ? "PASS (event code); other errors exist"
+        : false;
+  }
+}
+
+// -------------------------------------------------------------- reporting
+
+console.log("\n================ RESULTS ================");
+console.log(
+  `generated OK:        ${results.generated}/${targets.length + controls.length}`,
+);
+console.log(
+  `dup-name rejects:    ${results.dupRejected.length} (rejected by design)`,
+);
+console.log(`generation failures: ${results.genFailed.length}`);
+console.log(`structural failures: ${results.checkFailed.length}`);
+console.log(
+  `typecheck:           ${
+    tscOk === null ? "skipped" : tscOk === true ? "PASS" : tscOk || "FAIL"
+  }`,
+);
+console.log(`collision renames:   ${results.renamed} contracts`);
+console.log(
+  `event census: map=${results.census.map} vec=${results.census.vec} ` +
+    `single=${results.census.singleVal} dataParams=${results.census.dataParams} ` +
+    `zeroParam=${results.census.zeroParam} nonIdentNames=${results.census.oddNames}`,
+);
+
+if (results.genFailed.length) {
+  console.log("\nGeneration failures (grouped):");
+  const groups = new Map();
+  for (const f of results.genFailed) {
+    groups.set(f.error, [...(groups.get(f.error) ?? []), f.hash]);
+  }
+  for (const [err, hashes] of groups) {
+    console.log(`  [${hashes.length}] ${err}\n    e.g. ${hashes[0]}`);
+  }
+}
+if (results.checkFailed.length) {
+  console.log("\nStructural check failures:");
+  for (const f of results.checkFailed.slice(0, 20)) {
+    console.log(`  ${f.hash}`);
+    for (const p of f.problems.slice(0, 5)) console.log(`    - ${p}`);
+  }
+  fs.writeFileSync(
+    path.join(OUT_DIR, "structural-failures.json"),
+    JSON.stringify(results.checkFailed, null, 2),
+  );
+}
+
+const ok =
+  results.genFailed.length === 0 &&
+  results.checkFailed.length === 0 &&
+  tscOk !== false;
+console.log(ok ? "\n✓ ALL CHECKS PASSED" : "\n✗ FAILURES — see above");
+process.exit(ok ? 0 : 1);

--- a/scripts/test-event-bindings.mjs
+++ b/scripts/test-event-bindings.mjs
@@ -157,8 +157,7 @@ fs.mkdirSync(path.join(OUT_DIR, "gen"), { recursive: true });
 
 const results = {
   generated: 0,
-  genFailed: [], // {hash, error} — unexpected
-  dupRejected: [], // {hash, error} — duplicate event names, rejected by design
+  genFailed: [], // {hash, error} — any generate() throw is a failure
   checkFailed: [], // {hash, problems: string[]}
   renamed: 0, // outputs where a collision rename kicked in
   census: {
@@ -186,14 +185,14 @@ function verifyContract(hash, events, clientSrc, typesSrc) {
     problems.push("parseEvent generated for event-less contract");
   }
 
-  // client.ts: one filter method per event (names may carry rename suffixes,
-  // but every filter method name contains "EventFilter")
-  const filterDefs = (
-    clientSrc.match(/^ {2}[A-Za-z_$][\w$]*\(/gm) ?? []
-  ).filter((m) => m.includes("EventFilter"));
+  // client.ts: one filter method per event. Count eventTopicFilter delegate
+  // calls rather than method names — a contract function can legitimately be
+  // named like "transferEventFilter" and would inflate a name-based count.
+  const filterDefs =
+    clientSrc.match(/return this\.spec\.eventTopicFilter\(/g) ?? [];
   if (filterDefs.length !== n) {
     problems.push(
-      `expected ${n} *EventFilter methods, found ${filterDefs.length}`,
+      `expected ${n} event filter methods, found ${filterDefs.length}`,
     );
   }
 
@@ -266,14 +265,7 @@ async function runOne(hash, events) {
     const { generator } = await createGenerator({ wasm: wasmPath });
     bindings = generator.generate({ contractName: `c${hash.slice(0, 8)}` });
   } catch (error) {
-    const msg = String(error?.message ?? error);
-    // The generator rejects duplicate event names by design; track those
-    // separately so unexpected failures stand out.
-    if (msg.includes("duplicate event name")) {
-      results.dupRejected.push({ hash, error: msg });
-    } else {
-      results.genFailed.push({ hash, error: msg });
-    }
+    results.genFailed.push({ hash, error: String(error?.message ?? error) });
     return;
   }
   results.generated += 1;
@@ -423,9 +415,6 @@ if (TYPECHECK) {
 console.log("\n================ RESULTS ================");
 console.log(
   `generated OK:        ${results.generated}/${targets.length + controls.length}`,
-);
-console.log(
-  `dup-name rejects:    ${results.dupRejected.length} (rejected by design)`,
 );
 console.log(`generation failures: ${results.genFailed.length}`);
 console.log(`structural failures: ${results.checkFailed.length}`);

--- a/src/bindings/client.ts
+++ b/src/bindings/client.ts
@@ -238,6 +238,19 @@ ${eventMethods}
   }
 
   /**
+   * The resolved (possibly disambiguated) filter method name of every event
+   * in the spec, in declaration order. Exposed so callers (e.g. the bindings
+   * generator's diagnostics) can report renames and duplicates.
+   */
+  eventFilterMethodNamesInOrder(): string[] {
+    return this.spec
+      .events()
+      .map((event, eventIndex) =>
+        this.eventFilterMethodName(event, eventIndex),
+      );
+  }
+
+  /**
    * Generate a per-event helper that builds a topics-filter row for
    * `Api.EventFilter.topics`, suitable for passing to server.getEvents.
    */

--- a/src/bindings/client.ts
+++ b/src/bindings/client.ts
@@ -16,9 +16,11 @@ import {
 export class ClientGenerator {
   private spec: Spec;
 
-  // rawEventName -> resolved (possibly disambiguated) filter method name.
+  // event index (in declaration order) -> resolved (possibly disambiguated)
+  // filter method name. Keyed by index rather than raw name because a
+  // contract may declare several events with the same name.
   // Lazily computed on first use; see resolveEventFilterMethodNames().
-  private eventFilterMethodNames: Map<string, string> | null = null;
+  private eventFilterMethodNames: Map<number, string> | null = null;
 
   constructor(spec: Spec) {
     this.spec = spec;
@@ -61,7 +63,9 @@ export class ClientGenerator {
     const eventMethods =
       events.length > 0
         ? `\n${this.generateParseEventMethod(parseEventMethodName)}\n${events
-            .map((event) => this.generateEventFilterMethod(event))
+            .map((event, eventIndex) =>
+              this.generateEventFilterMethod(event, eventIndex),
+            )
             .join("\n")}`
         : "";
 
@@ -171,17 +175,19 @@ ${eventMethods}
   /**
    * The `<camelCase>EventFilter` method name derived from an event name is
    * not injective (e.g. "FooBar" and "foo_bar" both produce
-   * "fooBarEventFilter"), and it can just as easily collide with a
-   * generated contract function name (e.g. an event "transfer" plus a
-   * function "transferEventFilter"). Since function member names are
-   * load-bearing (called directly by users) and event filter names are
-   * already synthetic, function names always win: they are reserved first,
-   * in spec-entry order. Events are then resolved in spec-entry order,
-   * appending the smallest integer 2 or greater needed to make the name unique (and
-   * reserving whatever name results, so later events see it too). This is
-   * deterministic for a given spec.
+   * "fooBarEventFilter"), a contract may declare several events with the
+   * very same name (composed modules each emitting their own "transfer"),
+   * and it can just as easily collide with a generated contract function
+   * name (e.g. an event "transfer" plus a function "transferEventFilter").
+   * Since function member names are load-bearing (called directly by
+   * users) and event filter names are already synthetic, function names
+   * always win: they are reserved first, in spec-entry order. Events are
+   * then resolved in spec-entry order, appending the smallest integer 2 or
+   * greater needed to make the name unique (and reserving whatever name
+   * results, so later events see it too). This is deterministic for a
+   * given spec.
    */
-  private resolveEventFilterMethodNames(): Map<string, string> {
+  private resolveEventFilterMethodNames(): Map<number, string> {
     if (this.eventFilterMethodNames !== null) {
       return this.eventFilterMethodNames;
     }
@@ -195,16 +201,10 @@ ${eventMethods}
         reserved.add(sanitizeIdentifier(func.name().toString()));
       });
 
-    const resolved = new Map<string, string>();
+    const resolved = new Map<number, string>();
 
-    this.spec.events().forEach((event) => {
-      const rawName = event.name().toString();
-      if (resolved.has(rawName)) {
-        throw new Error(
-          `cannot generate bindings for duplicate event name: ${rawName}`,
-        );
-      }
-      const preferred = `${toCamelCase(sanitizeIdentifier(rawName))}EventFilter`;
+    this.spec.events().forEach((event, eventIndex) => {
+      const preferred = `${toCamelCase(sanitizeIdentifier(event.name().toString()))}EventFilter`;
 
       let candidate = preferred;
       let suffix = 2;
@@ -214,7 +214,7 @@ ${eventMethods}
       }
 
       reserved.add(candidate);
-      resolved.set(rawName, candidate);
+      resolved.set(eventIndex, candidate);
     });
 
     this.eventFilterMethodNames = resolved;
@@ -225,12 +225,14 @@ ${eventMethods}
    * Compute the resolved (possibly disambiguated) filter method name for an
    * event; see {@link resolveEventFilterMethodNames}.
    */
-  private eventFilterMethodName(event: xdr.ScSpecEventV0): string {
-    const rawName = event.name().toString();
-    const resolved = this.resolveEventFilterMethodNames().get(rawName);
+  private eventFilterMethodName(
+    event: xdr.ScSpecEventV0,
+    eventIndex: number,
+  ): string {
+    const resolved = this.resolveEventFilterMethodNames().get(eventIndex);
     /* istanbul ignore next -- every event in the spec is reserved a name */
     if (resolved === undefined) {
-      return `${toCamelCase(sanitizeIdentifier(rawName))}EventFilter`;
+      return `${toCamelCase(sanitizeIdentifier(event.name().toString()))}EventFilter`;
     }
     return resolved;
   }
@@ -239,10 +241,23 @@ ${eventMethods}
    * Generate a per-event helper that builds a topics-filter row for
    * `Api.EventFilter.topics`, suitable for passing to server.getEvents.
    */
-  private generateEventFilterMethod(event: xdr.ScSpecEventV0): string {
+  private generateEventFilterMethod(
+    event: xdr.ScSpecEventV0,
+    eventIndex: number,
+  ): string {
     const rawName = event.name().toString();
-    const methodName = this.eventFilterMethodName(event);
+    const methodName = this.eventFilterMethodName(event, eventIndex);
     const preferredMethodName = `${toCamelCase(sanitizeIdentifier(rawName))}EventFilter`;
+    // Which same-named event this is (0-based, declaration order) — needed
+    // so eventTopicFilter targets the right spec when names are duplicated.
+    const occurrence = this.spec
+      .events()
+      .slice(0, eventIndex)
+      .filter((e) => e.name().toString() === rawName).length;
+    const occurrenceNote =
+      occurrence > 0
+        ? ` This targets declaration ${occurrence + 1} of the "${rawName}" event in the contract spec.`
+        : "";
     const renameNote =
       methodName !== preferredMethodName
         ? ` Note: renamed from "${preferredMethodName}" to avoid a collision with another generated name.`
@@ -273,20 +288,21 @@ ${eventMethods}
     const doc = formatJSDocComment(
       `Build a topics filter row for the "${rawName}" event, for use in ` +
         `\`Api.EventFilter.topics\` when calling \`server.getEvents\`. ` +
-        `Omitted fields match any value.${renameNote}`,
+        `Omitted fields match any value.${occurrenceNote}${renameNote}`,
       2,
     );
 
     const escapedName = escapeStringLiteral(rawName);
+    const occurrenceArg = occurrence > 0 ? `, ${occurrence}` : "";
 
     if (topicParams.length === 0) {
       return `${doc}  ${methodName}(): string[] {
-    return this.spec.eventTopicFilter("${escapedName}");
+    return this.spec.eventTopicFilter("${escapedName}"${occurrence > 0 ? `, undefined${occurrenceArg}` : ""});
   }`;
     }
 
     return `${doc}  ${methodName}(topicValues?: { ${fields} }): string[] {
-    return this.spec.eventTopicFilter("${escapedName}", topicValues);
+    return this.spec.eventTopicFilter("${escapedName}", topicValues${occurrenceArg});
   }`;
   }
 

--- a/src/bindings/generator.ts
+++ b/src/bindings/generator.ts
@@ -36,8 +36,10 @@ export type EventDiagnostic = {
   interfaceName: string;
   /** The filter method name generated on the Client class */
   filterMethodName: string;
-  /** True if either generated name differs from its preferred form */
-  renamed: boolean;
+  /** True if the interface name differs from its preferred form */
+  interfaceRenamed: boolean;
+  /** True if the filter method name differs from its preferred form */
+  filterMethodRenamed: boolean;
 };
 
 /**
@@ -310,12 +312,13 @@ export class BindingGenerator {
 
       const declarations = declarationCounts.get(rawName)!;
       const sanitized = sanitizeIdentifier(rawName);
-      const renamed =
-        interfaceNames[eventIndex] !== `${toPascalCase(sanitized)}Event` ||
+      const interfaceRenamed =
+        interfaceNames[eventIndex] !== `${toPascalCase(sanitized)}Event`;
+      const filterMethodRenamed =
         filterMethodNames[eventIndex] !==
-          `${toCamelCase(sanitized)}EventFilter`;
+        `${toCamelCase(sanitized)}EventFilter`;
 
-      if (declarations <= 1 && !renamed) {
+      if (declarations <= 1 && !interfaceRenamed && !filterMethodRenamed) {
         return [];
       }
       return [
@@ -325,7 +328,8 @@ export class BindingGenerator {
           declarations,
           interfaceName: interfaceNames[eventIndex],
           filterMethodName: filterMethodNames[eventIndex],
-          renamed,
+          interfaceRenamed,
+          filterMethodRenamed,
         },
       ];
     });

--- a/src/bindings/generator.ts
+++ b/src/bindings/generator.ts
@@ -1,5 +1,6 @@
 import { Spec } from "../contract/index.js";
 import { ConfigGenerator } from "./config.js";
+import { sanitizeIdentifier, toCamelCase, toPascalCase } from "./utils.js";
 import { TypeGenerator } from "./types.js";
 import { ClientGenerator } from "./client.js";
 import { specFromWasm } from "../contract/wasm_spec_parser.js";
@@ -16,6 +17,27 @@ export type GenerateOptions = {
    * Should be in kebab-case (e.g., "my-contract").
    */
   contractName: string;
+};
+
+/**
+ * A note about an event whose generated names need the user's attention:
+ * either the contract declares the same event name more than once, or the
+ * generated names were renamed away from their preferred form to avoid a
+ * collision with another generated name.
+ */
+export type EventDiagnostic = {
+  /** The event name exactly as declared in the contract spec */
+  rawName: string;
+  /** 0-based index of this declaration among same-named events */
+  occurrence: number;
+  /** Total number of declarations of this raw name in the spec */
+  declarations: number;
+  /** The exported interface name generated in types.ts */
+  interfaceName: string;
+  /** The filter method name generated on the Client class */
+  filterMethodName: string;
+  /** True if either generated name differs from its preferred form */
+  renamed: boolean;
 };
 
 /**
@@ -39,6 +61,11 @@ export type GeneratedBindings = {
   readme: string;
   /** The .gitignore file for the generated package */
   gitignore: string;
+  /**
+   * Notes about events whose generated names need attention (duplicate
+   * declarations or collision-driven renames); empty when there are none
+   */
+  diagnostics: EventDiagnostic[];
 };
 
 /**
@@ -231,6 +258,7 @@ export class BindingGenerator {
 
     const types = typeGenerator.generate();
     const client = clientGenerator.generate();
+    const diagnostics = this.eventDiagnostics(typeGenerator, clientGenerator);
 
     let index = `export { Client } from "./client.js";`;
     if (types.trim() !== "") {
@@ -250,7 +278,57 @@ export class BindingGenerator {
       tsConfig,
       readme,
       gitignore,
+      diagnostics,
     };
+  }
+
+  /**
+   * Collect an {@link EventDiagnostic} for every event that a user should
+   * review in the generated output: duplicate declarations of the same raw
+   * name, and generated names renamed away from their preferred form to
+   * avoid a collision.
+   */
+  private eventDiagnostics(
+    typeGenerator: TypeGenerator,
+    clientGenerator: ClientGenerator,
+  ): EventDiagnostic[] {
+    const events = this.spec.events();
+    const interfaceNames = typeGenerator.eventInterfaceNamesInOrder();
+    const filterMethodNames = clientGenerator.eventFilterMethodNamesInOrder();
+
+    const declarationCounts = new Map<string, number>();
+    events.forEach((event) => {
+      const rawName = event.name().toString();
+      declarationCounts.set(rawName, (declarationCounts.get(rawName) ?? 0) + 1);
+    });
+
+    const occurrenceSoFar = new Map<string, number>();
+    return events.flatMap((event, eventIndex) => {
+      const rawName = event.name().toString();
+      const occurrence = occurrenceSoFar.get(rawName) ?? 0;
+      occurrenceSoFar.set(rawName, occurrence + 1);
+
+      const declarations = declarationCounts.get(rawName)!;
+      const sanitized = sanitizeIdentifier(rawName);
+      const renamed =
+        interfaceNames[eventIndex] !== `${toPascalCase(sanitized)}Event` ||
+        filterMethodNames[eventIndex] !==
+          `${toCamelCase(sanitized)}EventFilter`;
+
+      if (declarations <= 1 && !renamed) {
+        return [];
+      }
+      return [
+        {
+          rawName,
+          occurrence,
+          declarations,
+          interfaceName: interfaceNames[eventIndex],
+          filterMethodName: filterMethodNames[eventIndex],
+          renamed,
+        },
+      ];
+    });
   }
 
   /**

--- a/src/bindings/types.ts
+++ b/src/bindings/types.ts
@@ -305,6 +305,17 @@ ${members}
   }
 
   /**
+   * The resolved (possibly disambiguated) interface name of every event in
+   * the spec, in declaration order. Exposed so callers (e.g. the bindings
+   * generator's diagnostics) can report renames and duplicates.
+   */
+  eventInterfaceNamesInOrder(): string[] {
+    return this.spec
+      .events()
+      .map((event, eventIndex) => this.eventInterfaceName(event, eventIndex));
+  }
+
+  /**
    * True if the given event's resolved interface name differs from its
    * preferred (unsuffixed) form, i.e. it was disambiguated away from a
    * collision.

--- a/src/bindings/types.ts
+++ b/src/bindings/types.ts
@@ -44,9 +44,11 @@ export interface EnumCase {
 export class TypeGenerator {
   private spec: Spec;
 
-  // rawEventName -> resolved (possibly disambiguated) interface name.
+  // event index (in event-entry declaration order) -> resolved (possibly
+  // disambiguated) interface name. Keyed by index rather than raw name
+  // because a contract may declare several events with the same name.
   // Lazily computed on first use; see resolveEventInterfaceNames().
-  private eventInterfaceNames: Map<string, string> | null = null;
+  private eventInterfaceNames: Map<number, string> | null = null;
 
   constructor(spec: Spec) {
     this.spec = spec;
@@ -56,9 +58,15 @@ export class TypeGenerator {
    * Generate all TypeScript type definitions
    */
   generate(): string {
-    // Generate types for each entry in the spec
+    // Generate types for each entry in the spec. Events are numbered in
+    // declaration order so same-named events resolve to distinct interfaces.
+    let eventIndex = 0;
     const types = this.spec.entries
-      .map((entry) => this.generateEntry(entry))
+      .map((entry) =>
+        entry.switch() === xdr.ScSpecEntryKind.scSpecEntryEventV0()
+          ? this.generateEvent(entry.eventV0(), eventIndex++)
+          : this.generateEntry(entry),
+      )
       .filter((t) => t)
       .join("\n\n");
     // Generate imports for all types
@@ -89,8 +97,8 @@ export class TypeGenerator {
         return this.generateEnum(entry.udtEnumV0());
       case xdr.ScSpecEntryKind.scSpecEntryUdtErrorEnumV0():
         return this.generateErrorEnum(entry.udtErrorEnumV0());
-      case xdr.ScSpecEntryKind.scSpecEntryEventV0():
-        return this.generateEvent(entry.eventV0());
+      // Events are handled directly in generate(), which numbers them in
+      // declaration order.
       default:
         return null;
     }
@@ -284,12 +292,14 @@ ${members}
    * becomes "TransferEvent". Resolved (and disambiguated if necessary) via
    * {@link resolveEventInterfaceNames}, so every call site agrees.
    */
-  private eventInterfaceName(event: xdr.ScSpecEventV0): string {
-    const rawName = event.name().toString();
-    const resolved = this.resolveEventInterfaceNames().get(rawName);
+  private eventInterfaceName(
+    event: xdr.ScSpecEventV0,
+    eventIndex: number,
+  ): string {
+    const resolved = this.resolveEventInterfaceNames().get(eventIndex);
     /* istanbul ignore next -- every event in the spec is reserved a name */
     if (resolved === undefined) {
-      return `${toPascalCase(sanitizeIdentifier(rawName))}Event`;
+      return `${toPascalCase(sanitizeIdentifier(event.name().toString()))}Event`;
     }
     return resolved;
   }
@@ -299,25 +309,29 @@ ${members}
    * preferred (unsuffixed) form, i.e. it was disambiguated away from a
    * collision.
    */
-  private eventInterfaceNameWasRenamed(event: xdr.ScSpecEventV0): boolean {
-    const rawName = event.name().toString();
-    const preferred = `${toPascalCase(sanitizeIdentifier(rawName))}Event`;
-    return this.eventInterfaceName(event) !== preferred;
+  private eventInterfaceNameWasRenamed(
+    event: xdr.ScSpecEventV0,
+    eventIndex: number,
+  ): boolean {
+    const preferred = `${toPascalCase(sanitizeIdentifier(event.name().toString()))}Event`;
+    return this.eventInterfaceName(event, eventIndex) !== preferred;
   }
 
   /**
    * The name-normalization used for event interface names (and UDT type
    * names) is not injective — e.g. events "FooBar" and "foo_bar" both
-   * produce the interface name "FooBarEvent", and an event can just as
-   * easily collide with a UDT (struct/union/enum) of the same generated
-   * name. Since UDT/function names are load-bearing (referenced directly in
-   * signatures) and event-derived names are already synthetic, UDT names
-   * always win: they are reserved first, in spec-entry order. Events are
-   * then resolved in spec-entry order, appending the smallest integer 2 or greater
-   * needed to make the name unique (and reserving whatever name results, so
-   * later events see it too). This is deterministic for a given spec.
+   * produce the interface name "FooBarEvent", a contract may declare
+   * several events with the very same name (composed modules each emitting
+   * their own "transfer"), and an event can just as easily collide with a
+   * UDT (struct/union/enum) of the same generated name. Since UDT/function
+   * names are load-bearing (referenced directly in signatures) and
+   * event-derived names are already synthetic, UDT names always win: they
+   * are reserved first, in spec-entry order. Events are then resolved in
+   * spec-entry order, appending the smallest integer 2 or greater needed to
+   * make the name unique (and reserving whatever name results, so later
+   * events see it too). This is deterministic for a given spec.
    */
-  private resolveEventInterfaceNames(): Map<string, string> {
+  private resolveEventInterfaceNames(): Map<number, string> {
     if (this.eventInterfaceNames !== null) {
       return this.eventInterfaceNames;
     }
@@ -349,20 +363,15 @@ ${members}
       }
     }
 
-    const resolved = new Map<string, string>();
+    const resolved = new Map<number, string>();
 
+    let eventIndex = 0;
     for (const entry of this.spec.entries) {
       if (entry.switch() !== xdr.ScSpecEntryKind.scSpecEntryEventV0()) {
         continue;
       }
       const event = entry.eventV0();
-      const rawName = event.name().toString();
-      if (resolved.has(rawName)) {
-        throw new Error(
-          `cannot generate bindings for duplicate event name: ${rawName}`,
-        );
-      }
-      const preferred = `${toPascalCase(sanitizeIdentifier(rawName))}Event`;
+      const preferred = `${toPascalCase(sanitizeIdentifier(event.name().toString()))}Event`;
 
       let candidate = preferred;
       let suffix = 2;
@@ -372,7 +381,8 @@ ${members}
       }
 
       reserved.add(candidate);
-      resolved.set(rawName, candidate);
+      resolved.set(eventIndex, candidate);
+      eventIndex += 1;
     }
 
     this.eventInterfaceNames = resolved;
@@ -382,11 +392,11 @@ ${members}
   /**
    * Generate TypeScript interface for a Soroban contract event
    */
-  private generateEvent(event: xdr.ScSpecEventV0): string {
+  private generateEvent(event: xdr.ScSpecEventV0, eventIndex: number): string {
     const rawName = event.name().toString();
-    const name = this.eventInterfaceName(event);
+    const name = this.eventInterfaceName(event, eventIndex);
     const preferred = `${toPascalCase(sanitizeIdentifier(rawName))}Event`;
-    const renameNote = this.eventInterfaceNameWasRenamed(event)
+    const renameNote = this.eventInterfaceNameWasRenamed(event, eventIndex)
       ? `\n\nNote: renamed from "${preferred}" to avoid a collision with another generated name.`
       : "";
     const doc = formatJSDocComment(
@@ -444,8 +454,8 @@ ${dataFields}
       return "";
     }
 
-    const names = eventEntries.map((entry) =>
-      this.eventInterfaceName(entry.eventV0()),
+    const names = eventEntries.map((entry, eventIndex) =>
+      this.eventInterfaceName(entry.eventV0(), eventIndex),
     );
 
     return `export type ContractEvent = ${names.join(" | ")};`;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -154,11 +154,29 @@ function runCli() {
           `\n✓ Generating TypeScript bindings for "${contractName}"...`,
         );
 
-        await generateAndWrite(generator, {
+        const bindings = await generateAndWrite(generator, {
           contractName,
           outputDir: path.resolve(options.outputDir),
           overwrite: options.overwrite,
         });
+
+        for (const d of bindings.diagnostics) {
+          if (d.declarations > 1) {
+            console.warn(
+              `\n⚠ Event "${d.rawName}" is declared ${d.declarations} times; ` +
+                `declaration ${d.occurrence + 1} generated as ` +
+                `${d.interfaceName} with filter ${d.filterMethodName}(). ` +
+                `Review the generated bindings to confirm which declaration ` +
+                `you need.`,
+            );
+          } else {
+            console.warn(
+              `\n⚠ Event "${d.rawName}": generated names ${d.interfaceName} ` +
+                `and ${d.filterMethodName}() were renamed to avoid a ` +
+                `collision with another generated name.`,
+            );
+          }
+        }
 
         console.log(
           `\n✓ Successfully generated bindings in ${options.outputDir}`,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -170,9 +170,14 @@ function runCli() {
                 `you need.`,
             );
           } else {
+            const renamed = [
+              ...(d.interfaceRenamed ? [d.interfaceName] : []),
+              ...(d.filterMethodRenamed ? [`${d.filterMethodName}()`] : []),
+            ];
             console.warn(
-              `\n⚠ Event "${d.rawName}": generated names ${d.interfaceName} ` +
-                `and ${d.filterMethodName}() were renamed to avoid a ` +
+              `\n⚠ Event "${d.rawName}": generated name` +
+                `${renamed.length > 1 ? "s" : ""} ${renamed.join(" and ")} ` +
+                `${renamed.length > 1 ? "were" : "was"} renamed to avoid a ` +
                 `collision with another generated name.`,
             );
           }

--- a/src/cli/util.ts
+++ b/src/cli/util.ts
@@ -177,10 +177,11 @@ export async function writeBindings(
 export async function generateAndWrite(
   generator: BindingGenerator,
   options: GenerateAndWriteOptions,
-): Promise<void> {
+): Promise<GeneratedBindings> {
   const { outputDir, overwrite = false, ...genOptions } = options;
   const bindings = generator.generate(genOptions);
   await writeBindings(outputDir, bindings, overwrite);
+  return bindings;
 }
 
 /**

--- a/src/contract/event_spec.ts
+++ b/src/contract/event_spec.ts
@@ -38,18 +38,25 @@ export function events(entries: xdr.ScSpecEntry[]): xdr.ScSpecEventV0[] {
 
 /**
  * Finds the event spec with the given name among a contract's event entries.
+ * A contract may declare several events with the same name (e.g. composed
+ * modules each emitting their own `transfer`); `occurrence` selects among
+ * them, in declaration order.
  *
  * @param entries - the contract's XDR spec entries
  * @param name - the name of the event to find
+ * @param occurrence - 0-based index among the events with that name
  * @returns the event spec, or `undefined` if the contract declares no event
- *          with that name
+ *          with that name (at that occurrence)
  * @hidden
  */
 export function findEvent(
   entries: xdr.ScSpecEntry[],
   name: string,
+  occurrence: number = 0,
 ): xdr.ScSpecEventV0 | undefined {
-  return events(entries).find((e) => e.name().toString() === name);
+  return events(entries).filter((e) => e.name().toString() === name)[
+    occurrence
+  ];
 }
 
 /**
@@ -250,8 +257,10 @@ export function parseEvent(
  * @param entries - the contract's XDR spec entries
  * @param name - the name of the event
  * @param topicValues - (optional) native values for topic-list params, keyed by param name
+ * @param occurrence - (optional) 0-based index among same-named events, for
+ *        contracts that declare the same event name more than once
  * @returns a single topic filter row
- * @throws if no event with the given name exists
+ * @throws if no event with the given name (at the given occurrence) exists
  * @hidden
  */
 export function eventTopicFilter(
@@ -259,10 +268,15 @@ export function eventTopicFilter(
   entries: xdr.ScSpecEntry[],
   name: string,
   topicValues?: Record<string, any>,
+  occurrence: number = 0,
 ): string[] {
-  const event = findEvent(entries, name);
+  const event = findEvent(entries, name, occurrence);
   if (!event) {
-    throw new Error(`no such event: ${name}`);
+    throw new Error(
+      occurrence > 0
+        ? `no such event: ${name} (occurrence ${occurrence})`
+        : `no such event: ${name}`,
+    );
   }
   const filter: string[] = event
     .prefixTopics()

--- a/src/contract/event_spec.ts
+++ b/src/contract/event_spec.ts
@@ -47,6 +47,7 @@ export function events(entries: xdr.ScSpecEntry[]): xdr.ScSpecEventV0[] {
  * @param occurrence - 0-based index among the events with that name
  * @returns the event spec, or `undefined` if the contract declares no event
  *          with that name (at that occurrence)
+ * @throws if `occurrence` is not a non-negative integer
  * @hidden
  */
 export function findEvent(
@@ -54,6 +55,11 @@ export function findEvent(
   name: string,
   occurrence: number = 0,
 ): xdr.ScSpecEventV0 | undefined {
+  if (!Number.isInteger(occurrence) || occurrence < 0) {
+    throw new Error(
+      `invalid occurrence for event ${name}: ${occurrence} (expected a non-negative integer)`,
+    );
+  }
   return events(entries).filter((e) => e.name().toString() === name)[
     occurrence
   ];
@@ -260,7 +266,8 @@ export function parseEvent(
  * @param occurrence - (optional) 0-based index among same-named events, for
  *        contracts that declare the same event name more than once
  * @returns a single topic filter row
- * @throws if no event with the given name (at the given occurrence) exists
+ * @throws if no event with the given name (at the given occurrence) exists,
+ *         or if `occurrence` is not a non-negative integer
  * @hidden
  */
 export function eventTopicFilter(

--- a/src/contract/spec.ts
+++ b/src/contract/spec.ts
@@ -1291,17 +1291,30 @@ export class Spec {
    *
    * @param name - the name of the event
    * @param topicValues - (optional) native values for topic-list params, keyed by param name
+   * @param occurrence - (optional) 0-based index among same-named events, in
+   *        declaration order, for contracts that declare the same event name
+   *        more than once (defaults to the first)
    * @returns a single topic filter row
    *
-   * @throws if no event with the given name exists
+   * @throws if no event with the given name (at the given occurrence) exists
    *
    * @example
    * ```ts
    * const topics = contractSpec.eventTopicFilter('transfer', { to: someAddress });
    * ```
    */
-  eventTopicFilter(name: string, topicValues?: Record<string, any>): string[] {
-    return eventTopicFilterImpl(this, this.entries, name, topicValues);
+  eventTopicFilter(
+    name: string,
+    topicValues?: Record<string, any>,
+    occurrence?: number,
+  ): string[] {
+    return eventTopicFilterImpl(
+      this,
+      this.entries,
+      name,
+      topicValues,
+      occurrence,
+    );
   }
 
   /**

--- a/src/contract/spec.ts
+++ b/src/contract/spec.ts
@@ -1296,7 +1296,8 @@ export class Spec {
    *        more than once (defaults to the first)
    * @returns a single topic filter row
    *
-   * @throws if no event with the given name (at the given occurrence) exists
+   * @throws if no event with the given name (at the given occurrence) exists,
+   *         or if `occurrence` is not a non-negative integer
    *
    * @example
    * ```ts

--- a/test/unit/bindings/collisions.test.ts
+++ b/test/unit/bindings/collisions.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { xdr, contract } from "../../../src/index.js";
 import { TypeGenerator } from "../../../src/bindings/types.js";
 import { ClientGenerator } from "../../../src/bindings/client.js";
+import { BindingGenerator } from "../../../src/bindings/generator.js";
 
 const { Spec } = contract;
 
@@ -206,6 +207,59 @@ describe("bindings generated-name collision resolution", () => {
     expect(clientOutput).toMatch(/transferEventFilter\(/);
     expect(clientOutput).toMatch(/mintEventFilter\(/);
     expect(clientOutput).not.toMatch(/renamed from/);
+  });
+
+  it("reports diagnostics for duplicate event names and collision renames", () => {
+    const spec = new Spec([
+      eventEntry("transfer", ["first"]),
+      eventEntry("transfer", ["second"]),
+      eventEntry("FooBar", ["FooBar"]),
+      eventEntry("foo_bar", ["foo_bar"]),
+      eventEntry("mint", ["mint"]),
+    ]);
+
+    const { diagnostics } = BindingGenerator.fromSpec(spec).generate({
+      contractName: "test-contract",
+    });
+
+    expect(diagnostics).toEqual([
+      {
+        rawName: "transfer",
+        occurrence: 0,
+        declarations: 2,
+        interfaceName: "TransferEvent",
+        filterMethodName: "transferEventFilter",
+        renamed: false,
+      },
+      {
+        rawName: "transfer",
+        occurrence: 1,
+        declarations: 2,
+        interfaceName: "TransferEvent2",
+        filterMethodName: "transferEventFilter2",
+        renamed: true,
+      },
+      {
+        rawName: "foo_bar",
+        occurrence: 0,
+        declarations: 1,
+        interfaceName: "FooBarEvent2",
+        filterMethodName: "fooBarEventFilter2",
+        renamed: true,
+      },
+    ]);
+  });
+
+  it("reports no diagnostics when event names are unique and unrenamed", () => {
+    const spec = new Spec([
+      eventEntry("transfer", ["transfer"]),
+      eventEntry("mint", ["mint"]),
+    ]);
+
+    const { diagnostics } = BindingGenerator.fromSpec(spec).generate({
+      contractName: "test-contract",
+    });
+    expect(diagnostics).toEqual([]);
   });
 
   it("produces byte-identical output across repeated generation from the same spec", () => {

--- a/test/unit/bindings/collisions.test.ts
+++ b/test/unit/bindings/collisions.test.ts
@@ -235,7 +235,8 @@ describe("bindings generated-name collision resolution", () => {
         declarations: 2,
         interfaceName: "TransferEvent",
         filterMethodName: "transferEventFilter",
-        renamed: false,
+        interfaceRenamed: false,
+        filterMethodRenamed: false,
       },
       {
         rawName: "transfer",
@@ -243,7 +244,8 @@ describe("bindings generated-name collision resolution", () => {
         declarations: 2,
         interfaceName: "TransferEvent2",
         filterMethodName: "transferEventFilter2",
-        renamed: true,
+        interfaceRenamed: true,
+        filterMethodRenamed: true,
       },
       {
         rawName: "foo_bar",
@@ -251,7 +253,32 @@ describe("bindings generated-name collision resolution", () => {
         declarations: 1,
         interfaceName: "FooBarEvent2",
         filterMethodName: "fooBarEventFilter2",
-        renamed: true,
+        interfaceRenamed: true,
+        filterMethodRenamed: true,
+      },
+    ]);
+  });
+
+  it("tracks interface and filter renames independently in diagnostics", () => {
+    const spec = new Spec([
+      structEntry("TransferEvent"),
+      eventEntry("transfer", ["transfer"]),
+    ]);
+
+    const { diagnostics } = BindingGenerator.fromSpec(spec).generate({
+      contractName: "test-contract",
+    });
+    // The UDT collision renames only the interface; the filter method keeps
+    // its preferred name.
+    expect(diagnostics).toEqual([
+      {
+        rawName: "transfer",
+        occurrence: 0,
+        declarations: 1,
+        interfaceName: "TransferEvent2",
+        filterMethodName: "transferEventFilter",
+        interfaceRenamed: true,
+        filterMethodRenamed: false,
       },
     ]);
   });

--- a/test/unit/bindings/collisions.test.ts
+++ b/test/unit/bindings/collisions.test.ts
@@ -101,17 +101,46 @@ describe("bindings generated-name collision resolution", () => {
     expect(output).toMatch(/renamed from "FooBarEvent" to avoid a collision/);
   });
 
-  it("rejects duplicate raw event names instead of generating duplicate members", () => {
+  it("disambiguates duplicate raw event names, keeping the raw name as discriminant", () => {
     const spec = new Spec([
       eventEntry("transfer", ["first"]),
       eventEntry("transfer", ["second"]),
     ]);
 
-    expect(() => new TypeGenerator(spec).generate()).toThrow(
-      "cannot generate bindings for duplicate event name: transfer",
+    const typesOutput = new TypeGenerator(spec).generate();
+    expect(typesOutput).toMatch(/export interface TransferEvent \{/);
+    expect(typesOutput).toMatch(/export interface TransferEvent2 \{/);
+    // Both interfaces keep the raw event name as their discriminant.
+    const discriminants = typesOutput.match(/name: "transfer";/g) ?? [];
+    expect(discriminants.length).toBe(2);
+    expect(typesOutput).toMatch(
+      /export type ContractEvent = TransferEvent \| TransferEvent2;/,
     );
-    expect(() => new ClientGenerator(spec).generate()).toThrow(
-      "cannot generate bindings for duplicate event name: transfer",
+
+    const clientOutput = new ClientGenerator(spec).generate();
+    expect(clientOutput).toMatch(/transferEventFilter\(/);
+    expect(clientOutput).toMatch(/transferEventFilter2\(/);
+    // The first filter targets the first declaration (no occurrence arg);
+    // the second passes its occurrence so it targets the right spec.
+    expect(clientOutput).toMatch(/eventTopicFilter\("transfer", topicValues\)/);
+    expect(clientOutput).toMatch(
+      /eventTopicFilter\("transfer", topicValues, 1\)/,
+    );
+    expect(clientOutput).toMatch(/targets declaration 2 of the "transfer"/i);
+  });
+
+  it("builds occurrence-specific topic filters for duplicate event names at runtime", () => {
+    const spec = new Spec([
+      eventEntry("transfer", ["first"]),
+      eventEntry("transfer", ["second"]),
+    ]);
+
+    const first = spec.eventTopicFilter("transfer");
+    const second = spec.eventTopicFilter("transfer", undefined, 1);
+    expect(first[0]).toBe(xdr.ScVal.scvSymbol("first").toXDR("base64"));
+    expect(second[0]).toBe(xdr.ScVal.scvSymbol("second").toXDR("base64"));
+    expect(() => spec.eventTopicFilter("transfer", undefined, 2)).toThrow(
+      "no such event: transfer (occurrence 2)",
     );
   });
 

--- a/test/unit/bindings/collisions.test.ts
+++ b/test/unit/bindings/collisions.test.ts
@@ -143,6 +143,12 @@ describe("bindings generated-name collision resolution", () => {
     expect(() => spec.eventTopicFilter("transfer", undefined, 2)).toThrow(
       "no such event: transfer (occurrence 2)",
     );
+    expect(() => spec.eventTopicFilter("transfer", undefined, -1)).toThrow(
+      "invalid occurrence for event transfer: -1",
+    );
+    expect(() => spec.eventTopicFilter("transfer", undefined, 0.5)).toThrow(
+      "invalid occurrence for event transfer: 0.5",
+    );
   });
 
   it("disambiguates an event filter method that collides with a contract function member name, keeping the function's name", () => {


### PR DESCRIPTION
## What

Contracts can declare the same event name more than once (composed modules each emitting their own `transfer`). The bindings generator used to reject these specs with a hard error; on mainnet that left 87 of 593 event-bearing contracts (15%) with no bindings at all.

Now the generator handles them:

- Same-named events get distinct generated names (`TransferEvent` / `TransferEvent2`, `transferEventFilter()` / `transferEventFilter2()`), reusing the existing collision-rename machinery. Both interfaces keep the raw name as their discriminant.
- `Spec.eventTopicFilter` takes an optional `occurrence` argument, and each generated filter method passes its own, so every filter targets the right declaration.
- `generate()` returns a `diagnostics` array describing duplicates and renames, and the CLI prints a warning for each so users know to review the generated bindings.
- Adds the mainnet corpus harness (`scripts/test-event-bindings.mjs`) used to find and verify this.

## Why

Renaming alone was not enough: runtime lookups were by name and always resolved to the first declaration, so a renamed filter method would silently build a filter against the wrong event spec. Occurrence-based targeting closes that gap, and the diagnostics make the renames visible at generation time instead of only in JSDoc notes inside the generated code.