### PR TITLE
fix(xdr): restrict fromJson to SEP-0051 keys and reject unknown fields

### DIFF
--- a/docs/XDR_MIGRATION.md
+++ b/docs/XDR_MIGRATION.md
@@ -637,16 +637,39 @@ schema name:
 | `AssetCode4`                                                 | trimmed text (trailing zero bytes removed)                                |
 | `AssetCode12`                                                | trimmed text, minimum 5 bytes (so it's distinguishable from `AssetCode4`) |
 
-### `fromJson` accepts both canonical and forgiving inputs
+### `fromJson` accepts SEP-0051 keys only
 
-`fromJson` is lenient on input shape — accepts either the SEP-0051 form
-(snake_case keys) or the raw wire field names (camelCase keys), so
-internally-produced JSON round-trips even if a caller hands you the older shape.
+`fromJson` accepts the SEP-0051 form and nothing else. The raw wire field names
+(camelCase) are **not** accepted, and an unknown struct key is rejected rather
+than ignored — an omitted optional field decodes to `null`, so a silently
+skipped typo would drop data without any error.
 
 ```ts
-// Both work:
-xdr.AlphaNum4.fromJson({ asset_code: "USD", issuer: "GAAQ…" }); // canonical
-xdr.AlphaNum4.fromJson({ assetCode: "USD", issuer: "GAAQ…" }); // legacy
+xdr.AlphaNum4.fromJson({ asset_code: "USD", issuer: "GAAQ…" }); // ok
+xdr.AlphaNum4.fromJson({ assetCode: "USD", issuer: "GAAQ…" }); // throws: unknown field assetCode
+xdr.AlphaNum4.fromJson({ asset_code: "USD", issuer: "GAAQ…", extra: 1 }); // throws: unknown field extra
+```
+
+The same applies to enum and union case names — only the snake_case,
+prefix-stripped spelling works:
+
+```ts
+xdr.ScValType.fromJson("i32"); // ok
+xdr.ScValType.fromJson("scvI32"); // throws: unknown enum name scvI32
+xdr.Asset.fromJson({ credit_alphanum4: payload }); // ok
+xdr.Asset.fromJson({ assetTypeCreditAlphanum4: payload }); // throws: unknown case
+```
+
+One exception: for struct fields whose name is a Rust keyword, the Rust
+`stellar-xdr` crate emits a keyword-escaped key (`type_` instead of `type`).
+`fromJson` accepts that legacy spelling alongside the plain one so JSON from the
+Rust tooling still parses. Supplying both spellings of the same field is
+ambiguous and throws.
+
+```ts
+xdr.ContractEvent.fromJson({ ...rest, type: "contract" }); // ok (canonical)
+xdr.ContractEvent.fromJson({ ...rest, type_: "contract" }); // ok (Rust legacy)
+xdr.ContractEvent.fromJson({ ...rest, type: "contract", type_: "contract" }); // throws
 ```
 
 ### Method names

--- a/src/xdr/values/json-names.ts
+++ b/src/xdr/values/json-names.ts
@@ -82,6 +82,28 @@ export function legacyStructFieldJsonName(field: string): string | undefined {
 // large values (transaction metas) don't rebuild the same maps repeatedly.
 const ENUM_NAME_CACHE = new WeakMap<object, JsonNameMap>();
 const UNION_NAME_CACHE = new WeakMap<object, JsonNameMap>();
+const ACCEPTED_KEY_CACHE = new WeakMap<object, ReadonlySet<string>>();
+
+/**
+ * Every JSON key a struct schema accepts: the snake_case name for each field,
+ * plus the legacy Rust keyword-escaped form (`type_`) where one exists.
+ * Memoized per schema — `StructType` assigns `entries` once in its
+ * constructor, so the array identity is stable for the schema's lifetime.
+ */
+export function acceptedStructJsonKeys(
+  entries: ReadonlyArray<readonly [string, unknown]>,
+): ReadonlySet<string> {
+  const cached = ACCEPTED_KEY_CACHE.get(entries);
+  if (cached) return cached;
+  const accepted = new Set<string>();
+  for (const [k] of entries) {
+    accepted.add(structFieldJsonName(k));
+    const legacy = legacyStructFieldJsonName(k);
+    if (legacy !== undefined) accepted.add(legacy);
+  }
+  ACCEPTED_KEY_CACHE.set(entries, accepted);
+  return accepted;
+}
 
 /**
  * Canonical JSON names for an enum's members. Strips the enum's camelized

--- a/src/xdr/values/to-json.ts
+++ b/src/xdr/values/to-json.ts
@@ -20,6 +20,7 @@ import type {
 import type { JsonValue } from "./xdr-value.js";
 import { XdrString } from "./xdr-string.js";
 import {
+  acceptedStructJsonKeys,
   legacyStructFieldJsonName,
   structFieldJsonName,
   enumJsonNames,
@@ -230,10 +231,6 @@ export function walkFromJson(
           if (name === sourceName) return value;
         }
       }
-      // Tolerate the raw (camelCase) source name as well.
-      for (const [value, name] of e.nameByValue) {
-        if (name === target) return value;
-      }
       throw new XdrError(
         `${schema.name ?? "enum"}: unknown enum name ${target}`,
       );
@@ -272,21 +269,37 @@ export function walkFromJson(
       }
       const rec = json as Record<string, JsonValue>;
       const out: Record<string, unknown> = {};
-      // Accept the SEP-0051 snake_case key, the legacy Rust keyword-escaped
-      // key (`type_` from the `stellar-xdr` crate's buggy output), or the raw
-      // camelCase wire name (so internally-produced JSON round-trips even if
-      // a caller hands us camelCase).
+      // Accept the SEP-0051 snake_case key or the legacy Rust keyword-escaped
+      // key (`type_` from the `stellar-xdr` crate's buggy output). Supplying
+      // both spellings of the same field is ambiguous and rejected. Any other
+      // key is rejected outright: an absent optional field maps to `null`, so
+      // a silently ignored typo'd key would otherwise drop data undetectably.
+      const accepted = acceptedStructJsonKeys(s.entries);
+      for (const key of Object.keys(rec)) {
+        if (!accepted.has(key)) {
+          throw new XdrError(
+            `${schema.name ?? "struct"}: unknown field ${key}`,
+          );
+        }
+      }
       for (const [k, fieldSchema] of s.entries) {
         const snake = structFieldJsonName(k);
         const legacy = legacyStructFieldJsonName(k);
-        const lookupKey =
-          snake in rec
-            ? snake
-            : legacy !== undefined && legacy in rec
-              ? legacy
-              : k in rec
-                ? k
-                : undefined;
+        if (
+          legacy !== undefined &&
+          Object.hasOwn(rec, snake) &&
+          Object.hasOwn(rec, legacy)
+        ) {
+          throw new XdrError(
+            `${schema.name ?? "struct"}: field ${k} given as both ` +
+              `${snake} and ${legacy}`,
+          );
+        }
+        const lookupKey = Object.hasOwn(rec, snake)
+          ? snake
+          : legacy !== undefined && Object.hasOwn(rec, legacy)
+            ? legacy
+            : undefined;
         if (lookupKey === undefined) {
           // Match the serde-based Rust reference: an omitted optional field
           // is None, so JSON from tooling that skips nulls still parses.
@@ -333,11 +346,13 @@ function unionFromJson(json: JsonValue, schema: UnionSchema<unknown>): unknown {
     );
   }
 
-  // Accept either the SEP-0051 form (snake_case, prefix stripped) or the
-  // raw camelCase source name.
+  // Only the SEP-0051 form (snake_case, prefix stripped) is accepted.
   const names = unionCaseNames(schema);
-  const sourceName = names.byJson.get(jsonKey) ?? jsonKey;
-  const matched = schema.cases.find((c) => c.name === sourceName);
+  const sourceName = names.byJson.get(jsonKey);
+  const matched =
+    sourceName === undefined
+      ? undefined
+      : schema.cases.find((c) => c.name === sourceName);
   if (matched === undefined) {
     // See the walkToJson union case: default arms are deliberately
     // unsupported — the "default" JSON key would discard the discriminant.

--- a/test/unit/xdr/corpus_round_trip.test.ts
+++ b/test/unit/xdr/corpus_round_trip.test.ts
@@ -164,6 +164,45 @@ describe("corpus round-trip: TransactionEnvelope (mainnet)", () => {
   }
 });
 
+describe("corpus JSON round-trip: envelopes and metas (mainnet)", () => {
+  const records = loadCorpus<TransactionRecord>("transactions.json");
+  if (!records || records.length === 0) {
+    it.skip("(no corpus file; run `pnpm tsx scripts/refresh-horizon-corpus.ts`)", () => {});
+    return;
+  }
+
+  // toJson → fromJson on real, large mainnet values. Besides checking the
+  // JSON dialect round-trips, this exercises the memoized per-schema
+  // accepted-key set across many repeated struct nodes.
+  function assertJsonRoundTrip(b64: string, ctor: any): void {
+    const value = ctor.fromXdr(base64ToUint8Array(b64));
+    const round = ctor.fromJson(value.toJson());
+    expect(round.toXdr()).toEqual(value.toXdr());
+  }
+
+  for (const r of records) {
+    it(`envelope ${r.hash.slice(0, 12)}… JSON round-trips`, () => {
+      assertJsonRoundTrip(r.envelope_xdr, TransactionEnvelope);
+    });
+
+    it(`result_meta ${r.hash.slice(0, 12)}… JSON round-trips`, () => {
+      // Same fee-bump dispatch as the byte-level test above: the outer
+      // record's meta is wire-equivalent to an OperationMeta.
+      const envBytes = base64ToUint8Array(r.envelope_xdr);
+      const isFeeBump =
+        new DataView(
+          envBytes.buffer,
+          envBytes.byteOffset,
+          envBytes.byteLength,
+        ).getUint32(0) === 5;
+      assertJsonRoundTrip(
+        r.result_meta_xdr,
+        isFeeBump ? OperationMeta : TransactionMeta,
+      );
+    });
+  }
+});
+
 describe("corpus round-trip: LedgerHeader (mainnet)", () => {
   const records = loadCorpus<LedgerRecord>("ledgers.json");
   if (!records || records.length === 0) {

--- a/test/unit/xdr/corpus_round_trip.test.ts
+++ b/test/unit/xdr/corpus_round_trip.test.ts
@@ -39,7 +39,7 @@ import {
 
 const CORPUS_DIR = resolve(
   fileURLToPath(new URL(".", import.meta.url)),
-  "../../../fixtures/horizon-corpus",
+  "../../fixtures/horizon-corpus",
 );
 
 function loadCorpus<T>(filename: string): T[] | null {

--- a/test/unit/xdr/to_json.test.ts
+++ b/test/unit/xdr/to_json.test.ts
@@ -16,6 +16,7 @@ import {
   ContractId,
   PublicKey,
   ScVal,
+  ScValType,
   ScAddress,
   ScBytes,
   ScMapEntry,
@@ -326,6 +327,119 @@ describe("walker — Rust-keyword struct fields (`type`)", () => {
     delete json.type;
     const round = ContractEvent.fromJson(json as never);
     expect(round.toXdr()).toEqual(event.toXdr());
+  });
+
+  it("fromJson rejects a field supplied as both `type` and `type_`", () => {
+    const json = event.toJson() as Record<string, unknown>;
+    json.type_ = json.type; // both spellings present — ambiguous
+    expect(() => ContractEvent.fromJson(json as never)).toThrow(
+      /field type given as both type and type_/,
+    );
+  });
+});
+
+describe("walker — camelCase JSON input is rejected (SEP-0051 only)", () => {
+  it("struct: a camelCase alias alongside snake_case is rejected as unknown", () => {
+    // Originally `assetCode` was an accepted alias and the walker silently
+    // picked snake_case, discarding the conflicting value. It is no longer
+    // an accepted spelling, and unknown keys are rejected outright — so a
+    // consumer inspecting `assetCode` can never see a value the codec
+    // ignored.
+    expect(() =>
+      AlphaNum4.fromJson({
+        asset_code: "USD",
+        assetCode: "EVIL",
+        issuer: STRKEY,
+      } as never),
+    ).toThrow(/unknown field assetCode/);
+  });
+
+  it("struct: camelCase-only keys throw unknown-field", () => {
+    expect(() =>
+      AlphaNum4.fromJson({ assetCode: "USD", issuer: STRKEY } as never),
+    ).toThrow(/unknown field assetCode/);
+  });
+
+  it("enum: snake_case member name works, raw camelCase source name throws", () => {
+    expect(ScValType.fromJson("i32")).toBe(ScValType.scvI32);
+    expect(() => ScValType.fromJson("scvI32")).toThrow(/unknown enum name/);
+  });
+
+  it("union: snake_case case key works, raw camelCase source name throws", () => {
+    const payload = {
+      asset_code: "USD",
+      issuer: STRKEY,
+    };
+    const round = Asset.fromJson({ credit_alphanum4: payload });
+    expect(round.type).toBe("assetTypeCreditAlphanum4");
+    expect(() =>
+      Asset.fromJson({ assetTypeCreditAlphanum4: payload } as never),
+    ).toThrow(/unknown case/);
+  });
+});
+
+describe("walker — unknown struct keys are rejected", () => {
+  it("a typo'd OPTIONAL field key throws instead of silently decoding null", () => {
+    // ContractEvent.contractId is optional: an absent `contract_id` maps to
+    // `null`, so before unknown-key rejection a typo'd key produced a
+    // *successfully decoded* event with the contract id silently dropped.
+    const event = new ContractEvent({
+      ext: ExtensionPoint.v0(),
+      contractId: new ContractId(new Uint8Array(32).fill(9)),
+      type: ContractEventType.contract,
+      body: ContractEventBody.v0(
+        new ContractEventV0({ topics: [], data: ScVal.scvVoid() }),
+      ),
+    });
+    const json = event.toJson() as Record<string, unknown>;
+    json.contract_idd = json.contract_id; // typo
+    delete json.contract_id;
+    expect(() => ContractEvent.fromJson(json as never)).toThrow(
+      /unknown field contract_idd/,
+    );
+  });
+
+  it("a typo'd key alongside otherwise-valid input throws", () => {
+    expect(() =>
+      AlphaNum4.fromJson({
+        asset_code: "USD",
+        issuer: STRKEY,
+        asset_codee: "XLM",
+      } as never),
+    ).toThrow(/unknown field asset_codee/);
+  });
+
+  it("the legacy `type_` spelling does not trip the unknown-key check", () => {
+    const event = new ContractEvent({
+      ext: ExtensionPoint.v0(),
+      contractId: null,
+      type: ContractEventType.contract,
+      body: ContractEventBody.v0(
+        new ContractEventV0({ topics: [], data: ScVal.scvVoid() }),
+      ),
+    });
+    const json = event.toJson() as Record<string, unknown>;
+    json.type_ = json.type;
+    delete json.type;
+    const round = ContractEvent.fromJson(json as never);
+    expect(round.toXdr()).toEqual(event.toXdr());
+  });
+
+  it("large/deep round-trip: repeated structs share the memoized key set", () => {
+    // Thousands of ScMapEntry structs against the same schema — exercises
+    // the WeakMap-cached accepted-key set on a hot decode path.
+    const entries = [];
+    for (let i = 0; i < 2000; i += 1) {
+      entries.push(
+        new ScMapEntry({
+          key: ScVal.scvU32(i),
+          val: ScVal.scvVec([ScVal.scvSymbol(`v${i}`)]),
+        }),
+      );
+    }
+    const original = ScVal.scvMap(entries);
+    const round = ScVal.fromJson(original.toJson());
+    expect(round.toXdr()).toEqual(original.toXdr());
   });
 });
 
@@ -756,17 +870,17 @@ describe("SEP-0051 conformance — composites", () => {
     });
   });
 
-  it("rule 15 round-trip: struct fromJson accepts both snake_case and camelCase keys", () => {
+  it("rule 15 round-trip: struct fromJson accepts only snake_case keys", () => {
     const an4 = new AlphaNum4({
       assetCode: asciiCode("USD", 4),
       issuer: PublicKey.publicKeyTypeEd25519(ED),
     });
     // Snake-case (canonical):
     expect(AlphaNum4.fromJson(an4.toJson()).toXdr()).toEqual(an4.toXdr());
-    // Camel-case (legacy / forgiving): also accepted.
-    expect(
-      AlphaNum4.fromJson({ assetCode: "USD", issuer: STRKEY }).toXdr(),
-    ).toEqual(an4.toXdr());
+    // Camel-case is rejected: it is not SEP-0051 JSON, and never emitted.
+    expect(() =>
+      AlphaNum4.fromJson({ assetCode: "USD", issuer: STRKEY }),
+    ).toThrow(/unknown field assetCode/);
   });
 
   it("rule 16: union void arm → snake_case string", () => {


### PR DESCRIPTION
## What

`xdr.*.fromJson()` now accepts SEP-0051 keys only. Struct fields must be snake_case, and enum members and union cases must use the snake_case, prefix-stripped spelling — the raw camelCase wire names (`assetCode`, `scvI32`, `assetTypeCreditAlphanum4`) are no longer accepted. Any struct key that isn't a recognized field is rejected outright instead of ignored, and supplying a field under both its plain and Rust keyword-escaped spelling (`type` and `type_`) is an error. The legacy `type_` spelling on its own still parses, since that is what the Rust `stellar-xdr` crate emits.

Also fixes the Horizon corpus fixture path in `test/unit/xdr/corpus_round_trip.test.ts`, which pointed one directory too high and had been silently skipping every corpus test, and adds `toJson` → `fromJson` round-trips over the mainnet envelopes and metas in that corpus.

## Why

The camelCase aliases were not just unnecessary — they were actively harmful. `fromJson` looked up snake_case first and fell back to camelCase, so `{ asset_code: "USD", assetCode: "EVIL" }` decoded successfully with the second value silently discarded. A consumer reading `assetCode` back off its own input would see a value the codec never encoded.

Ignoring unknown keys is unsafe for the same reason. An omitted optional field decodes to `null` rather than throwing, so a typo'd key like `contract_idd` produced a fully decoded `ContractEvent` with the contract id quietly dropped. Rejecting the key surfaces the mistake at the boundary where it can still be fixed.

Neither leniency bought anything: `toJson` only ever emits SEP-0051 keys, so internally-produced JSON round-trips without the aliases, and no code in this repo feeds camelCase into `fromJson`. The accepted-key set is memoized per schema in a `WeakMap` keyed on the schema's `entries` array, which js-xdr assigns once in the `StructType` constructor, so the added validation costs one `Set` lookup per key on hot decode paths.

`toJson`/`fromJson` ship for the first time in v17, so this tightening breaks no released API and needs no changelog entry. `docs/XDR_MIGRATION.md` §13 documented the old lenient behavior and is updated in the same commit.
