### PR TITLE
Fix: xdr json decode validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ A breaking change will get clearly marked in this log.
 
 ### Fixed
 - `StrKey.decodeSignedPayload` and `StrKey.isValidSignedPayload` now validate the framing inside a `P...` strkey: the declared payload length must be 1-64, must match the number of payload bytes present, and the padding must be zero. The three [SEP-23](https://stellar.org/protocol/sep-23) invalid signed-payload test cases — length prefix shorter than the payload, longer than the payload, and missing zero padding — were previously accepted ([#1588](https://github.com/stellar/js-stellar-sdk/pull/1588)).
+- `StrKey.decodeClaimableBalance` and `StrKey.isValidClaimableBalance` now validate the discriminant byte that leads a `B...` strkey. `CLAIMABLE_BALANCE_ID_TYPE_V0` (0) is the only case `ClaimableBalanceID` declares, so the XDR decoder has always refused anything else — but the strkey checksum covers whatever byte is present, so a `B...` key with an unknown discriminant was decoded and reported valid.
 
 ## [v16.2.0](https://github.com/stellar/js-stellar-sdk/compare/v16.1.0...v16.2.0)
 

--- a/docs/reference/core-keys.md
+++ b/docs/reference/core-keys.md
@@ -468,7 +468,7 @@ class StrKey {
 }
 ```
 
-**Source:** [src/base/strkey.ts:113](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L113)
+**Source:** [src/base/strkey.ts:134](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L134)
 
 ### `new StrKey()`
 
@@ -482,7 +482,7 @@ constructor();
 static types: Record<string, VersionByteName>;
 ```
 
-**Source:** [src/base/strkey.ts:114](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L114)
+**Source:** [src/base/strkey.ts:135](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L135)
 
 ### `StrKey.decodeClaimableBalance(address)`
 
@@ -496,7 +496,7 @@ static decodeClaimableBalance(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — balance to decode
 
-**Source:** [src/base/strkey.ts:304](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L304)
+**Source:** [src/base/strkey.ts:325](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L325)
 
 ### `StrKey.decodeContract(address)`
 
@@ -510,7 +510,7 @@ static decodeContract(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — address to decode
 
-**Source:** [src/base/strkey.ts:277](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L277)
+**Source:** [src/base/strkey.ts:298](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L298)
 
 ### `StrKey.decodeEd25519PublicKey(data)`
 
@@ -527,7 +527,7 @@ static decodeEd25519PublicKey(data: string): Uint8Array;
 
 - **`data`** — `string` (required) — "G..." (or "M...") key representation to decode
 
-**Source:** [src/base/strkey.ts:133](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L133)
+**Source:** [src/base/strkey.ts:154](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L154)
 
 ### `StrKey.decodeEd25519SecretSeed(address)`
 
@@ -541,7 +541,7 @@ static decodeEd25519SecretSeed(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — data to decode
 
-**Source:** [src/base/strkey.ts:160](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L160)
+**Source:** [src/base/strkey.ts:181](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L181)
 
 ### `StrKey.decodeLiquidityPool(address)`
 
@@ -555,7 +555,7 @@ static decodeLiquidityPool(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — address to decode
 
-**Source:** [src/base/strkey.ts:331](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L331)
+**Source:** [src/base/strkey.ts:352](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L352)
 
 ### `StrKey.decodeMed25519PublicKey(address)`
 
@@ -569,7 +569,7 @@ static decodeMed25519PublicKey(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — data to decode
 
-**Source:** [src/base/strkey.ts:187](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L187)
+**Source:** [src/base/strkey.ts:208](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L208)
 
 ### `StrKey.decodePreAuthTx(address)`
 
@@ -583,7 +583,7 @@ static decodePreAuthTx(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — data to decode
 
-**Source:** [src/base/strkey.ts:214](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L214)
+**Source:** [src/base/strkey.ts:235](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L235)
 
 ### `StrKey.decodeSha256Hash(address)`
 
@@ -597,7 +597,7 @@ static decodeSha256Hash(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — data to decode
 
-**Source:** [src/base/strkey.ts:232](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L232)
+**Source:** [src/base/strkey.ts:253](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L253)
 
 ### `StrKey.decodeSignedPayload(address)`
 
@@ -611,7 +611,7 @@ static decodeSignedPayload(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — address to decode
 
-**Source:** [src/base/strkey.ts:250](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L250)
+**Source:** [src/base/strkey.ts:271](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L271)
 
 ### `StrKey.encodeClaimableBalance(data)`
 
@@ -625,7 +625,7 @@ static encodeClaimableBalance(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:295](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L295)
+**Source:** [src/base/strkey.ts:316](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L316)
 
 ### `StrKey.encodeContract(data)`
 
@@ -639,7 +639,7 @@ static encodeContract(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:268](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L268)
+**Source:** [src/base/strkey.ts:289](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L289)
 
 ### `StrKey.encodeEd25519PublicKey(data)`
 
@@ -653,7 +653,7 @@ static encodeEd25519PublicKey(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — raw data to encode
 
-**Source:** [src/base/strkey.ts:121](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L121)
+**Source:** [src/base/strkey.ts:142](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L142)
 
 ### `StrKey.encodeEd25519SecretSeed(data)`
 
@@ -667,7 +667,7 @@ static encodeEd25519SecretSeed(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:151](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L151)
+**Source:** [src/base/strkey.ts:172](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L172)
 
 ### `StrKey.encodeLiquidityPool(data)`
 
@@ -681,7 +681,7 @@ static encodeLiquidityPool(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:322](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L322)
+**Source:** [src/base/strkey.ts:343](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L343)
 
 ### `StrKey.encodeMed25519PublicKey(data)`
 
@@ -695,7 +695,7 @@ static encodeMed25519PublicKey(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:178](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L178)
+**Source:** [src/base/strkey.ts:199](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L199)
 
 ### `StrKey.encodePreAuthTx(data)`
 
@@ -709,7 +709,7 @@ static encodePreAuthTx(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:205](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L205)
+**Source:** [src/base/strkey.ts:226](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L226)
 
 ### `StrKey.encodeSha256Hash(data)`
 
@@ -723,7 +723,7 @@ static encodeSha256Hash(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:223](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L223)
+**Source:** [src/base/strkey.ts:244](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L244)
 
 ### `StrKey.encodeSignedPayload(data)`
 
@@ -737,7 +737,7 @@ static encodeSignedPayload(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:241](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L241)
+**Source:** [src/base/strkey.ts:262](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L262)
 
 ### `StrKey.getVersionByteForPrefix(address)`
 
@@ -752,7 +752,7 @@ static getVersionByteForPrefix(address: string): VersionByteName | undefined;
 
 - **`address`** — `string` (required) — the strkey address to check
 
-**Source:** [src/base/strkey.ts:350](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L350)
+**Source:** [src/base/strkey.ts:371](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L371)
 
 ### `StrKey.isValidClaimableBalance(address)`
 
@@ -766,7 +766,7 @@ static isValidClaimableBalance(address: string): boolean;
 
 - **`address`** — `string` (required) — balance to check
 
-**Source:** [src/base/strkey.ts:313](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L313)
+**Source:** [src/base/strkey.ts:334](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L334)
 
 ### `StrKey.isValidContract(address)`
 
@@ -780,7 +780,7 @@ static isValidContract(address: string): boolean;
 
 - **`address`** — `string` (required) — signer key to check
 
-**Source:** [src/base/strkey.ts:286](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L286)
+**Source:** [src/base/strkey.ts:307](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L307)
 
 ### `StrKey.isValidEd25519PublicKey(publicKey)`
 
@@ -794,7 +794,7 @@ static isValidEd25519PublicKey(publicKey: string): boolean;
 
 - **`publicKey`** — `string` (required) — public key to check
 
-**Source:** [src/base/strkey.ts:142](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L142)
+**Source:** [src/base/strkey.ts:163](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L163)
 
 ### `StrKey.isValidEd25519SecretSeed(seed)`
 
@@ -808,7 +808,7 @@ static isValidEd25519SecretSeed(seed: string): boolean;
 
 - **`seed`** — `string` (required) — seed to check
 
-**Source:** [src/base/strkey.ts:169](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L169)
+**Source:** [src/base/strkey.ts:190](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L190)
 
 ### `StrKey.isValidLiquidityPool(address)`
 
@@ -822,7 +822,7 @@ static isValidLiquidityPool(address: string): boolean;
 
 - **`address`** — `string` (required) — pool to check
 
-**Source:** [src/base/strkey.ts:340](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L340)
+**Source:** [src/base/strkey.ts:361](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L361)
 
 ### `StrKey.isValidMed25519PublicKey(publicKey)`
 
@@ -836,7 +836,7 @@ static isValidMed25519PublicKey(publicKey: string): boolean;
 
 - **`publicKey`** — `string` (required) — public key to check
 
-**Source:** [src/base/strkey.ts:196](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L196)
+**Source:** [src/base/strkey.ts:217](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L217)
 
 ### `StrKey.isValidSignedPayload(address)`
 
@@ -850,7 +850,7 @@ static isValidSignedPayload(address: string): boolean;
 
 - **`address`** — `string` (required) — signer key to check
 
-**Source:** [src/base/strkey.ts:259](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L259)
+**Source:** [src/base/strkey.ts:280](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L280)
 
 ## sign
 

--- a/src/base/strkey.ts
+++ b/src/base/strkey.ts
@@ -106,6 +106,27 @@ function assertSignedPayloadFraming(data: Uint8Array): void {
 }
 
 /**
+ * Enforces the discriminant byte that leads a claimable balance id.
+ *
+ * `ClaimableBalanceID` is a union, and `CLAIMABLE_BALANCE_ID_TYPE_V0` (0) is
+ * its only case — so the XDR wire decoder rejects any other value. Nothing in
+ * the strkey encoding does: the checksum covers whatever byte is there. Without
+ * this, a `B...` key with an unknown discriminant is vouched for by
+ * `isValidClaimableBalance` while the wire decoder refuses it.
+ *
+ * The length needs no check — `claimableBalance` has a fixed 58-character
+ * encoded length, so `decodeCheck` has already pinned the payload at 33 bytes.
+ */
+function assertClaimableBalanceDiscriminant(data: Uint8Array): void {
+  if (data[0] !== 0) {
+    throw new Error(
+      `claimable balance: unknown discriminant ${data[0]}, expected 0 ` +
+        `(CLAIMABLE_BALANCE_ID_TYPE_V0)`,
+    );
+  }
+}
+
+/**
  * StrKey is a helper class that allows encoding and decoding Stellar keys
  * to/from strings, i.e. between their binary (Uint8Array, xdr.PublicKey, etc.) and
  * string (i.e. "GABCD...", etc.) representations.
@@ -391,6 +412,7 @@ function isValid(versionByteName: string, encoded: unknown): boolean {
       return decoded.length === 32;
 
     case "claimableBalance":
+      // the discriminant byte's value is enforced by `decodeCheck`
       return decoded.length === 32 + 1; // +1 byte for discriminant
 
     case "med25519PublicKey":
@@ -463,6 +485,10 @@ export function decodeCheck(
 
   if (versionByteName === "signedPayload") {
     assertSignedPayloadFraming(data);
+  }
+
+  if (versionByteName === "claimableBalance") {
+    assertClaimableBalanceDiscriminant(data);
   }
 
   return data;

--- a/src/xdr/generated/account-entry-ext.ts
+++ b/src/xdr/generated/account-entry-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   AccountEntryExtensionV1,
@@ -65,6 +65,11 @@ abstract class AccountEntryExtBase extends XdrValue {
           AccountEntryExtensionV1.fromXdrObject(wire.v1),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `AccountEntryExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/account-entry-extension-v1-ext.ts
+++ b/src/xdr/generated/account-entry-extension-v1-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   AccountEntryExtensionV2,
@@ -67,6 +67,11 @@ abstract class AccountEntryExtensionV1ExtBase extends XdrValue {
           AccountEntryExtensionV2.fromXdrObject(wire.v2),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `AccountEntryExtensionV1Ext: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/account-entry-extension-v2-ext.ts
+++ b/src/xdr/generated/account-entry-extension-v2-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   AccountEntryExtensionV3,
@@ -67,6 +67,11 @@ abstract class AccountEntryExtensionV2ExtBase extends XdrValue {
           AccountEntryExtensionV3.fromXdrObject(wire.v3),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `AccountEntryExtensionV2Ext: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/account-merge-result.ts
+++ b/src/xdr/generated/account-merge-result.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { AccountMergeResultCode } from "./account-merge-result-code.js";
 
@@ -124,6 +124,11 @@ abstract class AccountMergeResultBase extends XdrValue {
       case -7:
         return new AccountMergeResultIsSponsor();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `AccountMergeResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/allow-trust-result.ts
+++ b/src/xdr/generated/allow-trust-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { AllowTrustResultCode } from "./allow-trust-result-code.js";
 
@@ -106,6 +106,11 @@ abstract class AllowTrustResultBase extends XdrValue {
       case -6:
         return new AllowTrustResultLowReserve();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `AllowTrustResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/asset-code.ts
+++ b/src/xdr/generated/asset-code.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { AssetType } from "./asset-type.js";
 import { AssetCode4, type AssetCode4Wire } from "./asset-code4.js";
@@ -73,6 +73,11 @@ abstract class AssetCodeBase extends XdrValue {
           AssetCode12.fromXdrObject(wire.assetCode12),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `AssetCode: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/asset.ts
+++ b/src/xdr/generated/asset.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { AssetType } from "./asset-type.js";
 import { AlphaNum4, type AlphaNum4Wire } from "./alpha-num4.js";
@@ -83,6 +83,11 @@ abstract class AssetBase extends XdrValue {
           AlphaNum12.fromXdrObject(wire.alphaNum12),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `Asset: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/authenticated-message.ts
+++ b/src/xdr/generated/authenticated-message.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, uint32, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   AuthenticatedMessageV0,
@@ -51,6 +51,11 @@ abstract class AuthenticatedMessageBase extends XdrValue {
           AuthenticatedMessageV0.fromXdrObject(wire.v0),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `AuthenticatedMessage: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/begin-sponsoring-future-reserves-result.ts
+++ b/src/xdr/generated/begin-sponsoring-future-reserves-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { BeginSponsoringFutureReservesResultCode } from "./begin-sponsoring-future-reserves-result-code.js";
 
@@ -77,6 +77,11 @@ abstract class BeginSponsoringFutureReservesResultBase extends XdrValue {
       case -3:
         return new BeginSponsoringFutureReservesResultRecursive();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `BeginSponsoringFutureReservesResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/bucket-entry.ts
+++ b/src/xdr/generated/bucket-entry.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { BucketEntryType } from "./bucket-entry-type.js";
 import { LedgerEntry, type LedgerEntryWire } from "./ledger-entry.js";
@@ -85,6 +85,11 @@ abstract class BucketEntryBase extends XdrValue {
           BucketMetadata.fromXdrObject(wire.metaEntry),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `BucketEntry: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/bucket-metadata-ext.ts
+++ b/src/xdr/generated/bucket-metadata-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { BucketListType, type BucketListTypeWire } from "./bucket-list-type.js";
 
@@ -68,6 +68,11 @@ abstract class BucketMetadataExtBase extends XdrValue {
           BucketListType.fromXdrObject(wire.bucketListType),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `BucketMetadataExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/bump-sequence-result.ts
+++ b/src/xdr/generated/bump-sequence-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { BumpSequenceResultCode } from "./bump-sequence-result-code.js";
 
@@ -54,6 +54,11 @@ abstract class BumpSequenceResultBase extends XdrValue {
       case -1:
         return new BumpSequenceResultBadSeq();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `BumpSequenceResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/change-trust-asset.ts
+++ b/src/xdr/generated/change-trust-asset.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { AssetType } from "./asset-type.js";
 import { AlphaNum4, type AlphaNum4Wire } from "./alpha-num4.js";
@@ -112,6 +112,11 @@ abstract class ChangeTrustAssetBase extends XdrValue {
           LiquidityPoolParameters.fromXdrObject(wire.liquidityPool),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ChangeTrustAsset: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/change-trust-result.ts
+++ b/src/xdr/generated/change-trust-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ChangeTrustResultCode } from "./change-trust-result-code.js";
 
@@ -126,6 +126,11 @@ abstract class ChangeTrustResultBase extends XdrValue {
       case -8:
         return new ChangeTrustResultNotAuthMaintainLiabilities();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ChangeTrustResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/claim-atom.ts
+++ b/src/xdr/generated/claim-atom.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ClaimAtomType } from "./claim-atom-type.js";
 import {
@@ -86,6 +86,11 @@ abstract class ClaimAtomBase extends XdrValue {
           ClaimLiquidityAtom.fromXdrObject(wire.liquidityPool),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ClaimAtom: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/claim-claimable-balance-result.ts
+++ b/src/xdr/generated/claim-claimable-balance-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ClaimClaimableBalanceResultCode } from "./claim-claimable-balance-result-code.js";
 
@@ -108,6 +108,11 @@ abstract class ClaimClaimableBalanceResultBase extends XdrValue {
       case -6:
         return new ClaimClaimableBalanceResultTrustlineFrozen();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ClaimClaimableBalanceResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/claim-predicate.ts
+++ b/src/xdr/generated/claim-predicate.ts
@@ -12,7 +12,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ClaimPredicateType } from "./claim-predicate-type.js";
 
@@ -155,6 +155,11 @@ abstract class ClaimPredicateBase extends XdrValue {
       case 5:
         return new ClaimPredicateBeforeRelativeTime(wire.relBefore);
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ClaimPredicate: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/claimable-balance-entry-ext.ts
+++ b/src/xdr/generated/claimable-balance-entry-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   ClaimableBalanceEntryExtensionV1,
@@ -67,6 +67,11 @@ abstract class ClaimableBalanceEntryExtBase extends XdrValue {
           ClaimableBalanceEntryExtensionV1.fromXdrObject(wire.v1),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ClaimableBalanceEntryExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/claimable-balance-entry-extension-v1-ext.ts
+++ b/src/xdr/generated/claimable-balance-entry-extension-v1-ext.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, int32, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 
 export type ClaimableBalanceEntryExtensionV1ExtWire = { v: 0 };
@@ -40,6 +40,11 @@ abstract class ClaimableBalanceEntryExtensionV1ExtBase extends XdrValue {
       case 0:
         return new ClaimableBalanceEntryExtensionV1ExtV0();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ClaimableBalanceEntryExtensionV1Ext: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/claimable-balance-id.ts
+++ b/src/xdr/generated/claimable-balance-id.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ClaimableBalanceIdType } from "./claimable-balance-id-type.js";
 import { Hash, type HashWire } from "./hash.js";
@@ -43,6 +43,11 @@ abstract class ClaimableBalanceIdBase extends XdrValue {
       case 0:
         return new ClaimableBalanceIdV0(Hash.fromXdrObject(wire.v0));
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ClaimableBalanceId: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/claimant.ts
+++ b/src/xdr/generated/claimant.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ClaimantType } from "./claimant-type.js";
 import { ClaimantV0, type ClaimantV0Wire } from "./claimant-v0.js";
@@ -42,6 +42,11 @@ abstract class ClaimantBase extends XdrValue {
       case 0:
         return new ClaimantV0Arm(ClaimantV0.fromXdrObject(wire.v0));
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `Claimant: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/clawback-claimable-balance-result.ts
+++ b/src/xdr/generated/clawback-claimable-balance-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ClawbackClaimableBalanceResultCode } from "./clawback-claimable-balance-result-code.js";
 
@@ -79,6 +79,11 @@ abstract class ClawbackClaimableBalanceResultBase extends XdrValue {
       case -3:
         return new ClawbackClaimableBalanceResultNotClawbackEnabled();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ClawbackClaimableBalanceResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/clawback-result.ts
+++ b/src/xdr/generated/clawback-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ClawbackResultCode } from "./clawback-result-code.js";
 
@@ -86,6 +86,11 @@ abstract class ClawbackResultBase extends XdrValue {
       case -4:
         return new ClawbackResultUnderfunded();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ClawbackResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/config-setting-entry.ts
+++ b/src/xdr/generated/config-setting-entry.ts
@@ -10,7 +10,7 @@ import {
   uint64,
   union,
 } from "@stellar/js-xdr";
-import { UNBOUNDED_MAX_LENGTH, type XdrType } from "@stellar/js-xdr";
+import { UNBOUNDED_MAX_LENGTH, XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ConfigSettingId } from "./config-setting-id.js";
 import {
@@ -579,6 +579,11 @@ abstract class ConfigSettingEntryBase extends XdrValue {
           FreezeBypassTxsDelta.fromXdrObject(wire.freezeBypassTxsDelta),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ConfigSettingEntry: unknown configSettingID ${(wire as { configSettingID: unknown }).configSettingID}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/contract-code-entry-ext.ts
+++ b/src/xdr/generated/contract-code-entry-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   ContractCodeEntryV1,
@@ -69,6 +69,11 @@ abstract class ContractCodeEntryExtBase extends XdrValue {
           ContractCodeEntryV1.fromXdrObject(wire.v1),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ContractCodeEntryExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/contract-event-body.ts
+++ b/src/xdr/generated/contract-event-body.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, int32, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   ContractEventV0,
@@ -48,6 +48,11 @@ abstract class ContractEventBodyBase extends XdrValue {
       case 0:
         return new ContractEventBodyV0(ContractEventV0.fromXdrObject(wire.v0));
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ContractEventBody: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/contract-executable.ts
+++ b/src/xdr/generated/contract-executable.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ContractExecutableType } from "./contract-executable-type.js";
 import { Hash, type HashWire } from "./hash.js";
@@ -81,6 +81,11 @@ abstract class ContractExecutableBase extends XdrValue {
           ContractExecutableExternalRef.fromXdrObject(wire.externalRef),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ContractExecutable: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/contract-id-preimage.ts
+++ b/src/xdr/generated/contract-id-preimage.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ContractIdPreimageType } from "./contract-id-preimage-type.js";
 import {
@@ -78,6 +78,11 @@ abstract class ContractIdPreimageBase extends XdrValue {
       case 1:
         return new ContractIdPreimageAsset(Asset.fromXdrObject(wire.fromAsset));
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ContractIdPreimage: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/create-account-result.ts
+++ b/src/xdr/generated/create-account-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { CreateAccountResultCode } from "./create-account-result-code.js";
 
@@ -86,6 +86,11 @@ abstract class CreateAccountResultBase extends XdrValue {
       case -4:
         return new CreateAccountResultAlreadyExist();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `CreateAccountResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/create-claimable-balance-result.ts
+++ b/src/xdr/generated/create-claimable-balance-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { CreateClaimableBalanceResultCode } from "./create-claimable-balance-result-code.js";
 import {
@@ -111,6 +111,11 @@ abstract class CreateClaimableBalanceResultBase extends XdrValue {
       case -5:
         return new CreateClaimableBalanceResultUnderfunded();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `CreateClaimableBalanceResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/data-entry-ext.ts
+++ b/src/xdr/generated/data-entry-ext.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, int32, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 
 export type DataEntryExtWire = { v: 0 };
@@ -37,6 +37,9 @@ abstract class DataEntryExtBase extends XdrValue {
       case 0:
         return new DataEntryExtV0();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(`DataEntryExt: unknown v ${(wire as { v: unknown }).v}`);
   }
 
   /**

--- a/src/xdr/generated/end-sponsoring-future-reserves-result.ts
+++ b/src/xdr/generated/end-sponsoring-future-reserves-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { EndSponsoringFutureReservesResultCode } from "./end-sponsoring-future-reserves-result-code.js";
 
@@ -55,6 +55,11 @@ abstract class EndSponsoringFutureReservesResultBase extends XdrValue {
       case -1:
         return new EndSponsoringFutureReservesResultNotSponsored();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `EndSponsoringFutureReservesResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/extend-footprint-ttl-result.ts
+++ b/src/xdr/generated/extend-footprint-ttl-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ExtendFootprintTtlResultCode } from "./extend-footprint-ttl-result-code.js";
 
@@ -78,6 +78,11 @@ abstract class ExtendFootprintTtlResultBase extends XdrValue {
       case -3:
         return new ExtendFootprintTtlResultInsufficientRefundableFee();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ExtendFootprintTtlResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/extension-point.ts
+++ b/src/xdr/generated/extension-point.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, int32, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 
 export type ExtensionPointWire = { v: 0 };
@@ -40,6 +40,11 @@ abstract class ExtensionPointBase extends XdrValue {
       case 0:
         return new ExtensionPointV0();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ExtensionPoint: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/fee-bump-transaction-ext.ts
+++ b/src/xdr/generated/fee-bump-transaction-ext.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, int32, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 
 export type FeeBumpTransactionExtWire = { v: 0 };
@@ -40,6 +40,11 @@ abstract class FeeBumpTransactionExtBase extends XdrValue {
       case 0:
         return new FeeBumpTransactionExtV0();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `FeeBumpTransactionExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/fee-bump-transaction-inner-tx.ts
+++ b/src/xdr/generated/fee-bump-transaction-inner-tx.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { EnvelopeType } from "./envelope-type.js";
 import {
@@ -55,6 +55,11 @@ abstract class FeeBumpTransactionInnerTxBase extends XdrValue {
           TransactionV1Envelope.fromXdrObject(wire.v1),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `FeeBumpTransactionInnerTx: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/generalized-transaction-set.ts
+++ b/src/xdr/generated/generalized-transaction-set.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, int32, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   TransactionSetV1,
@@ -52,6 +52,11 @@ abstract class GeneralizedTransactionSetBase extends XdrValue {
           TransactionSetV1.fromXdrObject(wire.v1TxSet),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `GeneralizedTransactionSet: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/hash-id-preimage.ts
+++ b/src/xdr/generated/hash-id-preimage.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { EnvelopeType } from "./envelope-type.js";
 import {
@@ -192,6 +192,11 @@ abstract class HashIdPreimageBase extends XdrValue {
           ),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `HashIdPreimage: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/host-function.ts
+++ b/src/xdr/generated/host-function.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, varOpaque } from "@stellar/js-xdr";
-import { UNBOUNDED_MAX_LENGTH, type XdrType } from "@stellar/js-xdr";
+import { UNBOUNDED_MAX_LENGTH, XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { HostFunctionType } from "./host-function-type.js";
 import {
@@ -116,6 +116,11 @@ abstract class HostFunctionBase extends XdrValue {
           CreateContractArgsV2.fromXdrObject(wire.createContractV2),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `HostFunction: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/hot-archive-bucket-entry.ts
+++ b/src/xdr/generated/hot-archive-bucket-entry.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { HotArchiveBucketEntryType } from "./hot-archive-bucket-entry-type.js";
 import { LedgerEntry, type LedgerEntryWire } from "./ledger-entry.js";
@@ -86,6 +86,11 @@ abstract class HotArchiveBucketEntryBase extends XdrValue {
           BucketMetadata.fromXdrObject(wire.metaEntry),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `HotArchiveBucketEntry: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/inflation-result.ts
+++ b/src/xdr/generated/inflation-result.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import { UNBOUNDED_MAX_LENGTH, type XdrType } from "@stellar/js-xdr";
+import { UNBOUNDED_MAX_LENGTH, XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { InflationResultCode } from "./inflation-result-code.js";
 import {
@@ -72,6 +72,11 @@ abstract class InflationResultBase extends XdrValue {
       case -1:
         return new InflationResultNotTime();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `InflationResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/inner-transaction-result-ext.ts
+++ b/src/xdr/generated/inner-transaction-result-ext.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, int32, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 
 export type InnerTransactionResultExtWire = { v: 0 };
@@ -42,6 +42,11 @@ abstract class InnerTransactionResultExtBase extends XdrValue {
       case 0:
         return new InnerTransactionResultExtV0();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `InnerTransactionResultExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/inner-transaction-result-result.ts
+++ b/src/xdr/generated/inner-transaction-result-result.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import { UNBOUNDED_MAX_LENGTH, type XdrType } from "@stellar/js-xdr";
+import { UNBOUNDED_MAX_LENGTH, XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { TransactionResultCode } from "./transaction-result-code.js";
 import {
@@ -246,6 +246,11 @@ abstract class InnerTransactionResultResultBase extends XdrValue {
       case -18:
         return new InnerTransactionResultResultTxFrozenKeyAccessed();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `InnerTransactionResultResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/invoke-host-function-result.ts
+++ b/src/xdr/generated/invoke-host-function-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { InvokeHostFunctionResultCode } from "./invoke-host-function-result-code.js";
 import { Hash, type HashWire } from "./hash.js";
@@ -103,6 +103,11 @@ abstract class InvokeHostFunctionResultBase extends XdrValue {
       case -5:
         return new InvokeHostFunctionResultInsufficientRefundableFee();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `InvokeHostFunctionResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/ledger-close-meta-ext.ts
+++ b/src/xdr/generated/ledger-close-meta-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   LedgerCloseMetaExtV1,
@@ -65,6 +65,11 @@ abstract class LedgerCloseMetaExtBase extends XdrValue {
           LedgerCloseMetaExtV1.fromXdrObject(wire.v1),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LedgerCloseMetaExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/ledger-close-meta.ts
+++ b/src/xdr/generated/ledger-close-meta.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, int32, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   LedgerCloseMetaV0,
@@ -81,6 +81,11 @@ abstract class LedgerCloseMetaBase extends XdrValue {
           LedgerCloseMetaV2.fromXdrObject(wire.v2),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LedgerCloseMeta: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/ledger-entry-change.ts
+++ b/src/xdr/generated/ledger-entry-change.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { LedgerEntryChangeType } from "./ledger-entry-change-type.js";
 import { LedgerEntry, type LedgerEntryWire } from "./ledger-entry.js";
@@ -100,6 +100,11 @@ abstract class LedgerEntryChangeBase extends XdrValue {
           LedgerEntry.fromXdrObject(wire.restored),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LedgerEntryChange: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/ledger-entry-data.ts
+++ b/src/xdr/generated/ledger-entry-data.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { LedgerEntryType } from "./ledger-entry-type.js";
 import { AccountEntry, type AccountEntryWire } from "./account-entry.js";
@@ -212,6 +212,11 @@ abstract class LedgerEntryDataBase extends XdrValue {
       case 9:
         return new LedgerEntryDataTtl(TtlEntry.fromXdrObject(wire.ttl));
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LedgerEntryData: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/ledger-entry-ext.ts
+++ b/src/xdr/generated/ledger-entry-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   LedgerEntryExtensionV1,
@@ -65,6 +65,11 @@ abstract class LedgerEntryExtBase extends XdrValue {
           LedgerEntryExtensionV1.fromXdrObject(wire.v1),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LedgerEntryExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/ledger-entry-extension-v1-ext.ts
+++ b/src/xdr/generated/ledger-entry-extension-v1-ext.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, int32, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 
 export type LedgerEntryExtensionV1ExtWire = { v: 0 };
@@ -42,6 +42,11 @@ abstract class LedgerEntryExtensionV1ExtBase extends XdrValue {
       case 0:
         return new LedgerEntryExtensionV1ExtV0();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LedgerEntryExtensionV1Ext: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/ledger-header-ext.ts
+++ b/src/xdr/generated/ledger-header-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   LedgerHeaderExtensionV1,
@@ -65,6 +65,11 @@ abstract class LedgerHeaderExtBase extends XdrValue {
           LedgerHeaderExtensionV1.fromXdrObject(wire.v1),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LedgerHeaderExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/ledger-header-extension-v1-ext.ts
+++ b/src/xdr/generated/ledger-header-extension-v1-ext.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, int32, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 
 export type LedgerHeaderExtensionV1ExtWire = { v: 0 };
@@ -42,6 +42,11 @@ abstract class LedgerHeaderExtensionV1ExtBase extends XdrValue {
       case 0:
         return new LedgerHeaderExtensionV1ExtV0();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LedgerHeaderExtensionV1Ext: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/ledger-header-history-entry-ext.ts
+++ b/src/xdr/generated/ledger-header-history-entry-ext.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, int32, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 
 export type LedgerHeaderHistoryEntryExtWire = { v: 0 };
@@ -42,6 +42,11 @@ abstract class LedgerHeaderHistoryEntryExtBase extends XdrValue {
       case 0:
         return new LedgerHeaderHistoryEntryExtV0();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LedgerHeaderHistoryEntryExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/ledger-key.ts
+++ b/src/xdr/generated/ledger-key.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { LedgerEntryType } from "./ledger-entry-type.js";
 import {
@@ -256,6 +256,11 @@ abstract class LedgerKeyBase extends XdrValue {
       case 9:
         return new LedgerKeyTtlArm(LedgerKeyTtl.fromXdrObject(wire.ttl));
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LedgerKey: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/ledger-upgrade.ts
+++ b/src/xdr/generated/ledger-upgrade.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, uint32, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { LedgerUpgradeType } from "./ledger-upgrade-type.js";
 import {
@@ -134,6 +134,11 @@ abstract class LedgerUpgradeBase extends XdrValue {
           wire.newMaxSorobanTxSetSize,
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LedgerUpgrade: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/liquidity-pool-deposit-result.ts
+++ b/src/xdr/generated/liquidity-pool-deposit-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { LiquidityPoolDepositResultCode } from "./liquidity-pool-deposit-result-code.js";
 
@@ -128,6 +128,11 @@ abstract class LiquidityPoolDepositResultBase extends XdrValue {
       case -8:
         return new LiquidityPoolDepositResultTrustlineFrozen();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LiquidityPoolDepositResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/liquidity-pool-entry-body.ts
+++ b/src/xdr/generated/liquidity-pool-entry-body.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { LiquidityPoolType } from "./liquidity-pool-type.js";
 import {
@@ -70,6 +70,11 @@ abstract class LiquidityPoolEntryBodyBase extends XdrValue {
           LiquidityPoolEntryConstantProduct.fromXdrObject(wire.constantProduct),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LiquidityPoolEntryBody: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/liquidity-pool-parameters.ts
+++ b/src/xdr/generated/liquidity-pool-parameters.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { LiquidityPoolType } from "./liquidity-pool-type.js";
 import {
@@ -66,6 +66,11 @@ abstract class LiquidityPoolParametersBase extends XdrValue {
           ),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LiquidityPoolParameters: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/liquidity-pool-withdraw-result.ts
+++ b/src/xdr/generated/liquidity-pool-withdraw-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { LiquidityPoolWithdrawResultCode } from "./liquidity-pool-withdraw-result-code.js";
 
@@ -108,6 +108,11 @@ abstract class LiquidityPoolWithdrawResultBase extends XdrValue {
       case -6:
         return new LiquidityPoolWithdrawResultTrustlineFrozen();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `LiquidityPoolWithdrawResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/manage-buy-offer-result.ts
+++ b/src/xdr/generated/manage-buy-offer-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ManageBuyOfferResultCode } from "./manage-buy-offer-result-code.js";
 import {
@@ -178,6 +178,11 @@ abstract class ManageBuyOfferResultBase extends XdrValue {
       case -12:
         return new ManageBuyOfferResultLowReserve();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ManageBuyOfferResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/manage-data-result.ts
+++ b/src/xdr/generated/manage-data-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ManageDataResultCode } from "./manage-data-result-code.js";
 
@@ -86,6 +86,11 @@ abstract class ManageDataResultBase extends XdrValue {
       case -4:
         return new ManageDataResultInvalidName();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ManageDataResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/manage-offer-success-result-offer.ts
+++ b/src/xdr/generated/manage-offer-success-result-offer.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ManageOfferEffect } from "./manage-offer-effect.js";
 import { OfferEntry, type OfferEntryWire } from "./offer-entry.js";
@@ -77,6 +77,11 @@ abstract class ManageOfferSuccessResultOfferBase extends XdrValue {
       case 2:
         return new ManageOfferSuccessResultOfferDeleted();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ManageOfferSuccessResultOffer: unknown effect ${(wire as { effect: unknown }).effect}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/manage-sell-offer-result.ts
+++ b/src/xdr/generated/manage-sell-offer-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ManageSellOfferResultCode } from "./manage-sell-offer-result-code.js";
 import {
@@ -178,6 +178,11 @@ abstract class ManageSellOfferResultBase extends XdrValue {
       case -12:
         return new ManageSellOfferResultLowReserve();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ManageSellOfferResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/memo.ts
+++ b/src/xdr/generated/memo.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { XdrString, xdrString } from "../values/xdr-string.js";
 import { MemoType } from "./memo-type.js";
@@ -93,6 +93,11 @@ abstract class MemoBase extends XdrValue {
       case 4:
         return new MemoReturn(Hash.fromXdrObject(wire.retHash));
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `Memo: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/muxed-account.ts
+++ b/src/xdr/generated/muxed-account.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, opaque, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { CryptoKeyType } from "./crypto-key-type.js";
 import {
@@ -66,6 +66,11 @@ abstract class MuxedAccountBase extends XdrValue {
           MuxedAccountMed25519.fromXdrObject(wire.med25519),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `MuxedAccount: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/offer-entry-ext.ts
+++ b/src/xdr/generated/offer-entry-ext.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, int32, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 
 export type OfferEntryExtWire = { v: 0 };
@@ -37,6 +37,11 @@ abstract class OfferEntryExtBase extends XdrValue {
       case 0:
         return new OfferEntryExtV0();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `OfferEntryExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/operation-body.ts
+++ b/src/xdr/generated/operation-body.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { OperationType } from "./operation-type.js";
 import {
@@ -575,6 +575,11 @@ abstract class OperationBodyBase extends XdrValue {
           RestoreFootprintOp.fromXdrObject(wire.restoreFootprintOp),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `OperationBody: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/operation-result-tr.ts
+++ b/src/xdr/generated/operation-result-tr.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { OperationType } from "./operation-type.js";
 import {
@@ -707,6 +707,11 @@ abstract class OperationResultTrBase extends XdrValue {
           RestoreFootprintResult.fromXdrObject(wire.restoreFootprintResult),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `OperationResultTr: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/operation-result.ts
+++ b/src/xdr/generated/operation-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { OperationResultCode } from "./operation-result-code.js";
 import {
@@ -169,6 +169,11 @@ abstract class OperationResultBase extends XdrValue {
       case -6:
         return new OperationResultOpTooManySponsoring();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `OperationResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/path-payment-strict-receive-result.ts
+++ b/src/xdr/generated/path-payment-strict-receive-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { PathPaymentStrictReceiveResultCode } from "./path-payment-strict-receive-result-code.js";
 import {
@@ -196,6 +196,11 @@ abstract class PathPaymentStrictReceiveResultBase extends XdrValue {
       case -12:
         return new PathPaymentStrictReceiveResultOverSendmax();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `PathPaymentStrictReceiveResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/path-payment-strict-send-result.ts
+++ b/src/xdr/generated/path-payment-strict-send-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { PathPaymentStrictSendResultCode } from "./path-payment-strict-send-result-code.js";
 import {
@@ -195,6 +195,11 @@ abstract class PathPaymentStrictSendResultBase extends XdrValue {
       case -12:
         return new PathPaymentStrictSendResultUnderDestmin();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `PathPaymentStrictSendResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/payment-result.ts
+++ b/src/xdr/generated/payment-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { PaymentResultCode } from "./payment-result-code.js";
 
@@ -133,6 +133,11 @@ abstract class PaymentResultBase extends XdrValue {
       case -9:
         return new PaymentResultNoIssuer();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `PaymentResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/peer-address-ip.ts
+++ b/src/xdr/generated/peer-address-ip.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, opaque, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { IpAddrType } from "./ip-addr-type.js";
 
@@ -50,6 +50,11 @@ abstract class PeerAddressIpBase extends XdrValue {
       case 1:
         return new PeerAddressIpIPv6(wire.ipv6);
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `PeerAddressIp: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/persisted-scp-state.ts
+++ b/src/xdr/generated/persisted-scp-state.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, int32, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   PersistedScpStateV0,
@@ -65,6 +65,11 @@ abstract class PersistedScpStateBase extends XdrValue {
           PersistedScpStateV1.fromXdrObject(wire.v1),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `PersistedScpState: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/preconditions.ts
+++ b/src/xdr/generated/preconditions.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { PreconditionType } from "./precondition-type.js";
 import { TimeBounds, type TimeBoundsWire } from "./time-bounds.js";
@@ -68,6 +68,11 @@ abstract class PreconditionsBase extends XdrValue {
       case 2:
         return new PreconditionsV2Arm(PreconditionsV2.fromXdrObject(wire.v2));
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `Preconditions: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/public-key.ts
+++ b/src/xdr/generated/public-key.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, opaque, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { PublicKeyType } from "./public-key-type.js";
 
@@ -37,6 +37,11 @@ abstract class PublicKeyBase extends XdrValue {
       case 0:
         return new PublicKeyEd25519(wire.ed25519);
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `PublicKey: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/restore-footprint-result.ts
+++ b/src/xdr/generated/restore-footprint-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { RestoreFootprintResultCode } from "./restore-footprint-result-code.js";
 
@@ -78,6 +78,11 @@ abstract class RestoreFootprintResultBase extends XdrValue {
       case -3:
         return new RestoreFootprintResultInsufficientRefundableFee();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `RestoreFootprintResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/revoke-sponsorship-op.ts
+++ b/src/xdr/generated/revoke-sponsorship-op.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { RevokeSponsorshipType } from "./revoke-sponsorship-type.js";
 import { LedgerKey, type LedgerKeyWire } from "./ledger-key.js";
@@ -80,6 +80,11 @@ abstract class RevokeSponsorshipOpBase extends XdrValue {
           RevokeSponsorshipOpSigner.fromXdrObject(wire.signer),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `RevokeSponsorshipOp: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/revoke-sponsorship-result.ts
+++ b/src/xdr/generated/revoke-sponsorship-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { RevokeSponsorshipResultCode } from "./revoke-sponsorship-result-code.js";
 
@@ -98,6 +98,11 @@ abstract class RevokeSponsorshipResultBase extends XdrValue {
       case -5:
         return new RevokeSponsorshipResultMalformed();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `RevokeSponsorshipResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/sc-address.ts
+++ b/src/xdr/generated/sc-address.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ScAddressType } from "./sc-address-type.js";
 import { PublicKey, type PublicKeyWire } from "./public-key.js";
@@ -124,6 +124,11 @@ abstract class ScAddressBase extends XdrValue {
           PoolId.fromXdrObject(wire.liquidityPoolId),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ScAddress: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/sc-env-meta-entry.ts
+++ b/src/xdr/generated/sc-env-meta-entry.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ScEnvMetaKind } from "./sc-env-meta-kind.js";
 import {
@@ -61,6 +61,11 @@ abstract class ScEnvMetaEntryBase extends XdrValue {
           ScEnvMetaEntryInterfaceVersion.fromXdrObject(wire.interfaceVersion),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ScEnvMetaEntry: unknown kind ${(wire as { kind: unknown }).kind}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/sc-error.ts
+++ b/src/xdr/generated/sc-error.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, uint32, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ScErrorType } from "./sc-error-type.js";
 import { ScErrorCode, type ScErrorCodeWire } from "./sc-error-code.js";
@@ -133,6 +133,11 @@ abstract class ScErrorBase extends XdrValue {
       case 9:
         return new ScErrorAuth(ScErrorCode.fromXdrObject(wire.code));
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ScError: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/sc-meta-entry.ts
+++ b/src/xdr/generated/sc-meta-entry.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ScMetaKind } from "./sc-meta-kind.js";
 import { ScMetaV0, type ScMetaV0Wire } from "./sc-meta-v0.js";
@@ -39,6 +39,11 @@ abstract class ScMetaEntryBase extends XdrValue {
       case 0:
         return new ScMetaEntryScMetaV0(ScMetaV0.fromXdrObject(wire.v0));
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ScMetaEntry: unknown kind ${(wire as { kind: unknown }).kind}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/sc-spec-entry.ts
+++ b/src/xdr/generated/sc-spec-entry.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ScSpecEntryKind } from "./sc-spec-entry-kind.js";
 import {
@@ -160,6 +160,11 @@ abstract class ScSpecEntryBase extends XdrValue {
           ScSpecEventV0.fromXdrObject(wire.eventV0),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ScSpecEntry: unknown kind ${(wire as { kind: unknown }).kind}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/sc-spec-type-def.ts
+++ b/src/xdr/generated/sc-spec-type-def.ts
@@ -11,7 +11,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ScSpecType } from "./sc-spec-type.js";
 import {
@@ -354,6 +354,11 @@ abstract class ScSpecTypeDefBase extends XdrValue {
       case 2000:
         return new ScSpecTypeDefUdt(ScSpecTypeUdt.fromXdrObject(wire.udt));
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ScSpecTypeDef: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/sc-spec-udt-union-case-v0.ts
+++ b/src/xdr/generated/sc-spec-udt-union-case-v0.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ScSpecUdtUnionCaseV0Kind } from "./sc-spec-udt-union-case-v0-kind.js";
 import {
@@ -80,6 +80,11 @@ abstract class ScSpecUdtUnionCaseV0Base extends XdrValue {
           ScSpecUdtUnionCaseTupleV0.fromXdrObject(wire.tupleCase),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ScSpecUdtUnionCaseV0: unknown kind ${(wire as { kind: unknown }).kind}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/sc-val.ts
+++ b/src/xdr/generated/sc-val.ts
@@ -17,7 +17,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import { UNBOUNDED_MAX_LENGTH, type XdrType } from "@stellar/js-xdr";
+import { UNBOUNDED_MAX_LENGTH, XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { XdrString, xdrString } from "../values/xdr-string.js";
 import {
@@ -475,6 +475,11 @@ abstract class ScValBase extends XdrValue {
       case 22:
         return new ScValExecutableTag(wire.executableTag);
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ScVal: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/scp-history-entry.ts
+++ b/src/xdr/generated/scp-history-entry.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, int32, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   ScpHistoryEntryV0,
@@ -46,6 +46,11 @@ abstract class ScpHistoryEntryBase extends XdrValue {
           ScpHistoryEntryV0.fromXdrObject(wire.v0),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ScpHistoryEntry: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/scp-statement-pledges.ts
+++ b/src/xdr/generated/scp-statement-pledges.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { ScpStatementType } from "./scp-statement-type.js";
 import {
@@ -128,6 +128,11 @@ abstract class ScpStatementPledgesBase extends XdrValue {
           ScpNomination.fromXdrObject(wire.nominate),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `ScpStatementPledges: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/set-options-result.ts
+++ b/src/xdr/generated/set-options-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { SetOptionsResultCode } from "./set-options-result-code.js";
 
@@ -146,6 +146,11 @@ abstract class SetOptionsResultBase extends XdrValue {
       case -10:
         return new SetOptionsResultAuthRevocableRequired();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `SetOptionsResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/set-trust-line-flags-result.ts
+++ b/src/xdr/generated/set-trust-line-flags-result.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { SetTrustLineFlagsResultCode } from "./set-trust-line-flags-result-code.js";
 
@@ -98,6 +98,11 @@ abstract class SetTrustLineFlagsResultBase extends XdrValue {
       case -5:
         return new SetTrustLineFlagsResultLowReserve();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `SetTrustLineFlagsResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/signer-key.ts
+++ b/src/xdr/generated/signer-key.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, opaque, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { SignerKeyType } from "./signer-key-type.js";
 import {
@@ -96,6 +96,11 @@ abstract class SignerKeyBase extends XdrValue {
           ),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `SignerKey: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/soroban-authorized-function.ts
+++ b/src/xdr/generated/soroban-authorized-function.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { SorobanAuthorizedFunctionType } from "./soroban-authorized-function-type.js";
 import {
@@ -116,6 +116,11 @@ abstract class SorobanAuthorizedFunctionBase extends XdrValue {
           CreateContractArgsV2.fromXdrObject(wire.createContractV2HostFn),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `SorobanAuthorizedFunction: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/soroban-credentials.ts
+++ b/src/xdr/generated/soroban-credentials.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { SorobanCredentialsType } from "./soroban-credentials-type.js";
 import {
@@ -117,6 +117,11 @@ abstract class SorobanCredentialsBase extends XdrValue {
           ),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `SorobanCredentials: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/soroban-transaction-data-ext.ts
+++ b/src/xdr/generated/soroban-transaction-data-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   SorobanResourcesExtV0,
@@ -73,6 +73,11 @@ abstract class SorobanTransactionDataExtBase extends XdrValue {
           SorobanResourcesExtV0.fromXdrObject(wire.resourceExt),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `SorobanTransactionDataExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/soroban-transaction-meta-ext.ts
+++ b/src/xdr/generated/soroban-transaction-meta-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   SorobanTransactionMetaExtV1,
@@ -67,6 +67,11 @@ abstract class SorobanTransactionMetaExtBase extends XdrValue {
           SorobanTransactionMetaExtV1.fromXdrObject(wire.v1),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `SorobanTransactionMetaExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/stellar-message.ts
+++ b/src/xdr/generated/stellar-message.ts
@@ -10,7 +10,7 @@ import {
   uint32,
   union,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { MessageType } from "./message-type.js";
 import { Error, type ErrorWire } from "./error.js";
@@ -433,6 +433,11 @@ abstract class StellarMessageBase extends XdrValue {
           FloodDemand.fromXdrObject(wire.floodDemand),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `StellarMessage: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/stellar-value-ext.ts
+++ b/src/xdr/generated/stellar-value-ext.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { StellarValueType } from "./stellar-value-type.js";
 import {
@@ -97,6 +97,11 @@ abstract class StellarValueExtBase extends XdrValue {
           StellarValueProposedValue.fromXdrObject(wire.proposedValue),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `StellarValueExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/stored-transaction-set.ts
+++ b/src/xdr/generated/stored-transaction-set.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, int32, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { TransactionSet, type TransactionSetWire } from "./transaction-set.js";
 import {
@@ -68,6 +68,11 @@ abstract class StoredTransactionSetBase extends XdrValue {
           GeneralizedTransactionSet.fromXdrObject(wire.generalizedTxSet),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `StoredTransactionSet: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/survey-response-body.ts
+++ b/src/xdr/generated/survey-response-body.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { SurveyMessageResponseType } from "./survey-message-response-type.js";
 import {
@@ -59,6 +59,11 @@ abstract class SurveyResponseBodyBase extends XdrValue {
           TopologyResponseBodyV2.fromXdrObject(wire.topologyResponseBodyV2),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `SurveyResponseBody: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/transaction-envelope.ts
+++ b/src/xdr/generated/transaction-envelope.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { EnvelopeType } from "./envelope-type.js";
 import {
@@ -90,6 +90,11 @@ abstract class TransactionEnvelopeBase extends XdrValue {
           FeeBumpTransactionEnvelope.fromXdrObject(wire.feeBump),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TransactionEnvelope: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/transaction-ext.ts
+++ b/src/xdr/generated/transaction-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   SorobanTransactionData,
@@ -71,6 +71,11 @@ abstract class TransactionExtBase extends XdrValue {
           SorobanTransactionData.fromXdrObject(wire.sorobanData),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TransactionExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/transaction-history-entry-ext.ts
+++ b/src/xdr/generated/transaction-history-entry-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   GeneralizedTransactionSet,
@@ -73,6 +73,11 @@ abstract class TransactionHistoryEntryExtBase extends XdrValue {
           GeneralizedTransactionSet.fromXdrObject(wire.generalizedTxSet),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TransactionHistoryEntryExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/transaction-history-result-entry-ext.ts
+++ b/src/xdr/generated/transaction-history-result-entry-ext.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, int32, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 
 export type TransactionHistoryResultEntryExtWire = { v: 0 };
@@ -42,6 +42,11 @@ abstract class TransactionHistoryResultEntryExtBase extends XdrValue {
       case 0:
         return new TransactionHistoryResultEntryExtV0();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TransactionHistoryResultEntryExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/transaction-meta.ts
+++ b/src/xdr/generated/transaction-meta.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { array, case as case_, field, int32, union } from "@stellar/js-xdr";
-import { UNBOUNDED_MAX_LENGTH, type XdrType } from "@stellar/js-xdr";
+import { UNBOUNDED_MAX_LENGTH, XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { OperationMeta, type OperationMetaWire } from "./operation-meta.js";
 import {
@@ -122,6 +122,11 @@ abstract class TransactionMetaBase extends XdrValue {
           TransactionMetaV4.fromXdrObject(wire.v4),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TransactionMeta: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/transaction-phase.ts
+++ b/src/xdr/generated/transaction-phase.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { array, case as case_, field, int32, union } from "@stellar/js-xdr";
-import { UNBOUNDED_MAX_LENGTH, type XdrType } from "@stellar/js-xdr";
+import { UNBOUNDED_MAX_LENGTH, XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { TxSetComponent, type TxSetComponentWire } from "./tx-set-component.js";
 import {
@@ -79,6 +79,11 @@ abstract class TransactionPhaseBase extends XdrValue {
           ParallelTxsComponent.fromXdrObject(wire.parallelTxsComponent),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TransactionPhase: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/transaction-result-ext.ts
+++ b/src/xdr/generated/transaction-result-ext.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, int32, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 
 export type TransactionResultExtWire = { v: 0 };
@@ -40,6 +40,11 @@ abstract class TransactionResultExtBase extends XdrValue {
       case 0:
         return new TransactionResultExtV0();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TransactionResultExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/transaction-result-result.ts
+++ b/src/xdr/generated/transaction-result-result.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import { UNBOUNDED_MAX_LENGTH, type XdrType } from "@stellar/js-xdr";
+import { UNBOUNDED_MAX_LENGTH, XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { TransactionResultCode } from "./transaction-result-code.js";
 import {
@@ -284,6 +284,11 @@ abstract class TransactionResultResultBase extends XdrValue {
       case -18:
         return new TransactionResultResultTxFrozenKeyAccessed();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TransactionResultResult: unknown code ${(wire as { code: unknown }).code}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/transaction-signature-payload-tagged-transaction.ts
+++ b/src/xdr/generated/transaction-signature-payload-tagged-transaction.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { EnvelopeType } from "./envelope-type.js";
 import { Transaction, type TransactionWire } from "./transaction.js";
@@ -73,6 +73,11 @@ abstract class TransactionSignaturePayloadTaggedTransactionBase extends XdrValue
           FeeBumpTransaction.fromXdrObject(wire.feeBump),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TransactionSignaturePayloadTaggedTransaction: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/transaction-v0-ext.ts
+++ b/src/xdr/generated/transaction-v0-ext.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, int32, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 
 export type TransactionV0ExtWire = { v: 0 };
@@ -40,6 +40,11 @@ abstract class TransactionV0ExtBase extends XdrValue {
       case 0:
         return new TransactionV0ExtV0();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TransactionV0Ext: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/trust-line-asset.ts
+++ b/src/xdr/generated/trust-line-asset.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { AssetType } from "./asset-type.js";
 import { AlphaNum4, type AlphaNum4Wire } from "./alpha-num4.js";
@@ -103,6 +103,11 @@ abstract class TrustLineAssetBase extends XdrValue {
           PoolId.fromXdrObject(wire.liquidityPoolId),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TrustLineAsset: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/trust-line-entry-ext.ts
+++ b/src/xdr/generated/trust-line-entry-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   TrustLineEntryV1,
@@ -75,6 +75,11 @@ abstract class TrustLineEntryExtBase extends XdrValue {
       case 1:
         return new TrustLineEntryExtV1(TrustLineEntryV1.fromXdrObject(wire.v1));
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TrustLineEntryExt: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/trust-line-entry-extension-v2-ext.ts
+++ b/src/xdr/generated/trust-line-entry-extension-v2-ext.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, int32, union, void as voidType } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 
 export type TrustLineEntryExtensionV2ExtWire = { v: 0 };
@@ -42,6 +42,11 @@ abstract class TrustLineEntryExtensionV2ExtBase extends XdrValue {
       case 0:
         return new TrustLineEntryExtensionV2ExtV0();
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TrustLineEntryExtensionV2Ext: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/trust-line-entry-v1-ext.ts
+++ b/src/xdr/generated/trust-line-entry-v1-ext.ts
@@ -9,7 +9,7 @@ import {
   union,
   void as voidType,
 } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import {
   TrustLineEntryExtensionV2,
@@ -65,6 +65,11 @@ abstract class TrustLineEntryV1ExtBase extends XdrValue {
           TrustLineEntryExtensionV2.fromXdrObject(wire.v2),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TrustLineEntryV1Ext: unknown v ${(wire as { v: unknown }).v}`,
+    );
   }
 
   /**

--- a/src/xdr/generated/tx-set-component.ts
+++ b/src/xdr/generated/tx-set-component.ts
@@ -3,7 +3,7 @@
 // under class hoisting — every reference site runs after both classes are fully
 // initialized.
 import { case as case_, field, union } from "@stellar/js-xdr";
-import type { XdrType } from "@stellar/js-xdr";
+import { XdrError, type XdrType } from "@stellar/js-xdr";
 import { XdrValue } from "../values/xdr-value.js";
 import { TxSetComponentType } from "./tx-set-component-type.js";
 import {
@@ -68,6 +68,11 @@ abstract class TxSetComponentBase extends XdrValue {
           ),
         );
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      `TxSetComponent: unknown type ${(wire as { type: unknown }).type}`,
+    );
   }
 
   /**

--- a/src/xdr/values/bigint-parts.ts
+++ b/src/xdr/values/bigint-parts.ts
@@ -94,6 +94,32 @@ export function assertDecimalDigitBudget(
   }
 }
 
+/** An optionally-signed run of decimal digits, and nothing else. */
+const DECIMAL_INTEGER = /^[+-]?[0-9]+$/;
+
+/**
+ * Reject strings that `BigInt(...)` would accept but that do not denote a
+ * decimal integer, BEFORE they reach it.
+ *
+ * `BigInt` inherits the numeric-literal grammar, so it silently accepts `""`
+ * and `" "` as 0, and reads `"0x10"` as 16 — none of which are SEP-51 integer
+ * values. Each one decodes without complaint and re-serializes as a different
+ * string than it came in as, which is a value change rather than a parse error.
+ * `assertDecimalDigitBudget` does not catch these: it only bounds length.
+ *
+ * The accepted grammar matches the reference implementation
+ * (`@stellar/stellar-xdr-json`, which parses these fields with Rust's
+ * `from_str`), verified case by case: `"+7"`, `"01"`, `"0007"` and `"-0"` are
+ * accepted there and so are accepted here, even though they are not canonical
+ * and normalize on the way back out; `""`, `" "`, `"0x10"`, `"1e3"`, `" 7"` and
+ * `"7 "` are rejected there and are rejected here.
+ */
+export function assertDecimalString(s: string, name: string): void {
+  if (!DECIMAL_INTEGER.test(s)) {
+    throw new XdrError(`${name}: "${s}" is not a decimal integer string`);
+  }
+}
+
 /**
  * Number-valued counterpart of `assertBigIntFits` for the 32-bit `Int32`/
  * `Uint32` shims: validate that `value` is an integer within a `bits`-wide

--- a/src/xdr/values/to-json.ts
+++ b/src/xdr/values/to-json.ts
@@ -29,6 +29,7 @@ import {
 import {
   assertBigIntFits,
   assertDecimalDigitBudget,
+  assertDecimalString,
   bigIntTo128Parts,
   bigIntTo256Parts,
   partsTo128BigInt,
@@ -180,6 +181,7 @@ export function walkFromJson(
     case "uint64": {
       assertJsonType(json, "string", schema);
       assertDecimalDigitBudget(json as string, 64, schema.name ?? s.kind);
+      assertDecimalString(json as string, schema.name ?? s.kind);
       let value: bigint;
       try {
         value = BigInt(json as string);
@@ -799,6 +801,7 @@ OVERRIDES.set("Int128Parts", {
       throw new XdrError("Int128Parts: expected decimal string");
     }
     assertDecimalDigitBudget(json, 128, "Int128Parts");
+    assertDecimalString(json, "Int128Parts");
     const value = BigInt(json);
     assertBigIntFits(value, true, 128, "Int128Parts");
     return bigIntTo128Parts(value, true);
@@ -814,6 +817,7 @@ OVERRIDES.set("Uint128Parts", {
       throw new XdrError("Uint128Parts: expected decimal string");
     }
     assertDecimalDigitBudget(json, 128, "Uint128Parts");
+    assertDecimalString(json, "Uint128Parts");
     const value = BigInt(json);
     assertBigIntFits(value, false, 128, "Uint128Parts");
     return bigIntTo128Parts(value, false);
@@ -829,6 +833,7 @@ OVERRIDES.set("Int256Parts", {
       throw new XdrError("Int256Parts: expected decimal string");
     }
     assertDecimalDigitBudget(json, 256, "Int256Parts");
+    assertDecimalString(json, "Int256Parts");
     const value = BigInt(json);
     assertBigIntFits(value, true, 256, "Int256Parts");
     return bigIntTo256Parts(value, true);
@@ -844,6 +849,7 @@ OVERRIDES.set("Uint256Parts", {
       throw new XdrError("Uint256Parts: expected decimal string");
     }
     assertDecimalDigitBudget(json, 256, "Uint256Parts");
+    assertDecimalString(json, "Uint256Parts");
     const value = BigInt(json);
     assertBigIntFits(value, false, 256, "Uint256Parts");
     return bigIntTo256Parts(value, false);

--- a/test/unit/base/strkey.test.ts
+++ b/test/unit/base/strkey.test.ts
@@ -717,13 +717,16 @@ describe("StrKey", () => {
       });
     }
 
-    it("current limitation: claimable balance discriminant is not validated", () => {
+    it("rejects an unknown claimable balance discriminant", () => {
+      // CLAIMABLE_BALANCE_ID_TYPE_V0 (0) is the union's only case, so the wire
+      // decoder refuses anything else; the strkey checksum covers whatever
+      // discriminant byte is present, so this has to be checked separately.
       const invalidDiscriminant =
         "BAAT6DBUX6J22DMZOHIEZTEQ64CVCHEDRKWZONFEUL5Q26QD7R76RGXACA";
       expect(() =>
         decodeCheck("claimableBalance", invalidDiscriminant),
-      ).not.toThrow();
-      expect(StrKey.isValidClaimableBalance(invalidDiscriminant)).toBe(true);
+      ).toThrow(/unknown discriminant/);
+      expect(StrKey.isValidClaimableBalance(invalidDiscriminant)).toBe(false);
     });
   });
 });

--- a/test/unit/xdr/json_decode_rejects.test.ts
+++ b/test/unit/xdr/json_decode_rejects.test.ts
@@ -1,0 +1,180 @@
+// The JSON decoder is a second decoder running parallel to the schema: an
+// entry in `to-json.ts`'s OVERRIDES table short-circuits `walkFromJson` before
+// any schema-driven check and hand-builds a wire object from a strkey or a bare
+// string. Nothing downstream re-derives the schema's rules, so each override is
+// on its own to reject what the wire decoder would reject.
+//
+// Every bug in this family so far — #1581, #1583, #1585, #1588 — was one
+// override accepting a value `fromXdr` refuses, then silently re-encoding it as
+// something else. The parity monitor (`scripts/xdr-json-parity-monitor.ts`)
+// can't catch these: it replays real mainnet payloads, so it only ever exercises
+// values that are already valid. This is the negative half — the two decoders
+// must agree on what to *reject*.
+//
+// These inputs are caught at the outermost layer that can see them, so a case
+// here pins the behavior, not the layer: a bad claimable-balance discriminant
+// is rejected by `StrKey.decodeCheck` before the generated union's own guard
+// ever runs. That guard is covered directly, for every union, in
+// `union_dispatch.test.ts`.
+
+import { describe, it, expect } from "vitest";
+import { XdrError } from "@stellar/js-xdr";
+
+import { StrKey } from "../../../src/base/strkey.js";
+import {
+  AssetCode,
+  AssetCode4,
+  AssetCode12,
+  ClaimableBalanceId,
+  ClaimPredicate,
+  Int128Parts,
+  Int256Parts,
+  ScAddress,
+  ScVal,
+  Uint128Parts,
+  Uint256Parts,
+} from "../../../src/xdr/index.js";
+
+/** A `B...` strkey whose 33-byte payload leads with `discriminant`. */
+function claimableBalanceStrkey(discriminant: number): string {
+  const raw = new Uint8Array(33);
+  raw[0] = discriminant;
+  raw.set(new Uint8Array(32).fill(7), 1);
+  return StrKey.encodeClaimableBalance(raw);
+}
+
+interface RejectCase {
+  desc: string;
+  fromJson: () => unknown;
+  /**
+   * Expected message. Deliberately not an error *class*: a strkey-borne value
+   * is rejected by `StrKey.decodeCheck`, which throws a plain `Error` (as it
+   * does for a bad checksum or version byte), while a value that reaches the
+   * schema throws `XdrError`. Which layer catches it is an implementation
+   * detail; that it is caught, with a message naming the reason, is not.
+   */
+  message: RegExp;
+  /** Wire bytes denoting the same value, when they can be built at all. */
+  wire?: { decode: (bytes: Uint8Array) => unknown; bytes: Uint8Array };
+}
+
+// `ClaimableBalanceID` has exactly one case, CLAIMABLE_BALANCE_ID_TYPE_V0 (0).
+// The strkey checksum covers whatever discriminant byte is present, so a `B...`
+// key carrying another value is well-formed as a string and invalid as XDR.
+function claimableBalanceIdWire(discriminant: number): Uint8Array {
+  const bytes = new Uint8Array(4 + 32);
+  new DataView(bytes.buffer).setUint32(0, discriminant);
+  bytes.set(new Uint8Array(32).fill(7), 4);
+  return bytes;
+}
+
+const CASES: RejectCase[] = [
+  {
+    desc: "claimable balance id with an unknown discriminant",
+    fromJson: () => ClaimableBalanceId.fromJson(claimableBalanceStrkey(1)),
+    message: /unknown discriminant 1/,
+    wire: {
+      decode: (b) => ClaimableBalanceId.fromXdr(b),
+      bytes: claimableBalanceIdWire(1),
+    },
+  },
+  {
+    desc: "claimable balance id with a far out-of-range discriminant",
+    fromJson: () => ClaimableBalanceId.fromJson(claimableBalanceStrkey(255)),
+    message: /unknown discriminant 255/,
+    wire: {
+      decode: (b) => ClaimableBalanceId.fromXdr(b),
+      bytes: claimableBalanceIdWire(255),
+    },
+  },
+  {
+    desc: "sc address wrapping a bad claimable balance discriminant",
+    fromJson: () => ScAddress.fromJson(claimableBalanceStrkey(1)),
+    message: /unknown discriminant 1/,
+  },
+
+  // `padRightZeros` cannot truncate, so an over-long code would reach the
+  // opaque wrapper as a mis-sized buffer.
+  {
+    desc: "asset code longer than its 4-byte arm",
+    fromJson: () => AssetCode4.fromJson("ABCDEFGHIJ"),
+    message: /expected 4 byte\(s\), got 10/,
+  },
+  {
+    desc: "asset code longer than its 12-byte arm",
+    fromJson: () => AssetCode12.fromJson("ABCDEFGHIJKLMNOPQR"),
+    message: /expected 12 byte\(s\), got 18/,
+  },
+  {
+    desc: "flattened asset code longer than either arm",
+    fromJson: () => AssetCode.fromJson("ABCDEFGHIJKLMNOPQR"),
+    message: /expected 12 byte\(s\), got 18/,
+  },
+];
+
+// `BigInt()` inherits the numeric-literal grammar, so each of these parses to a
+// number that is not what the string says — a silent value change, not a parse
+// error. Verified case by case against the reference implementation
+// (`@stellar/stellar-xdr-json`): it rejects all of them.
+const NON_DECIMAL = ["", " ", "0x10", "0b11", "1e3", " 7", "7 ", "1_0", "٧"];
+
+// Accepted by the reference (Rust's `from_str`), so accepted here too, even
+// though they are not canonical and normalize on the way back out.
+const NON_CANONICAL_BUT_VALID: [string, bigint][] = [
+  ["+7", 7n],
+  ["01", 1n],
+  ["0007", 7n],
+  ["-0", 0n],
+];
+
+describe("JSON decoding rejects what XDR decoding rejects", () => {
+  for (const { desc, fromJson, message, wire } of CASES) {
+    describe(desc, () => {
+      it("is rejected by fromJson", () => {
+        expect(fromJson).toThrow(message);
+      });
+
+      if (wire) {
+        it("is rejected by fromXdr too", () => {
+          expect(() => wire.decode(wire.bytes)).toThrow(XdrError);
+        });
+      }
+    });
+  }
+
+  describe("integer fields reject non-decimal strings", () => {
+    for (const value of NON_DECIMAL) {
+      it(`int64 rejects ${JSON.stringify(value)}`, () => {
+        expect(() =>
+          ClaimPredicate.fromJson({ before_absolute_time: value }),
+        ).toThrow(XdrError);
+      });
+
+      it(`wide ints reject ${JSON.stringify(value)}`, () => {
+        // each `*Parts` class has its own wire type, so they can't share a
+        // loop variable — list the decoders as bare thunks instead
+        const decoders = [
+          () => Int128Parts.fromJson(value),
+          () => Uint128Parts.fromJson(value),
+          () => Int256Parts.fromJson(value),
+          () => Uint256Parts.fromJson(value),
+        ];
+        for (const decode of decoders) {
+          expect(decode).toThrow(XdrError);
+        }
+      });
+    }
+  });
+
+  describe("integer fields accept non-canonical decimal strings", () => {
+    for (const [value, expected] of NON_CANONICAL_BUT_VALID) {
+      it(`int64 accepts ${JSON.stringify(value)}`, () => {
+        expect(ScVal.fromJson({ i64: value }).value).toBe(expected);
+      });
+
+      it(`int128 accepts ${JSON.stringify(value)}`, () => {
+        expect(Int128Parts.fromJson(value).toJson()).toBe(expected.toString());
+      });
+    }
+  });
+});

--- a/test/unit/xdr/to_json.test.ts
+++ b/test/unit/xdr/to_json.test.ts
@@ -694,8 +694,8 @@ describe("walker — fromJson input validation", () => {
   });
 
   it("rejects malformed int64 strings with an XdrError, not SyntaxError", () => {
-    expect(() => ScVal.fromJson({ i64: "1.5" })).toThrow(/not a valid/);
-    expect(() => ScVal.fromJson({ i64: "12x" })).toThrow(/not a valid/);
+    expect(() => ScVal.fromJson({ i64: "1.5" })).toThrow(jsxdr.XdrError);
+    expect(() => ScVal.fromJson({ i64: "12x" })).toThrow(jsxdr.XdrError);
   });
 
   it("rejects strings over the schema max length", () => {

--- a/test/unit/xdr/union_dispatch.test.ts
+++ b/test/unit/xdr/union_dispatch.test.ts
@@ -1,0 +1,71 @@
+// Every generated union's `fromXdrObject` dispatches on the discriminant with a
+// `case` per arm. The wire type declares the discriminant as a closed set of
+// literals, so that switch is exhaustive to the compiler and typechecks without
+// a fall-through — but a wire object built by hand, or by a JSON decoder that
+// skipped schema validation, can carry an out-of-range value. Without a guard
+// the method returns `undefined` against a non-optional return type, and the
+// caller fails with a `TypeError` frames away from the bad input.
+
+import { describe, it, expect } from "vitest";
+import { XdrError } from "@stellar/js-xdr";
+
+import * as classXdr from "../../../src/xdr/index.js";
+
+interface UnionExport {
+  name: string;
+  cls: { fromXdrObject(wire: unknown): unknown };
+  switchKey: string;
+}
+
+// A discriminant no union declares a case for: enum and `v`-style discriminants
+// are small, and bool-switched unions only match `true` / `false`.
+const UNKNOWN_DISCRIMINANT = 0x7ffffffe;
+
+// Variant subclasses are exported alongside their abstract base and inherit its
+// statics, so several exports share one union schema. Key by schema identity to
+// visit each union once, under the name the schema itself carries.
+function unionExports(): UnionExport[] {
+  const bySchema = new Map<object, UnionExport>();
+  for (const exported of Object.values(classXdr)) {
+    const schema = (exported as { schema?: { kind?: string } })?.schema as
+      | { kind: string; name: string; switchKey: string }
+      | undefined;
+    if (schema?.kind !== "union" || bySchema.has(schema)) continue;
+    bySchema.set(schema, {
+      name: schema.name,
+      cls: exported as UnionExport["cls"],
+      switchKey: schema.switchKey,
+    });
+  }
+  return [...bySchema.values()];
+}
+
+describe("union fromXdrObject rejects unknown discriminants", () => {
+  const unions = unionExports();
+
+  it("finds every generated union (suite sanity check)", () => {
+    expect(unions.length).toBeGreaterThanOrEqual(115);
+  });
+
+  for (const { name, cls, switchKey } of unions) {
+    it(`${name} throws on ${switchKey} ${UNKNOWN_DISCRIMINANT}`, () => {
+      let caught: unknown;
+      let returned: unknown;
+      try {
+        returned = cls.fromXdrObject({ [switchKey]: UNKNOWN_DISCRIMINANT });
+      } catch (error) {
+        caught = error;
+      }
+
+      // asserted separately from the throw: returning `undefined` is the
+      // regression, and `expect(...).toThrow()` alone reads as if any
+      // failure mode would do
+      expect(
+        returned,
+        `${name}.fromXdrObject returned instead of throwing`,
+      ).toBeUndefined();
+      expect(caught).toBeInstanceOf(XdrError);
+      expect((caught as Error).message).toContain(name);
+    });
+  }
+});

--- a/tools/xdrgen/generate.mjs
+++ b/tools/xdrgen/generate.mjs
@@ -1278,6 +1278,8 @@ function bodyOfUnion(rawDef, ctx) {
   ctx.currentType = def.name;
   ctx.builders.add("union");
   ctx.coreImports.add("type XdrType");
+  // `fromXdrObject`'s fall-through guard, below.
+  ctx.coreImports.add("XdrError");
   ctx.valueImports.add("XdrValue");
 
   const name = def.name;
@@ -1386,7 +1388,18 @@ function bodyOfUnion(rawDef, ctx) {
     })
     .join("\n\n");
 
-  // fromXdrObject dispatch
+  // fromXdrObject dispatch. `<Name>Wire` types the discriminant as a closed set
+  // of literals, so the emitted switch is exhaustive to the compiler and needs
+  // no fall-through to typecheck — but a wire object built by hand, or by a JSON
+  // decoder that skipped schema validation, can still carry an out-of-range
+  // value. Without the guard below such a value falls through and the method
+  // returns `undefined` against a non-optional return type, surfacing as a
+  // `TypeError` frames away from the bad input.
+  //
+  // The guard is emitted *after* the switch rather than as a `default:` case so
+  // that a union with a real XDR `default` arm (none exist today, and
+  // `xdr.json` cannot express one) can add its own case without this having to
+  // become conditional; the throw simply becomes dead code.
   const fromWireCases = armsMeta
     .map((a) => {
       if (a.isVoid) {
@@ -1495,6 +1508,11 @@ ${factories}
     switch (wire.${switchKey}) {
 ${fromWireCases}
     }
+    // unreachable for a well-typed wire object; a hand-built one can still
+    // carry an out-of-range discriminant
+    throw new XdrError(
+      \`${name}: unknown ${switchKey} \${(wire as { ${switchKey}: unknown }).${switchKey}}\`,
+    );
   }
 
   /**


### PR DESCRIPTION
## What

- Generated unions' `fromXdrObject` now throws `XdrError` on an unknown discriminant instead of falling through and returning `undefined` (generator change, regenerated across all 118 unions).
- `StrKey.decodeClaimableBalance` / `isValidClaimableBalance` now reject a `B...` key whose discriminant byte is not `CLAIMABLE_BALANCE_ID_TYPE_V0` (0).
- JSON decoding of integer fields (`int64`/`uint64` and the 128/256-bit parts) now rejects strings that are not plain decimal integers — `""`, `" "`, `"0x10"`, `"1e3"` — which `BigInt()` silently accepts as different values.

## Why

The JSON decoder runs parallel to the schema: its overrides hand-build wire objects, so nothing downstream re-checks the schema's rules. Every recent bug in this family (#1581, #1583, #1585, #1588) was the JSON path accepting a value `fromXdr` refuses, then re-encoding it as something else — a silent value change instead of a parse error. These fixes close the remaining known gaps, and the new tests (`json_decode_rejects.test.ts`, `union_dispatch.test.ts`) pin reject-parity: the union guard is exercised for every generated union, and each rejected input is asserted against both decoders. Accepted grammar for integer strings was verified case by case against the reference implementation (`@stellar/stellar-xdr-json`).