### PR TITLE
test: surface skipped and todo tests at the end of every run

### DIFF
--- a/config/skipped-tests-reporter.ts
+++ b/config/skipped-tests-reporter.ts
@@ -19,6 +19,19 @@ interface SkipRecord {
   note: string | undefined;
 }
 
+// Per-path tally. A run can load one path several times — the browser suite
+// loads every file once per browser — so whole-file status has to be counted
+// against the number of modules for that path, not stored as a single flag.
+// Otherwise a file skipped in one browser reads as dead in all of them.
+interface FileStatus {
+  modules: number;
+  wholeSkipped: number;
+  // Projects behind `wholeSkipped`, kept for display when only some skipped.
+  projects: Set<string>;
+}
+
+type FileStatuses = Map<string, FileStatus>;
+
 const RULE = "─".repeat(72);
 
 function toRecord(mod: TestModule, test: TestCase): SkipRecord {
@@ -35,20 +48,34 @@ function toRecord(mod: TestModule, test: TestCase): SkipRecord {
 function collect(testModules: ReadonlyArray<TestModule>): {
   skipped: SkipRecord[];
   todo: SkipRecord[];
-  wholeFiles: Set<string>;
+  statuses: FileStatuses;
 } {
   const skipped: SkipRecord[] = [];
   const todo: SkipRecord[] = [];
-  const wholeFiles = new Set<string>();
+  const statuses: FileStatuses = new Map();
 
   for (const mod of testModules) {
+    const file = mod.relativeModuleId;
+    const status = statuses.get(file) ?? {
+      modules: 0,
+      wholeSkipped: 0,
+      projects: new Set<string>(),
+    };
+    // Counted before the early continue below: a project that ran the file in
+    // full still has to weigh in on "did every project skip this?".
+    status.modules += 1;
+    statuses.set(file, status);
+
     const all = [...mod.children.allTests()];
     const notRun = all.filter((test) => test.result().state === "skipped");
     if (notRun.length === 0) continue;
 
     // Nothing in this file ran at all — the loudest case, and the one a
     // single "1 skipped" file count hides completely.
-    if (notRun.length === all.length) wholeFiles.add(mod.relativeModuleId);
+    if (notRun.length === all.length) {
+      status.wholeSkipped += 1;
+      status.projects.add(mod.project.name);
+    }
 
     for (const test of notRun) {
       const record = toRecord(mod, test);
@@ -62,19 +89,39 @@ function collect(testModules: ReadonlyArray<TestModule>): {
     }
   }
 
-  return { skipped, todo, wholeFiles };
+  return { skipped, todo, statuses };
+}
+
+// A path only counts as entirely skipped when every module for it skipped
+// everything.
+function isFullySkipped(status: FileStatus): boolean {
+  return status.wholeSkipped > 0 && status.wholeSkipped === status.modules;
+}
+
+function entireFileFlag(file: string, statuses: FileStatuses): string {
+  const status = statuses.get(file);
+  if (!status || status.wholeSkipped === 0) return "";
+  if (isFullySkipped(status)) return "   <-- ENTIRE FILE";
+
+  // Only some projects skipped the whole file, so say which — the file did run
+  // elsewhere and a bare "ENTIRE FILE" would be a false alarm.
+  const named = [...status.projects].filter((project) => project !== "").sort();
+  const where = named.map((project) => `[${project}]`).join(", ");
+  return where
+    ? `   <-- ENTIRE FILE in ${where}`
+    : "   <-- ENTIRE FILE in some projects";
 }
 
 function headline(
   skipped: number,
   todo: number,
-  wholeFiles: Set<string>,
+  statuses: FileStatuses,
 ): string {
   const counts: string[] = [];
   if (skipped > 0) counts.push(`${skipped} skipped`);
   if (todo > 0) counts.push(`${todo} todo`);
 
-  const files = wholeFiles.size;
+  const files = [...statuses.values()].filter(isFullySkipped).length;
   const entirely =
     files > 0
       ? `, including ${files} file${files === 1 ? "" : "s"} entirely`
@@ -86,7 +133,7 @@ function headline(
 function section(
   label: string,
   records: SkipRecord[],
-  wholeFiles: Set<string>,
+  statuses: FileStatuses,
   showProject: boolean,
 ): string[] {
   const byFile = new Map<string, SkipRecord[]>();
@@ -103,8 +150,7 @@ function section(
   const files = [...byFile.keys()].sort((a, b) => a.localeCompare(b));
   for (const file of files) {
     const group = byFile.get(file) ?? [];
-    const flag = wholeFiles.has(file) ? "   <-- ENTIRE FILE" : "";
-    lines.push(`  ${file}${flag}`);
+    lines.push(`  ${file}${entireFileFlag(file, statuses)}`);
     for (const record of group) {
       const project = showProject ? ` [${record.project}]` : "";
       const note = record.note ? ` — ${record.note}` : "";
@@ -117,22 +163,22 @@ function section(
 
 export class SkippedTestsReporter implements Reporter {
   onTestRunEnd(testModules: ReadonlyArray<TestModule>): void {
-    const { skipped, todo, wholeFiles } = collect(testModules);
+    const { skipped, todo, statuses } = collect(testModules);
     if (skipped.length === 0 && todo.length === 0) return;
 
     // Browser runs execute the same files once per browser instance, so the
     // same test name shows up twice; the project name is what tells them apart.
-    const projects = new Set(
-      [...skipped, ...todo].map((record) => record.project),
-    );
+    // Derived from the projects active in the run rather than the ones holding
+    // skips, so a finding that applies to only one project still names it.
+    const projects = new Set(testModules.map((mod) => mod.project.name));
     const showProject = projects.size > 1;
 
-    const lines = ["", RULE, headline(skipped.length, todo.length, wholeFiles)];
+    const lines = ["", RULE, headline(skipped.length, todo.length, statuses)];
     if (skipped.length > 0) {
-      lines.push(...section("skipped", skipped, wholeFiles, showProject));
+      lines.push(...section("skipped", skipped, statuses, showProject));
     }
     if (todo.length > 0) {
-      lines.push(...section("todo", todo, wholeFiles, showProject));
+      lines.push(...section("todo", todo, statuses, showProject));
     }
     lines.push(RULE, "");
 

--- a/config/skipped-tests-reporter.ts
+++ b/config/skipped-tests-reporter.ts
@@ -1,0 +1,141 @@
+// Reprints every skipped and todo test as an explicit block at the end of a
+// run.
+//
+// Vitest's summary collapses them into a single count ("6 skipped"), which is
+// trivial to miss in a run of thousands of passing tests. That matters because
+// a whole file can stop running without anything turning red — a fixture that
+// moved, a `skipIf` predicate that flipped, a stale entry in a skip list — and
+// the run still reads green. Naming the lost coverage forces it to be looked
+// at rather than scrolled past.
+//
+// Deliberately advisory: it never fails a run. Whether a given skip is
+// acceptable is a case-by-case call, so this only makes the cost visible.
+import type { Reporter, TestCase, TestModule } from "vitest/node";
+
+interface SkipRecord {
+  file: string;
+  project: string;
+  name: string;
+  note: string | undefined;
+}
+
+const RULE = "─".repeat(72);
+
+function toRecord(mod: TestModule, test: TestCase): SkipRecord {
+  const result = test.result();
+  return {
+    file: mod.relativeModuleId,
+    project: test.project.name,
+    name: test.fullName,
+    // `note` only exists on the skipped result shape (set by `ctx.skip(note)`).
+    note: result.state === "skipped" ? result.note : undefined,
+  };
+}
+
+function collect(testModules: ReadonlyArray<TestModule>): {
+  skipped: SkipRecord[];
+  todo: SkipRecord[];
+  wholeFiles: Set<string>;
+} {
+  const skipped: SkipRecord[] = [];
+  const todo: SkipRecord[] = [];
+  const wholeFiles = new Set<string>();
+
+  for (const mod of testModules) {
+    const all = [...mod.children.allTests()];
+    const notRun = all.filter((test) => test.result().state === "skipped");
+    if (notRun.length === 0) continue;
+
+    // Nothing in this file ran at all — the loudest case, and the one a
+    // single "1 skipped" file count hides completely.
+    if (notRun.length === all.length) wholeFiles.add(mod.relativeModuleId);
+
+    for (const test of notRun) {
+      const record = toRecord(mod, test);
+      // `it.todo` also lands in the skipped state; `options.mode` is the only
+      // thing that separates a deliberate placeholder from lost coverage.
+      if (test.options.mode === "todo") {
+        todo.push(record);
+      } else {
+        skipped.push(record);
+      }
+    }
+  }
+
+  return { skipped, todo, wholeFiles };
+}
+
+function headline(
+  skipped: number,
+  todo: number,
+  wholeFiles: Set<string>,
+): string {
+  const counts: string[] = [];
+  if (skipped > 0) counts.push(`${skipped} skipped`);
+  if (todo > 0) counts.push(`${todo} todo`);
+
+  const files = wholeFiles.size;
+  const entirely =
+    files > 0
+      ? `, including ${files} file${files === 1 ? "" : "s"} entirely`
+      : "";
+
+  return `DID NOT RUN: ${counts.join(", ")}${entirely}`;
+}
+
+function section(
+  label: string,
+  records: SkipRecord[],
+  wholeFiles: Set<string>,
+  showProject: boolean,
+): string[] {
+  const byFile = new Map<string, SkipRecord[]>();
+  for (const record of records) {
+    const group = byFile.get(record.file);
+    if (group) {
+      group.push(record);
+    } else {
+      byFile.set(record.file, [record]);
+    }
+  }
+
+  const lines = ["", `${label}:`];
+  const files = [...byFile.keys()].sort((a, b) => a.localeCompare(b));
+  for (const file of files) {
+    const group = byFile.get(file) ?? [];
+    const flag = wholeFiles.has(file) ? "   <-- ENTIRE FILE" : "";
+    lines.push(`  ${file}${flag}`);
+    for (const record of group) {
+      const project = showProject ? ` [${record.project}]` : "";
+      const note = record.note ? ` — ${record.note}` : "";
+      lines.push(`    ${record.name}${project}${note}`);
+    }
+  }
+
+  return lines;
+}
+
+export class SkippedTestsReporter implements Reporter {
+  onTestRunEnd(testModules: ReadonlyArray<TestModule>): void {
+    const { skipped, todo, wholeFiles } = collect(testModules);
+    if (skipped.length === 0 && todo.length === 0) return;
+
+    // Browser runs execute the same files once per browser instance, so the
+    // same test name shows up twice; the project name is what tells them apart.
+    const projects = new Set(
+      [...skipped, ...todo].map((record) => record.project),
+    );
+    const showProject = projects.size > 1;
+
+    const lines = ["", RULE, headline(skipped.length, todo.length, wholeFiles)];
+    if (skipped.length > 0) {
+      lines.push(...section("skipped", skipped, wholeFiles, showProject));
+    }
+    if (todo.length > 0) {
+      lines.push(...section("todo", todo, wholeFiles, showProject));
+    }
+    lines.push(RULE, "");
+
+    process.stdout.write(`${lines.join("\n")}\n`);
+  }
+}

--- a/config/vitest.config.browser.ts
+++ b/config/vitest.config.browser.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 import { playwright } from "@vitest/browser-playwright";
 import packageJson from "../package.json" with { type: "json" };
 import { aliasHttpClientToAxiosSource } from "./vitest-utils";
+import { SkippedTestsReporter } from "./skipped-tests-reporter";
 import { resolve } from "path";
 const isAxios = process.env.TRANSPORT === "axios";
 
@@ -66,6 +67,9 @@ export default defineConfig({
     ],
     // Setup files to load the browser bundle
     setupFiles: [resolve(__dirname, "../test/setup-browser.ts")],
+    // `reporters` replaces the default rather than adding to it, so "default"
+    // has to be listed.
+    reporters: ["default", new SkippedTestsReporter()],
   },
   resolve: {
     alias: {

--- a/config/vitest.config.e2e.ts
+++ b/config/vitest.config.e2e.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config'
 import { resolve } from 'path'
+import { SkippedTestsReporter } from './skipped-tests-reporter'
 
 export default defineConfig({
   test: {
@@ -17,6 +18,9 @@ export default defineConfig({
     // Include only e2e tests
     include: ['test/e2e/src/**/*.test.ts'],
     exclude: ['**/browser.test.ts'],
+    // `reporters` replaces the default rather than adding to it, so 'default'
+    // has to be listed.
+    reporters: ['default', new SkippedTestsReporter()],
     // Run tests in sequence to avoid conflicts with shared resources
     pool: 'forks',
     poolOptions: {

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 import { resolve } from "path";
 import packageJson from "../package.json" with { type: "json" };
 import { aliasHttpClientToAxiosSource } from "./vitest-utils";
+import { SkippedTestsReporter } from "./skipped-tests-reporter";
 
 const isAxios = process.env.TRANSPORT === "axios";
 
@@ -38,6 +39,10 @@ export default defineConfig({
     // vitest.config.guides.ts, never as part of a default run.
     include: ["test/unit/**/*.test.ts", "test/integration/**/*.test.ts"],
     exclude: ["**/browser.test.ts"],
+    // `reporters` replaces the default rather than adding to it, so "default"
+    // has to be listed. Inherited by vitest.config.guides.ts via mergeConfig —
+    // do not add it there too, the merge concatenates arrays.
+    reporters: ["default", new SkippedTestsReporter()],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Problem

Vitest reports skipped tests as a single count in the summary. In a run of ~5500 passing tests, `6 skipped` scrolls past unnoticed — so a test file that silently stops running doesn't fail anything and doesn't get spotted.

## Change

A custom reporter (`config/skipped-tests-reporter.ts`) that prints an explicit block after each run:

- every skipped and todo test, grouped by file, with `ctx.skip()` notes when present
- files where *nothing* ran flagged `<-- ENTIRE FILE`
- project labels (`[chromium]`/`[firefox]`) when more than one project is active
- nothing at all when a run has no skips or todos

Registered in the node, browser, and e2e configs. Not added to the guides config — it inherits via `mergeConfig`, and adding it there would register it twice.

Deliberately advisory: it never fails a run. Whether a given skip is acceptable is a judgement call, so this only makes the cost visible.

## Known limitations

- Tests deselected by `it.only` land in the skipped bucket, so one `.only` in a large generated suite prints a long listing. Local only — CI rejects `.only` via `allowOnly`.
- With `--coverage`, the coverage table prints after the block, since coverage is sequenced after `onTestRunEnd`.