### PR TITLE
fix(xdr): bound decimal string length before BigInt parse in JSON decode

### DIFF
--- a/src/xdr/values/bigint-parts.ts
+++ b/src/xdr/values/bigint-parts.ts
@@ -12,6 +12,15 @@
 import { XdrError } from "@stellar/js-xdr";
 
 const MASK_64 = (1n << 64n) - 1n;
+
+// log10(2): decimal digits per bit, so a `bits`-wide integer has at most
+// `ceil(bits * LOG10_OF_2)` decimal digits.
+const LOG10_OF_2 = 0.30103;
+
+// Slack on the digit budget: one character for an optional leading `-` sign,
+// plus one digit of rounding headroom.
+const DIGIT_BUDGET_SLACK = 2;
+
 const MASK_HI_SIGNED_128 = 1n << 127n;
 const MASK_HI_SIGNED_256 = 1n << 255n;
 
@@ -61,10 +70,10 @@ export function assertBigIntFits(
  * the length first makes that rejection O(1) and keeps the huge value out of
  * the range error message.
  *
- * Budget formula: a `bits`-wide integer has at most `ceil(bits * log10(2))`
- * decimal digits (log10(2) ≈ 0.30103) — e.g. 20 digits for a 64-bit value.
- * The `+ 2` is slack: one character for an optional leading `-` sign, plus
- * one digit of rounding headroom, giving 22 for 64 bits. Any longer string
+ * Budget formula: a `bits`-wide integer has at most
+ * `ceil(bits * LOG10_OF_2)` decimal digits — e.g. 20 digits for a 64-bit
+ * value. `DIGIT_BUDGET_SLACK` adds room for an optional leading `-` sign plus
+ * a digit of rounding headroom, giving 22 for 64 bits. Any longer string
  * cannot possibly denote an in-range value, so no legitimate input is
  * affected. It does, however, reject padding that `BigInt()` itself would
  * tolerate (long runs of leading zeros, `+`, surrounding whitespace) once the
@@ -76,7 +85,7 @@ export function assertDecimalDigitBudget(
   bits: number,
   name: string,
 ): void {
-  const maxDigits = Math.ceil(bits * 0.30103) + 2;
+  const maxDigits = Math.ceil(bits * LOG10_OF_2) + DIGIT_BUDGET_SLACK;
   if (s.length > maxDigits) {
     throw new XdrError(
       `${name}: decimal string length ${s.length} exceeds the ` +

--- a/src/xdr/values/bigint-parts.ts
+++ b/src/xdr/values/bigint-parts.ts
@@ -54,6 +54,38 @@ export function assertBigIntFits(
 }
 
 /**
+ * Reject decimal strings whose length alone rules out fitting a `bits`-wide
+ * integer, BEFORE the string reaches `BigInt(...)`. Parsing an
+ * attacker-supplied multi-megabyte string costs work per input byte and
+ * produces a value that `assertBigIntFits` is then certain to reject; checking
+ * the length first makes that rejection O(1) and keeps the huge value out of
+ * the range error message.
+ *
+ * Budget formula: a `bits`-wide integer has at most `ceil(bits * log10(2))`
+ * decimal digits (log10(2) ≈ 0.30103) — e.g. 20 digits for a 64-bit value.
+ * The `+ 2` is slack: one character for an optional leading `-` sign, plus
+ * one digit of rounding headroom, giving 22 for 64 bits. Any longer string
+ * cannot possibly denote an in-range value, so no legitimate input is
+ * affected. It does, however, reject padding that `BigInt()` itself would
+ * tolerate (long runs of leading zeros, `+`, surrounding whitespace) once the
+ * string exceeds the budget — intentional, since SEP-51 integer fields carry
+ * canonical decimal strings.
+ */
+export function assertDecimalDigitBudget(
+  s: string,
+  bits: number,
+  name: string,
+): void {
+  const maxDigits = Math.ceil(bits * 0.30103) + 2;
+  if (s.length > maxDigits) {
+    throw new XdrError(
+      `${name}: decimal string length ${s.length} exceeds the ` +
+        `${maxDigits}-character budget for a ${bits}-bit integer`,
+    );
+  }
+}
+
+/**
  * Number-valued counterpart of `assertBigIntFits` for the 32-bit `Int32`/
  * `Uint32` shims: validate that `value` is an integer within a `bits`-wide
  * signed/unsigned range, throwing a consistent `XdrError` otherwise.

--- a/src/xdr/values/to-json.ts
+++ b/src/xdr/values/to-json.ts
@@ -27,6 +27,7 @@ import {
 } from "./json-names.js";
 import {
   assertBigIntFits,
+  assertDecimalDigitBudget,
   bigIntTo128Parts,
   bigIntTo256Parts,
   partsTo128BigInt,
@@ -177,6 +178,7 @@ export function walkFromJson(
     case "int64":
     case "uint64": {
       assertJsonType(json, "string", schema);
+      assertDecimalDigitBudget(json as string, 64, schema.name ?? s.kind);
       let value: bigint;
       try {
         value = BigInt(json as string);
@@ -774,6 +776,7 @@ OVERRIDES.set("Int128Parts", {
     if (typeof json !== "string") {
       throw new XdrError("Int128Parts: expected decimal string");
     }
+    assertDecimalDigitBudget(json, 128, "Int128Parts");
     const value = BigInt(json);
     assertBigIntFits(value, true, 128, "Int128Parts");
     return bigIntTo128Parts(value, true);
@@ -788,6 +791,7 @@ OVERRIDES.set("Uint128Parts", {
     if (typeof json !== "string") {
       throw new XdrError("Uint128Parts: expected decimal string");
     }
+    assertDecimalDigitBudget(json, 128, "Uint128Parts");
     const value = BigInt(json);
     assertBigIntFits(value, false, 128, "Uint128Parts");
     return bigIntTo128Parts(value, false);
@@ -802,6 +806,7 @@ OVERRIDES.set("Int256Parts", {
     if (typeof json !== "string") {
       throw new XdrError("Int256Parts: expected decimal string");
     }
+    assertDecimalDigitBudget(json, 256, "Int256Parts");
     const value = BigInt(json);
     assertBigIntFits(value, true, 256, "Int256Parts");
     return bigIntTo256Parts(value, true);
@@ -816,6 +821,7 @@ OVERRIDES.set("Uint256Parts", {
     if (typeof json !== "string") {
       throw new XdrError("Uint256Parts: expected decimal string");
     }
+    assertDecimalDigitBudget(json, 256, "Uint256Parts");
     const value = BigInt(json);
     assertBigIntFits(value, false, 256, "Uint256Parts");
     return bigIntTo256Parts(value, false);

--- a/test/unit/xdr/xdr_json_bigint_digit_budget.test.ts
+++ b/test/unit/xdr/xdr_json_bigint_digit_budget.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { XdrError } from "@stellar/js-xdr";
+
+import {
+  Memo,
+  ScVal,
+  Int128,
+  Uint128,
+  Int256,
+  Uint256,
+} from "../../../src/xdr/index.js";
+import { assertDecimalDigitBudget } from "../../../src/xdr/values/bigint-parts.js";
+
+// JSON integer decode paths check the decimal string's length before calling
+// BigInt() on it. A string longer than the target width's digit budget can
+// never be in range, so it is rejected up front instead of being parsed first.
+
+const HUGE = "9".repeat(1_000_000);
+
+describe("assertDecimalDigitBudget (unit)", () => {
+  // Budget = ceil(bits * log10(2)) + 2; the +2 covers a leading '-' plus one
+  // digit of rounding headroom.
+  it.each([
+    [64, 22],
+    [128, 41],
+    [256, 80],
+  ])("%d-bit budget is %d characters", (bits, budget) => {
+    expect(() =>
+      assertDecimalDigitBudget("9".repeat(budget), bits, "t"),
+    ).not.toThrow();
+    expect(() =>
+      assertDecimalDigitBudget("9".repeat(budget + 1), bits, "t"),
+    ).toThrow(XdrError);
+  });
+
+  it("includes the type name and budget in the error", () => {
+    expect(() => assertDecimalDigitBudget(HUGE, 64, "Memo")).toThrow(
+      /Memo: decimal string length 1000000 exceeds the 22-character budget/,
+    );
+  });
+});
+
+describe("over-long decimal strings are rejected before the BigInt parse", () => {
+  it("walkFromJson uint64 (Memo.id) throws on a 1M-digit string", () => {
+    expect(() => Memo.fromJson({ id: HUGE })).toThrow(/exceeds the/);
+  });
+
+  it("walkFromJson int64 (ScVal.i64) throws on a 1M-digit string", () => {
+    expect(() => ScVal.fromJson({ i64: HUGE })).toThrow(/exceeds the/);
+    expect(() => ScVal.fromJson({ i64: `-${HUGE}` })).toThrow(/exceeds the/);
+  });
+
+  it.each(["i128", "u128", "i256", "u256"] as const)(
+    "%s Parts override throws on a 1M-digit string",
+    (key) => {
+      expect(() => ScVal.fromJson({ [key]: HUGE })).toThrow(/exceeds the/);
+    },
+  );
+
+  it("rejects long non-canonical spellings BigInt() would tolerate", () => {
+    // BigInt("000…001") === 1n, but SEP-51 fields are canonical decimal, so
+    // padding past the digit budget is rejected (documented behavior change).
+    expect(() => Memo.fromJson({ id: `${"0".repeat(10_000)}1` })).toThrow(
+      /exceeds the/,
+    );
+  });
+
+  it("reports the length budget, not an out-of-range value", () => {
+    // The budget error proves the rejection happened before the parse: a
+    // parse-then-check ordering would throw the `out of range` message from
+    // assertBigIntFits and interpolate the whole 1M-digit value into it.
+    expect(() => Memo.fromJson({ id: HUGE })).toThrow(
+      /decimal string length 1000000 exceeds the 22-character budget/,
+    );
+    expect(() => Memo.fromJson({ id: HUGE })).not.toThrow(/out of range/);
+  });
+});
+
+describe("extreme in-range values still parse", () => {
+  it("uint64 max (2^64 - 1)", () => {
+    expect(Memo.fromJson({ id: "18446744073709551615" }).value).toBe(
+      18446744073709551615n,
+    );
+  });
+
+  it("int64 max/min", () => {
+    expect(ScVal.fromJson({ i64: "9223372036854775807" }).value).toBe(
+      9223372036854775807n,
+    );
+    expect(ScVal.fromJson({ i64: "-9223372036854775808" }).value).toBe(
+      -9223372036854775808n,
+    );
+  });
+
+  const U128_MAX = (1n << 128n) - 1n;
+  const I128_MAX = (1n << 127n) - 1n;
+  const I128_MIN = -(1n << 127n);
+  const U256_MAX = (1n << 256n) - 1n;
+  const I256_MAX = (1n << 255n) - 1n;
+  const I256_MIN = -(1n << 255n);
+
+  it.each([
+    ["u128 max", "u128", U128_MAX],
+    ["i128 max", "i128", I128_MAX],
+    ["i128 min", "i128", I128_MIN],
+    ["u256 max", "u256", U256_MAX],
+    ["i256 max", "i256", I256_MAX],
+    ["i256 min", "i256", I256_MIN],
+  ] as const)("%s via ScVal JSON", (_label, key, value) => {
+    const round = ScVal.fromJson({ [key]: value.toString() });
+    expect(round.toJson()).toEqual({ [key]: value.toString() });
+  });
+
+  it.each([
+    [Uint128, U128_MAX],
+    [Int128, I128_MAX],
+    [Int128, I128_MIN],
+    [Uint256, U256_MAX],
+    [Int256, I256_MAX],
+    [Int256, I256_MIN],
+  ] as const)("wide-int constructor accepts extreme %#", (Ctor, value) => {
+    expect(new Ctor(value.toString()).value).toBe(value);
+  });
+});


### PR DESCRIPTION
## What

SEP-51 JSON decoding of integer fields now checks the decimal string's length before handing it to `BigInt()`. A string longer than the target width can possibly hold is rejected up front instead of being parsed and then found out of range.

The new `assertDecimalDigitBudget(s, bits, name)` in `src/xdr/values/bigint-parts.ts` derives the budget from the width: a `bits`-wide integer needs at most `ceil(bits * log10(2))` decimal digits, plus 2 characters of slack for an optional leading `-` and a digit of rounding headroom. That gives 22 characters for 64 bits, 41 for 128, and 80 for 256. It is wired into the five decode paths in `src/xdr/values/to-json.ts`: the `int64`/`uint64` case in `walkFromJson`, and the `fromJson` overrides for `Int128Parts`, `Uint128Parts`, `Int256Parts`, and `Uint256Parts`.

The check is deliberately scoped to the decode paths, where the SDK is the parser and the string length is chosen by whoever wrote the JSON rather than by the caller. Construction entry points that take a developer-supplied value — the `Int128`/`Uint128`/`Int256`/`Uint256` constructors, `xdr.Int64`/`xdr.Uint64`, `ScInt`, and `XdrLargeInt` — are left as they are: those callers pick the argument, so validating it belongs at their own trust boundary, not inside the SDK.

One behavior change worth knowing about: non-canonical spellings that native `BigInt()` tolerates — long runs of leading zeros, a leading `+`, surrounding whitespace, or `0x`/`0o`/`0b` prefixes — are now rejected once they push the string past the budget, so `"0".repeat(10000) + "1"` throws where it previously decoded as `1`. SEP-51 integer fields carry canonical decimal strings, so no legitimate input is affected. Every extreme in-range value is covered by a test, including unsigned max and signed min/max for all four widths.

No CHANGELOG entry: these decode paths are unreleased, so there is no shipped behavior for this to change.

## Why

Parsing an attacker-supplied multi-megabyte decimal string costs work proportional to the input, and produces a value that the range check is then certain to reject. Measured on Node 22, base-10 `BigInt` parsing runs at roughly 80 ns per input byte — 44 ms for 1M digits, 230 ms for 4M, 1.26 s for 16M. That is linear-ish rather than quadratic, so this is a modest cost rather than a severe one, but it is entirely wasted: the length alone already proves the value cannot fit. Checking it first makes the rejection O(1) and keeps a megabyte-long value out of the interpolated range error message.

`Memo.fromJson({ id })` is the clearest instance — an application decoding a JSON payload from a third party reaches `BigInt()` on an unbounded string with no opportunity to bound it first.

## Test plan

`test/unit/xdr/xdr_json_bigint_digit_budget.test.ts` covers the budget formula per width, the boundary at budget and budget + 1, every decode path against a 1M-digit string, the non-canonical padding case, and the extreme in-range values for all four widths. The regression guard asserts the budget error message and asserts the `out of range` message is not thrown, which is what distinguishes check-then-parse from parse-then-check; disabling the check fails it. The `to_json` and `bigint_parts` suites pass unchanged.
