### PR TITLE
perf(strkey): reject by length and prefix before decodeCheck throws

### DIFF
--- a/docs/reference/core-keys.md
+++ b/docs/reference/core-keys.md
@@ -468,7 +468,7 @@ class StrKey {
 }
 ```
 
-**Source:** [src/base/strkey.ts:134](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L134)
+**Source:** [src/base/strkey.ts:180](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L180)
 
 ### `new StrKey()`
 
@@ -482,7 +482,7 @@ constructor();
 static types: Record<string, VersionByteName>;
 ```
 
-**Source:** [src/base/strkey.ts:135](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L135)
+**Source:** [src/base/strkey.ts:181](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L181)
 
 ### `StrKey.decodeClaimableBalance(address)`
 
@@ -496,7 +496,7 @@ static decodeClaimableBalance(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — balance to decode
 
-**Source:** [src/base/strkey.ts:325](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L325)
+**Source:** [src/base/strkey.ts:371](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L371)
 
 ### `StrKey.decodeContract(address)`
 
@@ -510,7 +510,7 @@ static decodeContract(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — address to decode
 
-**Source:** [src/base/strkey.ts:298](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L298)
+**Source:** [src/base/strkey.ts:344](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L344)
 
 ### `StrKey.decodeEd25519PublicKey(data)`
 
@@ -527,7 +527,7 @@ static decodeEd25519PublicKey(data: string): Uint8Array;
 
 - **`data`** — `string` (required) — "G..." (or "M...") key representation to decode
 
-**Source:** [src/base/strkey.ts:154](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L154)
+**Source:** [src/base/strkey.ts:200](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L200)
 
 ### `StrKey.decodeEd25519SecretSeed(address)`
 
@@ -541,7 +541,7 @@ static decodeEd25519SecretSeed(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — data to decode
 
-**Source:** [src/base/strkey.ts:181](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L181)
+**Source:** [src/base/strkey.ts:227](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L227)
 
 ### `StrKey.decodeLiquidityPool(address)`
 
@@ -555,7 +555,7 @@ static decodeLiquidityPool(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — address to decode
 
-**Source:** [src/base/strkey.ts:352](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L352)
+**Source:** [src/base/strkey.ts:398](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L398)
 
 ### `StrKey.decodeMed25519PublicKey(address)`
 
@@ -569,7 +569,7 @@ static decodeMed25519PublicKey(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — data to decode
 
-**Source:** [src/base/strkey.ts:208](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L208)
+**Source:** [src/base/strkey.ts:254](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L254)
 
 ### `StrKey.decodePreAuthTx(address)`
 
@@ -583,7 +583,7 @@ static decodePreAuthTx(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — data to decode
 
-**Source:** [src/base/strkey.ts:235](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L235)
+**Source:** [src/base/strkey.ts:281](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L281)
 
 ### `StrKey.decodeSha256Hash(address)`
 
@@ -597,7 +597,7 @@ static decodeSha256Hash(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — data to decode
 
-**Source:** [src/base/strkey.ts:253](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L253)
+**Source:** [src/base/strkey.ts:299](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L299)
 
 ### `StrKey.decodeSignedPayload(address)`
 
@@ -611,7 +611,7 @@ static decodeSignedPayload(address: string): Uint8Array;
 
 - **`address`** — `string` (required) — address to decode
 
-**Source:** [src/base/strkey.ts:271](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L271)
+**Source:** [src/base/strkey.ts:317](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L317)
 
 ### `StrKey.encodeClaimableBalance(data)`
 
@@ -625,7 +625,7 @@ static encodeClaimableBalance(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:316](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L316)
+**Source:** [src/base/strkey.ts:362](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L362)
 
 ### `StrKey.encodeContract(data)`
 
@@ -639,7 +639,7 @@ static encodeContract(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:289](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L289)
+**Source:** [src/base/strkey.ts:335](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L335)
 
 ### `StrKey.encodeEd25519PublicKey(data)`
 
@@ -653,7 +653,7 @@ static encodeEd25519PublicKey(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — raw data to encode
 
-**Source:** [src/base/strkey.ts:142](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L142)
+**Source:** [src/base/strkey.ts:188](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L188)
 
 ### `StrKey.encodeEd25519SecretSeed(data)`
 
@@ -667,7 +667,7 @@ static encodeEd25519SecretSeed(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:172](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L172)
+**Source:** [src/base/strkey.ts:218](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L218)
 
 ### `StrKey.encodeLiquidityPool(data)`
 
@@ -681,7 +681,7 @@ static encodeLiquidityPool(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:343](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L343)
+**Source:** [src/base/strkey.ts:389](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L389)
 
 ### `StrKey.encodeMed25519PublicKey(data)`
 
@@ -695,7 +695,7 @@ static encodeMed25519PublicKey(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:199](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L199)
+**Source:** [src/base/strkey.ts:245](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L245)
 
 ### `StrKey.encodePreAuthTx(data)`
 
@@ -709,7 +709,7 @@ static encodePreAuthTx(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:226](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L226)
+**Source:** [src/base/strkey.ts:272](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L272)
 
 ### `StrKey.encodeSha256Hash(data)`
 
@@ -723,7 +723,7 @@ static encodeSha256Hash(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:244](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L244)
+**Source:** [src/base/strkey.ts:290](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L290)
 
 ### `StrKey.encodeSignedPayload(data)`
 
@@ -737,7 +737,7 @@ static encodeSignedPayload(data: Uint8Array): string;
 
 - **`data`** — `Uint8Array` (required) — data to encode
 
-**Source:** [src/base/strkey.ts:262](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L262)
+**Source:** [src/base/strkey.ts:308](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L308)
 
 ### `StrKey.getVersionByteForPrefix(address)`
 
@@ -752,7 +752,7 @@ static getVersionByteForPrefix(address: string): VersionByteName | undefined;
 
 - **`address`** — `string` (required) — the strkey address to check
 
-**Source:** [src/base/strkey.ts:371](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L371)
+**Source:** [src/base/strkey.ts:417](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L417)
 
 ### `StrKey.isValidClaimableBalance(address)`
 
@@ -766,7 +766,7 @@ static isValidClaimableBalance(address: string): boolean;
 
 - **`address`** — `string` (required) — balance to check
 
-**Source:** [src/base/strkey.ts:334](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L334)
+**Source:** [src/base/strkey.ts:380](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L380)
 
 ### `StrKey.isValidContract(address)`
 
@@ -780,7 +780,7 @@ static isValidContract(address: string): boolean;
 
 - **`address`** — `string` (required) — signer key to check
 
-**Source:** [src/base/strkey.ts:307](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L307)
+**Source:** [src/base/strkey.ts:353](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L353)
 
 ### `StrKey.isValidEd25519PublicKey(publicKey)`
 
@@ -794,7 +794,7 @@ static isValidEd25519PublicKey(publicKey: string): boolean;
 
 - **`publicKey`** — `string` (required) — public key to check
 
-**Source:** [src/base/strkey.ts:163](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L163)
+**Source:** [src/base/strkey.ts:209](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L209)
 
 ### `StrKey.isValidEd25519SecretSeed(seed)`
 
@@ -808,7 +808,7 @@ static isValidEd25519SecretSeed(seed: string): boolean;
 
 - **`seed`** — `string` (required) — seed to check
 
-**Source:** [src/base/strkey.ts:190](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L190)
+**Source:** [src/base/strkey.ts:236](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L236)
 
 ### `StrKey.isValidLiquidityPool(address)`
 
@@ -822,7 +822,7 @@ static isValidLiquidityPool(address: string): boolean;
 
 - **`address`** — `string` (required) — pool to check
 
-**Source:** [src/base/strkey.ts:361](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L361)
+**Source:** [src/base/strkey.ts:407](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L407)
 
 ### `StrKey.isValidMed25519PublicKey(publicKey)`
 
@@ -836,7 +836,7 @@ static isValidMed25519PublicKey(publicKey: string): boolean;
 
 - **`publicKey`** — `string` (required) — public key to check
 
-**Source:** [src/base/strkey.ts:217](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L217)
+**Source:** [src/base/strkey.ts:263](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L263)
 
 ### `StrKey.isValidSignedPayload(address)`
 
@@ -850,7 +850,7 @@ static isValidSignedPayload(address: string): boolean;
 
 - **`address`** — `string` (required) — signer key to check
 
-**Source:** [src/base/strkey.ts:280](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L280)
+**Source:** [src/base/strkey.ts:326](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/strkey.ts#L326)
 
 ## sign
 

--- a/src/base/strkey.ts
+++ b/src/base/strkey.ts
@@ -67,6 +67,52 @@ function encodedLengthRange(name: VersionByteName): [number, number] {
 }
 
 /**
+ * The checks that can be made before decoding anything: is this a strkey type
+ * we know, and is `encoded` a legal length for it?
+ *
+ * Returns a boolean rather than throwing so both callers get what they need.
+ * `isValid` answers with it directly, which matters because its common case is
+ * the *negative* one — `decodeAddressToMuxedAccount` asks
+ * `isValidMed25519PublicKey` about every destination address, and ordinary G
+ * addresses are not M addresses. Constructing an `Error` (and its stack trace)
+ * only to discard it costs orders of magnitude more than the checks
+ * themselves. `decodeCheck` turns a `false` into the corresponding throw via
+ * {@link strkeyFormatError}.
+ */
+function hasValidStrkeyFormat(
+  versionByteName: string,
+  encoded: string,
+): versionByteName is VersionByteName {
+  if (!hasVersionByteName(versionByteName)) {
+    return false;
+  }
+
+  const [minLen, maxLen] = encodedLengthRange(versionByteName);
+  return encoded.length >= minLen && encoded.length <= maxLen;
+}
+
+/**
+ * Explains a {@link hasValidStrkeyFormat} rejection. Only ever called on the
+ * failure path, so it can afford to re-run the checks to find out which one
+ * failed.
+ */
+function strkeyFormatError(versionByteName: string, encoded: string): Error {
+  if (!hasVersionByteName(versionByteName)) {
+    return new Error(
+      `${versionByteName} is not a valid version byte name. ` +
+        `Expected one of ${Object.keys(versionBytes).join(", ")}`,
+    );
+  }
+
+  const [minLen, maxLen] = encodedLengthRange(versionByteName);
+  return new Error(
+    `invalid encoded string length: expected ` +
+      `${minLen === maxLen ? minLen : `${minLen}-${maxLen}`}, ` +
+      `got ${encoded.length}`,
+  );
+}
+
+/**
  * Enforces the `opaque payload<64>` framing that the XDR wire decoder enforces
  * on a signed payload: 32 bytes of signer, a payload length word, then exactly
  * that many payload bytes zero-padded to a 4-byte boundary.
@@ -393,9 +439,19 @@ function isValid(versionByteName: string, encoded: unknown): boolean {
     return false;
   }
 
+  // Screen out the mismatches that don't need decoding before entering the
+  // `try`, so the common negative case never pays for a thrown `Error`.
+  if (!hasValidStrkeyFormat(versionByteName, encoded)) {
+    return false;
+  }
+  // The prefix determines the version byte, which `decodeCheck` would reject
+  // after decoding anyway.
+  if (strkeyTypes[encoded[0]] !== versionByteName) {
+    return false;
+  }
+
   let decoded: Uint8Array;
   try {
-    // encoded-length bounds are enforced by `decodeCheck`
     decoded = decodeCheck(versionByteName, encoded);
   } catch {
     return false;
@@ -443,20 +499,8 @@ export function decodeCheck(
     throw new TypeError("encoded argument must be of type String");
   }
 
-  if (!hasVersionByteName(versionByteName)) {
-    throw new Error(
-      `${versionByteName} is not a valid version byte name. ` +
-        `Expected one of ${Object.keys(versionBytes).join(", ")}`,
-    );
-  }
-
-  const [minLen, maxLen] = encodedLengthRange(versionByteName);
-  if (encoded.length < minLen || encoded.length > maxLen) {
-    throw new Error(
-      `invalid encoded string length: expected ` +
-        `${minLen === maxLen ? minLen : `${minLen}-${maxLen}`}, ` +
-        `got ${encoded.length}`,
-    );
+  if (!hasValidStrkeyFormat(versionByteName, encoded)) {
+    throw strkeyFormatError(versionByteName, encoded);
   }
 
   const decoded = fromBase32(encoded, { padding: false });

--- a/test/unit/base/strkey.test.ts
+++ b/test/unit/base/strkey.test.ts
@@ -657,6 +657,50 @@ describe("StrKey", () => {
     });
   });
 
+  describe("cross-type validation", () => {
+    // `isValid` screens out length and prefix mismatches before calling
+    // `decodeCheck`, because `decodeCheck` reports failure by throwing and the
+    // negative answer is the common case (`decodeAddressToMuxedAccount` asks
+    // `isValidMed25519PublicKey` about every G address). This matrix pins down
+    // that the fast rejection agrees with the slow one: every predicate
+    // accepts its own type and nothing else.
+    const seed32 = new Uint8Array(32).map((_, i) => i + 1);
+    const seed40 = new Uint8Array(40).map((_, i) => i + 1);
+    const seed33 = new Uint8Array(33).map((_, i) => (i === 0 ? 0 : i));
+
+    const samples: Record<string, string> = {
+      ed25519PublicKey: StrKey.encodeEd25519PublicKey(seed32),
+      ed25519SecretSeed: StrKey.encodeEd25519SecretSeed(seed32),
+      med25519PublicKey: StrKey.encodeMed25519PublicKey(seed40),
+      preAuthTx: StrKey.encodePreAuthTx(seed32),
+      sha256Hash: StrKey.encodeSha256Hash(seed32),
+      contract: StrKey.encodeContract(seed32),
+      liquidityPool: StrKey.encodeLiquidityPool(seed32),
+      claimableBalance: StrKey.encodeClaimableBalance(seed33),
+      signedPayload:
+        "PA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAQACAQDAQCQMBYIBEFAWDANBYHRAEISCMKBKFQXDAMRUGY4DUPB6IBZGM",
+    };
+
+    const predicates: Record<string, (value: string) => boolean> = {
+      ed25519PublicKey: StrKey.isValidEd25519PublicKey,
+      ed25519SecretSeed: StrKey.isValidEd25519SecretSeed,
+      med25519PublicKey: StrKey.isValidMed25519PublicKey,
+      contract: StrKey.isValidContract,
+      liquidityPool: StrKey.isValidLiquidityPool,
+      claimableBalance: StrKey.isValidClaimableBalance,
+      signedPayload: StrKey.isValidSignedPayload,
+    };
+
+    for (const [predicateName, isValid] of Object.entries(predicates)) {
+      for (const [sampleName, strkey] of Object.entries(samples)) {
+        const expected = predicateName === sampleName;
+        it(`isValid${predicateName} on a ${sampleName} strkey is ${expected}`, () => {
+          expect(isValid(strkey)).toBe(expected);
+        });
+      }
+    }
+  });
+
   describe("#getVersionByteForPrefix", () => {
     it("returns the correct type for each prefix", () => {
       expect(StrKey.getVersionByteForPrefix("G...")).toBe("ed25519PublicKey");


### PR DESCRIPTION
## What

`StrKey.isValid` now screens the encoded length and the prefix before calling `decodeCheck`. Both checks live in a shared `hasValidStrkeyFormat` helper that returns a boolean; `decodeCheck` turns a `false` into its existing throw via `strkeyFormatError`, so error messages are unchanged.

Adds a cross-type test matrix asserting every `isValid*` predicate accepts its own strkey type and rejects the other eight.

## Why

`decodeCheck` signals every rejection by throwing, and `isValid` called it unconditionally inside a `try`. The negative answer is the common case: `decodeAddressToMuxedAccount` asks `isValidMed25519PublicKey` about every destination address, so an ordinary G address constructed an `Error` with a stack trace and discarded it, twice per transaction build.

Measured against 16.2.0 on Node 24.7:

| | 16.2.0 | v17 before | after |
| --- | --- | --- | --- |
| `TransactionBuilder.build()` | 158k ops/s | 85k ops/s | 271k ops/s |
| `isValidMed25519PublicKey(G…)` | 234,243k ops/s | 309k ops/s | 147,811k ops/s |

`build()` was a ~46% regression against v16 and is now ahead of it.

The docs change is regenerated line numbers from the source edit.
