### PR TITLE
fix(xdr): reject AssetCode12 JSON codes shorter than 5 bytes

### DIFF
--- a/src/xdr/values/to-json.ts
+++ b/src/xdr/values/to-json.ts
@@ -720,7 +720,14 @@ OVERRIDES.set("AssetCode12", {
     if (typeof json !== "string") {
       throw new XdrError("AssetCode12: expected escaped-string JSON");
     }
-    return padRightZeros(XdrString.fromJson(json).bytes, 12);
+    const bytes = XdrString.fromJson(json).bytes;
+    if (bytes.length < 5) {
+      throw new XdrError(
+        "AssetCode12: code must be at least 5 bytes; " +
+          "use AssetCode4 for shorter codes",
+      );
+    }
+    return padRightZeros(bytes, 12);
   },
 });
 

--- a/test/unit/xdr/to_json.test.ts
+++ b/test/unit/xdr/to_json.test.ts
@@ -945,6 +945,33 @@ describe("SEP-0051 conformance — Stellar-specific asset codes & integers", () 
     expect(json.asset_code).toBe("USDTether");
   });
 
+  it("AssetCode12.fromJson rejects codes shorter than 5 bytes", () => {
+    expect(() => AssetCode12.fromJson("USD")).toThrow(/at least 5 bytes/);
+    expect(() => AssetCode12.fromJson("")).toThrow(/at least 5 bytes/);
+    expect(() => AssetCode12.fromJson("ABCD")).toThrow(/at least 5 bytes/);
+    // 5 escaped bytes (3 chars + 2 NULs, as toJson emits) are still accepted.
+    expect(Array.from(AssetCode12.fromJson("ABC\\0\\0").value)).toEqual([
+      65, 66, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+  });
+
+  it("Asset.fromJson rejects a credit_alphanum12 code shorter than 5 bytes", () => {
+    expect(() =>
+      Asset.fromJson({
+        credit_alphanum12: { asset_code: "USD", issuer: STRKEY },
+      }),
+    ).toThrow(/at least 5 bytes/);
+  });
+
+  it("Asset.fromJson keeps the alphanum12 discriminant for genuine 5-12 byte codes", () => {
+    const round = Asset.fromJson({
+      credit_alphanum12: { asset_code: "USDTether", issuer: STRKEY },
+    });
+    const wire = round.toXdr();
+    // AssetType discriminant is the first 4 bytes: 2 = ASSET_TYPE_CREDIT_ALPHANUM12.
+    expect(Array.from(wire.slice(0, 4))).toEqual([0, 0, 0, 2]);
+  });
+
   it("rule 28: Int128Parts → decimal string", () => {
     expect(
       ScVal.scvI128(new Int128Parts({ hi: 0n, lo: 12345n })).toJson(),


### PR DESCRIPTION
## What

`xdr.AssetCode12.fromJson` now rejects asset codes shorter than 5 bytes instead of zero-padding them into a valid alphanum12 value. Any JSON decode that reaches it gets the same guard, `xdr.Asset.fromJson` included.

The output side already had this rule. `AssetCode12.toJson` floors its trailing-zero trimming at 5 bytes precisely so alphanum12 output stays distinguishable from alphanum4 output, and the flattened `AssetCode` union override picks its arm back by code length on the way in. Without a matching floor on `AssetCode12.fromJson`, a 3-byte code like `"USD"` silently became an alphanum12 asset, which is a different asset on the wire than the alphanum4 `"USD"` a caller writing that JSON meant. Genuine round trips are unaffected: `toJson` emits `"USD\0\0"` for such a value, 5 bytes, which still decodes.

This is stricter than the Rust `stellar-xdr` reference, which accepts short codes. The divergence is deliberate — Stellar Core rejects alphanum12 codes under 5 characters, so no such asset can exist on-network, and accepting one only produces a value that cannot round-trip back to the JSON it came from.

No changelog entry: the JSON codec being corrected here has not shipped in a release yet.

A related pre-existing gap is filed separately as #1584 — `Asset.fromOperation` drops the alphanum12 discriminant for a short code, so a decoded asset re-encodes as alphanum4. That one lives in `src/base/asset.ts` and is out of scope here.
