### PR TITLE
docs: fix tsdoc syntax and recover dropped @param field docs

### DIFF
--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -238,7 +238,7 @@ class AssembledTransaction<T> {
 }
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:272](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L272)
+**Source:** [src/contract/assembled_transaction.ts:270](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L270)
 
 ### `AssembledTransaction.Errors`
 
@@ -250,7 +250,7 @@ logic.
 static Errors: { ExpiredState: typeof ExpiredStateError; ExternalServiceError: typeof ExternalServiceError; FakeAccount: typeof FakeAccountError; InternalWalletError: typeof InternalWalletError; InvalidClientRequest: typeof InvalidClientRequestError; NeedsMoreSignatures: typeof NeedsMoreSignaturesError; NoSignatureNeeded: typeof NoSignatureNeededError; NoSigner: typeof NoSignerError; NotYetSimulated: typeof NotYetSimulatedError; NoUnsignedNonInvokerAuthEntries: typeof NoUnsignedNonInvokerAuthEntriesError; RestorationFailure: typeof RestoreFailureError; SimulationFailed: typeof SimulationFailedError; UserRejected: typeof UserRejectedError };
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:353](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L353)
+**Source:** [src/contract/assembled_transaction.ts:351](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L351)
 
 ### `AssembledTransaction.build(options)`
 
@@ -286,7 +286,7 @@ const tx = await AssembledTransaction.build({
 })
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:603](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L603)
+**Source:** [src/contract/assembled_transaction.ts:601](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L601)
 
 ### `AssembledTransaction.buildWithOp(operation, options)`
 
@@ -318,7 +318,7 @@ const tx = await AssembledTransaction.buildWithOp(
 )
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:632](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L632)
+**Source:** [src/contract/assembled_transaction.ts:630](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L630)
 
 ### `AssembledTransaction.fromJson(options, __namedParameters)`
 
@@ -331,7 +331,7 @@ static fromJson<T>(options: Omit<AssembledTransactionOptions<T>, "args">, __name
 - **`options`** — `Omit<AssembledTransactionOptions<T>, "args">` (required)
 - **`__namedParameters`** — `{ simulationResult: { auth: string[]; retval: string }; simulationTransactionData: string; tx: string }` (required)
 
-**Source:** [src/contract/assembled_transaction.ts:456](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L456)
+**Source:** [src/contract/assembled_transaction.ts:454](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L454)
 
 ### `AssembledTransaction.fromJSON(args)`
 
@@ -345,7 +345,7 @@ static fromJSON<T>(...args: [options: Omit<AssembledTransactionOptions<T>, "args
 
 - **`...args`** — `[options: Omit<AssembledTransactionOptions<T>, "args">, { simulationResult: { auth: string[]; retval: string }; simulationTransactionData: string; tx: string }]` (required)
 
-**Source:** [src/contract/assembled_transaction.ts:503](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L503)
+**Source:** [src/contract/assembled_transaction.ts:501](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L501)
 
 ### `AssembledTransaction.fromXdr(options, encodedXDR, spec)`
 
@@ -361,7 +361,7 @@ static fromXdr<T>(options: Omit<AssembledTransactionOptions<T>, "args" | "method
 - **`encodedXDR`** — `string` (required)
 - **`spec`** — `Spec` (required)
 
-**Source:** [src/contract/assembled_transaction.ts:524](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L524)
+**Source:** [src/contract/assembled_transaction.ts:522](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L522)
 
 ### `assembledTransaction.built`
 
@@ -373,7 +373,7 @@ you call `tx.simulate()` again.
 built?: Transaction;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:300](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L300)
+**Source:** [src/contract/assembled_transaction.ts:298](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L298)
 
 ### `assembledTransaction.options`
 
@@ -381,7 +381,7 @@ built?: Transaction;
 options: AssembledTransactionOptions<T>;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:573](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L573)
+**Source:** [src/contract/assembled_transaction.ts:571](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L571)
 
 ### `assembledTransaction.raw`
 
@@ -402,7 +402,7 @@ await tx.simulate();
 raw?: TransactionBuilder;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:287](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L287)
+**Source:** [src/contract/assembled_transaction.ts:285](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L285)
 
 ### `assembledTransaction.signed`
 
@@ -412,7 +412,7 @@ The signed transaction.
 signed?: Transaction;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:346](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L346)
+**Source:** [src/contract/assembled_transaction.ts:344](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L344)
 
 ### `assembledTransaction.simulation`
 
@@ -426,7 +426,7 @@ logic.
 simulation?: SimulateTransactionResponse;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:309](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L309)
+**Source:** [src/contract/assembled_transaction.ts:307](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L307)
 
 ### `assembledTransaction.isReadCall`
 
@@ -439,7 +439,7 @@ returns `false`, then you need to call `signAndSend` on this transaction.
 readonly isReadCall: boolean;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:1143](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1143)
+**Source:** [src/contract/assembled_transaction.ts:1141](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1141)
 
 ### `assembledTransaction.result`
 
@@ -447,7 +447,7 @@ readonly isReadCall: boolean;
 readonly result: T;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:778](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L778)
+**Source:** [src/contract/assembled_transaction.ts:776](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L776)
 
 ### `assembledTransaction.simulationData`
 
@@ -455,7 +455,7 @@ readonly result: T;
 readonly simulationData: { result: SimulateHostFunctionResult; transactionData: SorobanTransactionData };
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:735](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L735)
+**Source:** [src/contract/assembled_transaction.ts:733](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L733)
 
 ### `assembledTransaction.needsNonInvokerSigningBy(__namedParameters)`
 
@@ -485,7 +485,7 @@ needsNonInvokerSigningBy(__namedParameters: { includeAlreadySigned?: boolean } =
 
 - **`__namedParameters`** — `{ includeAlreadySigned?: boolean }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:971](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L971)
+**Source:** [src/contract/assembled_transaction.ts:969](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L969)
 
 ### `assembledTransaction.restoreFootprint(restorePreamble, account)`
 
@@ -520,7 +520,7 @@ Client initialization.
 - - Throws a custom error if the
 restore transaction fails, providing the details of the failure.
 
-**Source:** [src/contract/assembled_transaction.ts:1170](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1170)
+**Source:** [src/contract/assembled_transaction.ts:1168](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1168)
 
 ### `assembledTransaction.send(watcher)`
 
@@ -537,7 +537,7 @@ send(watcher?: Watcher): Promise<SentTransaction<T>>;
 
 - **`watcher`** — `Watcher` (optional)
 
-**Source:** [src/contract/assembled_transaction.ts:896](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L896)
+**Source:** [src/contract/assembled_transaction.ts:894](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L894)
 
 ### `assembledTransaction.sign(__namedParameters)`
 
@@ -552,7 +552,7 @@ sign(__namedParameters: { force?: boolean; signTransaction?: SignTransactionLike
 
 - **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransactionLike }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:806](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L806)
+**Source:** [src/contract/assembled_transaction.ts:804](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L804)
 
 ### `assembledTransaction.signAndSend(__namedParameters)`
 
@@ -571,7 +571,7 @@ signAndSend(__namedParameters: { force?: boolean; signTransaction?: SignTransact
 
 - **`__namedParameters`** — `{ force?: boolean; signTransaction?: SignTransactionLike; watcher?: Watcher }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:914](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L914)
+**Source:** [src/contract/assembled_transaction.ts:912](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L912)
 
 ### `assembledTransaction.signAuthEntries(__namedParameters)`
 
@@ -598,7 +598,7 @@ signAuthEntries(__namedParameters: { address?: string; authorizeEntry?: (entry: 
 
 - **`__namedParameters`** — `{ address?: string; authorizeEntry?: (entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string) => Promise<SorobanAuthorizationEntry>; expiration?: number | Promise<number>; signAuthEntry?: SignAuthEntryLike }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:1032](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1032)
+**Source:** [src/contract/assembled_transaction.ts:1030](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L1030)
 
 ### `assembledTransaction.simulate(__namedParameters)`
 
@@ -610,7 +610,7 @@ simulate(__namedParameters: { restore?: boolean; useUpgradedAuth?: boolean } = {
 
 - **`__namedParameters`** — `{ restore?: boolean; useUpgradedAuth?: boolean }` (optional) (default: `{}`)
 
-**Source:** [src/contract/assembled_transaction.ts:673](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L673)
+**Source:** [src/contract/assembled_transaction.ts:671](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L671)
 
 ### `assembledTransaction.toJson()`
 
@@ -623,7 +623,7 @@ transaction. This only works with transactions that have been simulated.
 toJson(): string;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:375](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L375)
+**Source:** [src/contract/assembled_transaction.ts:373](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L373)
 
 ### `assembledTransaction.toJSON()`
 
@@ -634,7 +634,7 @@ toJson(): string;
 toJSON(): string;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:392](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L392)
+**Source:** [src/contract/assembled_transaction.ts:390](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L390)
 
 ### `assembledTransaction.toXdr()`
 
@@ -644,7 +644,7 @@ Serialize the AssembledTransaction to a base64-encoded XDR string.
 toXdr(): string;
 ```
 
-**Source:** [src/contract/assembled_transaction.ts:512](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L512)
+**Source:** [src/contract/assembled_transaction.ts:510](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/assembled_transaction.ts#L510)
 
 ## contract.Client
 

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -7,7 +7,7 @@ description: High-level client for invoking Soroban smart contracts — assemble
 
 ## contract.AssembledTransaction
 
-The main workhorse of `Client`. This class is used to wrap a
+The main workhorse of [`Client`](#contractclient). This class is used to wrap a
 transaction-under-construction and provide high-level interfaces to the most
 common workflows, while still providing access to low-level stellar-sdk
 transaction manipulation.
@@ -44,7 +44,7 @@ const { result } = await AssembledTransaction.build({
 ```
 
 While that looks pretty complicated, most of the time you will use this in
-conjunction with `Client`, which simplifies it to:
+conjunction with [`Client`](#contractclient), which simplifies it to:
 
 ```ts
 const { result }  = await client.myReadMethod({
@@ -68,11 +68,11 @@ const assembledTx = await client.myWriteMethod({
 const sentTx = await assembledTx.signAndSend()
 ```
 
-Here we're assuming that you're using a `Client`, rather than
+Here we're assuming that you're using a [`Client`](#contractclient), rather than
 constructing `AssembledTransaction`'s directly.
 
 Note that `sentTx`, the return value of `signAndSend`, is a
-`SentTransaction`. `SentTransaction` is similar to
+[`SentTransaction`](#contractsenttransaction). `SentTransaction` is similar to
 `AssembledTransaction`, but is missing many of the methods and fields that
 are only relevant while assembling a transaction. It also has a few extra
 methods and fields that are only relevant after the transaction has been
@@ -91,8 +91,8 @@ const { result } = await tx.signAndSend()
 #### 3. More fine-grained control over transaction construction
 
 If you need more control over the transaction before simulating it, you can
-set various `MethodOptions` when constructing your
-`AssembledTransaction`. With a `Client`, this is passed as a
+set various [`MethodOptions`](#contractmethodoptions) when constructing your
+`AssembledTransaction`. With a [`Client`](#contractclient), this is passed as a
 second object after the arguments (or the only object, if the method takes
 no arguments):
 
@@ -267,7 +267,7 @@ If you don't want to simulate the transaction, you can set `simulate` to
 `false` in the options.
 
 If you need to create an operation other than `invokeHostFunction`, you
-can use `AssembledTransaction.buildWithOp` instead.
+can use [`AssembledTransaction.buildWithOp`](#assembledtransactionbuildwithopoperation-options) instead.
 
 ```ts
 static build<T>(options: AssembledTransactionOptions<T>): Promise<AssembledTransaction<T>>;
@@ -291,7 +291,7 @@ const tx = await AssembledTransaction.build({
 ### `AssembledTransaction.buildWithOp(operation, options)`
 
 Construct a new AssembledTransaction, specifying an Operation other than
-`invokeHostFunction` (the default used by `AssembledTransaction.build`).
+`invokeHostFunction` (the default used by [`AssembledTransaction.build`](#assembledtransactionbuildoptions)).
 
 Note: `AssembledTransaction` currently assumes these operations can be
 simulated. This is not true for classic operations; only for those used by
@@ -335,7 +335,7 @@ static fromJson<T>(options: Omit<AssembledTransactionOptions<T>, "args">, __name
 
 ### `AssembledTransaction.fromJSON(args)`
 
-**Deprecated.** Use `fromJson` instead.
+**Deprecated.** Use [`fromJson`](#assembledtransactionfromjsonoptions-__namedparameters) instead.
 
 ```ts
 static fromJSON<T>(...args: [options: Omit<AssembledTransactionOptions<T>, "args">, { simulationResult: { auth: string[]; retval: string }; simulationTransactionData: string; tx: string }]): AssembledTransaction<T>;
@@ -386,7 +386,7 @@ options: AssembledTransactionOptions<T>;
 ### `assembledTransaction.raw`
 
 The TransactionBuilder as constructed in
-`AssembledTransaction`.build. Feel free set `simulate: false` to modify
+[`AssembledTransaction`](#contractassembledtransaction).build. Feel free set `simulate: false` to modify
 this object before calling `tx.simulate()` manually. Example:
 
 ```ts
@@ -474,7 +474,7 @@ transaction envelope as signed the initial simulation.
 One at a time, for each public key in this array, you will need to
 serialize this transaction with `toJson`, send to the owner of that key,
 deserialize the transaction with `txFromJson`, and call
-`AssembledTransaction.signAuthEntries`. Then re-serialize and send to
+[`AssembledTransaction.signAuthEntries`](#assembledtransactionsignauthentries__namedparameters). Then re-serialize and send to
 the next account in this list.
 
 ```ts
@@ -526,7 +526,7 @@ restore transaction fails, providing the details of the failure.
 
 Sends the transaction to the network to return a `SentTransaction` that
 keeps track of all the attempts to fetch the transaction. Optionally pass
-a `Watcher` that allows you to keep track of the progress as the
+a [`Watcher`](#contractwatcher) that allows you to keep track of the progress as the
 transaction is sent and processed.
 
 ```ts
@@ -560,7 +560,7 @@ Sign the transaction with the `signTransaction` function included previously.
 If you did not previously include one, you need to include one now.
 After signing, this method will send the transaction to the network and
 return a `SentTransaction` that keeps track of all the attempts to fetch
-the transaction. You may pass a `Watcher` to keep
+the transaction. You may pass a [`Watcher`](#contractwatcher) to keep
 track of this progress.
 
 ```ts
@@ -575,7 +575,7 @@ signAndSend(__namedParameters: { force?: boolean; signTransaction?: SignTransact
 
 ### `assembledTransaction.signAuthEntries(__namedParameters)`
 
-If `AssembledTransaction#needsNonInvokerSigningBy` returns a
+If [`AssembledTransaction#needsNonInvokerSigningBy`](#assembledtransactionneedsnoninvokersigningby__namedparameters) returns a
 non-empty list, you can serialize the transaction with `toJson`, send it to
 the owner of one of the public keys in the map, deserialize with
 `txFromJson`, and call this method on their machine. Internally, this will
@@ -583,8 +583,8 @@ use `signAuthEntry` function from connected `wallet` for each.
 
 Then, re-serialize the transaction and either send to the next
 `needsNonInvokerSigningBy` owner, or send it back to the original account
-who simulated the transaction so they can `AssembledTransaction.sign`
-the transaction envelope and `AssembledTransaction.send` it to the
+who simulated the transaction so they can [`AssembledTransaction.sign`](#assembledtransactionsign__namedparameters)
+the transaction envelope and [`AssembledTransaction.send`](#assembledtransactionsendwatcher) it to the
 network.
 
 Sending to all `needsNonInvokerSigningBy` owners in parallel is not
@@ -627,7 +627,7 @@ toJson(): string;
 
 ### `assembledTransaction.toJSON()`
 
-**Deprecated.** Use `toJson` instead. Kept so existing callers and the
+**Deprecated.** Use [`toJson`](#assembledtransactiontojson) instead. Kept so existing callers and the
 `JSON.stringify` protocol hook keep working.
 
 ```ts
@@ -651,7 +651,7 @@ toXdr(): string;
 Generate a class from the contract spec that where each contract method
 gets included with an identical name.
 
-Each method returns an `AssembledTransaction` that can
+Each method returns an [`AssembledTransaction`](#contractassembledtransaction) that can
 be used to modify, simulate, decode results, and possibly sign, & submit the
 transaction.
 
@@ -708,7 +708,7 @@ executable on-chain.
 
 If the contract was created from a CAP-85 external executable reference,
 the reference is resolved to a Wasm hash first (see
-`rpc.Server.getExternalRefWasmHash`), then the spec is read from
+[`rpc.Server.getExternalRefWasmHash`](/reference/network-rpc/#servergetexternalrefwasmhashref)), then the spec is read from
 that Wasm.
 
 ```ts
@@ -825,7 +825,7 @@ readonly spec: Spec;
 
 ### `client.txFromJSON`
 
-**Deprecated.** Use `txFromJson` instead.
+**Deprecated.** Use [`txFromJson`](#clienttxfromjsonjson) instead.
 
 ```ts
 txFromJSON: <T>(json: string) => AssembledTransaction<T>;
@@ -876,11 +876,11 @@ const DEFAULT_TIMEOUT: number
 
 ## contract.KeypairSigner
 
-A `Signer` backed by a local `Keypair`.
+A [`Signer`](#contractsigner) backed by a local [`Keypair`](/reference/core-keys/#keypair).
 
 Suitable for Node applications, scripts, and tests — anywhere the secret key
 lives in the same process. For browser applications, use the SEP-43 wallet's
-own `signTransaction`, or wrap it in an object satisfying `Signer`.
+own `signTransaction`, or wrap it in an object satisfying [`Signer`](#contractsigner).
 
 ```ts
 class KeypairSigner implements Signer {
@@ -917,7 +917,7 @@ constructor(keypair: Keypair, networkPassphrase: string);
 
 **Parameters**
 
-- **`keypair`** — `Keypair` (required) — the `Keypair` to sign with. Signing throws
+- **`keypair`** — `Keypair` (required) — the [`Keypair`](/reference/core-keys/#keypair) to sign with. Signing throws
      `cannot sign: no secret key available` if it holds only a public key.
 - **`networkPassphrase`** — `string` (required) — passphrase of the network to sign for, used
      whenever the caller does not pass one at signing time
@@ -1017,8 +1017,8 @@ static Errors: { SendFailed: typeof SendFailedError; SendResultOnly: typeof Send
 
 ### `SentTransaction.init(assembled, watcher)`
 
-Initialize a `SentTransaction` from `AssembledTransaction`
-`assembled`, passing an optional `Watcher` `watcher`. This will also
+Initialize a `SentTransaction` from [`AssembledTransaction`](#contractassembledtransaction)
+`assembled`, passing an optional [`Watcher`](#contractwatcher) `watcher`. This will also
 send the transaction to the network.
 
 ```ts
@@ -1027,7 +1027,7 @@ static init<U>(assembled: AssembledTransaction<U>, watcher?: Watcher): Promise<S
 
 **Parameters**
 
-- **`assembled`** — `AssembledTransaction<U>` (required) — `AssembledTransaction` from which this SentTransaction was initialized
+- **`assembled`** — `AssembledTransaction<U>` (required) — [`AssembledTransaction`](#contractassembledtransaction) from which this SentTransaction was initialized
 - **`watcher`** — `Watcher` (optional)
 
 **Source:** [src/contract/sent_transaction.ts:70](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/sent_transaction.ts#L70)
@@ -1294,7 +1294,7 @@ the entry
 
 Finds the XDR event spec for the given event name.
 
-Unlike `Spec.findEntry`, a missing event is not an error: this
+Unlike [`Spec.findEntry`](#specfindentryname), a missing event is not an error: this
 returns `undefined` so callers can probe a contract for an event without
 wrapping the call in a `try`.
 
@@ -1611,15 +1611,15 @@ onSubmitted(response?: SendTransactionResponse): void;
 
 ## contract.basicNodeSigner
 
-For use with `Client` and `contract.AssembledTransaction`.
+For use with [`Client`](#contractclient) and [`contract.AssembledTransaction`](#contractassembledtransaction).
 Implements `signTransaction` and `signAuthEntry` with signatures expected by
 those classes. This is useful for testing and maybe some simple Node
 applications. Feel free to use this as a starting point for your own
 Wallet/TransactionSigner implementation.
 
-Prefer `KeypairSigner`, which does the same thing and also carries the
+Prefer [`KeypairSigner`](#contractkeypairsigner), which does the same thing and also carries the
 signer's address, so you can pass one object instead of spreading two
-functions. You can also pass a `Keypair` directly as `signTransaction`.
+functions. You can also pass a [`Keypair`](/reference/core-keys/#keypair) directly as `signTransaction`.
 
 ```ts
 basicNodeSigner(keypair: Keypair, networkPassphrase: string): { signAuthEntry: SignAuthEntry; signTransaction: SignTransaction }
@@ -1627,7 +1627,7 @@ basicNodeSigner(keypair: Keypair, networkPassphrase: string): { signAuthEntry: S
 
 **Parameters**
 
-- **`keypair`** — `Keypair` (required) — `Keypair` to use to sign the transaction or auth entry
+- **`keypair`** — `Keypair` (required) — [`Keypair`](/reference/core-keys/#keypair) to use to sign the transaction or auth entry
 - **`networkPassphrase`** — `string` (required) — passphrase of network to sign for
 
 **Source:** [src/contract/basic_node_signer.ts:20](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/basic_node_signer.ts#L20)
@@ -1665,7 +1665,7 @@ type Duration = bigint
 ### contract.ErrorMessage
 
 Error interface containing the error message. Matches Rust's implementation.
-Part of implementing `Result`, a minimal
+Part of implementing [`Result`](#contractresult), a minimal
 implementation of Rust's `Result` type. Used for contract methods that return
 Results, to maintain their distinction from methods that simply either return
 a value or throw.
@@ -1707,7 +1707,7 @@ type Option<T> = T | undefined
 ### contract.ParsedEvent
 
 The result of successfully matching an emitted contract event against one
-of the event specs (`ScSpecEventV0`) defined in a `Spec`.
+of the event specs (`ScSpecEventV0`) defined in a [`Spec`](#contractspec).
 
 ```ts
 interface ParsedEvent {
@@ -1753,8 +1753,8 @@ that simply either return a value or throw.
 
 #### Why is this needed?
 
-This is used by ``ContractSpec`` and
-``AssembledTransaction`` when
+This is used by [``ContractSpec``](#contractspec) and
+[``AssembledTransaction``](#contractassembledtransaction) when
 parsing values return by contracts.
 
 Contract methods can be implemented to return simple values, in which case
@@ -1837,7 +1837,7 @@ type SignAuthEntry = (authEntry: string, opts?: { address?: string; networkPassp
 ### contract.SignAuthEntryLike
 
 Anything accepted where a `signAuthEntry` callback is expected: the raw
-SEP-43 callback, a `Signer`, or a `Keypair`.
+SEP-43 callback, a [`Signer`](#contractsigner), or a [`Keypair`](/reference/core-keys/#keypair).
 
 ```ts
 type SignAuthEntryLike = SignAuthEntry | Signer | Keypair
@@ -1862,7 +1862,7 @@ type SignTransaction = (xdr: string, opts?: { address?: string; networkPassphras
 ### contract.SignTransactionLike
 
 Anything accepted where a `signTransaction` callback is expected: the raw
-SEP-43 callback, a `Signer`, or a `Keypair`.
+SEP-43 callback, a [`Signer`](#contractsigner), or a [`Keypair`](/reference/core-keys/#keypair).
 
 ```ts
 type SignTransactionLike = SignTransaction | Signer | Keypair
@@ -1874,7 +1874,7 @@ type SignTransactionLike = SignTransaction | Signer | Keypair
 
 A signing identity: something that can sign, and that knows who it is.
 
-A bare `SignTransaction` callback carries no identity, so callers have
+A bare [`SignTransaction`](#contractsigntransaction) callback carries no identity, so callers have
 to pass the signer's address alongside it and keep the two in sync. A
 `Signer` bundles them.
 
@@ -1956,7 +1956,7 @@ type Tx = Transaction
 
 ### contract.Typepoint
 
-**Deprecated.** Use `Timepoint` instead.
+**Deprecated.** Use [`Timepoint`](#contracttimepoint) instead.
 
 ```ts
 type Typepoint = bigint

--- a/docs/reference/core-assets.md
+++ b/docs/reference/core-assets.md
@@ -54,7 +54,7 @@ constructor(code: string, issuer?: string);
 
 Compares two assets according to the criteria:
 
- 1. First compare the type (native < alphanum4 < alphanum12).
+ 1. First compare the type (`native < alphanum4 < alphanum12`).
  2. If the types are equal, compare the assets codes.
  3. If the asset codes are equal, compare the issuers.
 
@@ -152,7 +152,7 @@ getAssetType(): AssetType;
 
 **Throws**
 
-- Throws `Error` if asset type is unsupported.
+- if asset type is unsupported.
 
 **See also**
 
@@ -455,8 +455,8 @@ constructor(assetA: Asset, assetB: Asset, fee: number);
 
 **Parameters**
 
-- **`assetA`** — `Asset` (required) — The first asset in the Pool, it must respect the rule assetA < assetB. See `Asset.compare` for more details on how assets are sorted.
-- **`assetB`** — `Asset` (required) — The second asset in the Pool, it must respect the rule assetA < assetB. See `Asset.compare` for more details on how assets are sorted.
+- **`assetA`** — `Asset` (required) — The first asset in the Pool, it must respect the rule `assetA < assetB`. See `Asset.compare` for more details on how assets are sorted.
+- **`assetB`** — `Asset` (required) — The second asset in the Pool, it must respect the rule `assetA < assetB`. See `Asset.compare` for more details on how assets are sorted.
 - **`fee`** — `number` (required) — The liquidity pool fee. For now the only fee supported is `30`.
 
 **Source:** [src/base/liquidity_pool_asset.ts:27](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/liquidity_pool_asset.ts#L27)
@@ -701,6 +701,9 @@ getLiquidityPoolId(liquidityPoolType: "constant_product", liquidityPoolParameter
 
 - **`liquidityPoolType`** — `"constant_product"` (required) — A string representing the liquidity pool type.
 - **`liquidityPoolParameters`** — `ConstantProduct` (required) — The liquidity pool parameters.
+    - `assetA`: The first asset in the Pool, it must respect the rule `assetA < assetB`.
+    - `assetB`: The second asset in the Pool, it must respect the rule `assetA < assetB`.
+    - `fee`: The liquidity pool fee. For now the only fee supported is `30`.
 
 **See also**
 

--- a/docs/reference/core-assets.md
+++ b/docs/reference/core-assets.md
@@ -126,7 +126,7 @@ contractId(networkPassphrase: string): string;
 
 - **`networkPassphrase`** — `string` (required) — indicates which network the contract
      ID should refer to, since every network will have a unique ID for the
-     same contract (see `Networks` for options)
+     same contract (see [`Networks`](/reference/core-transactions/#networks) for options)
 
 **Source:** [src/base/asset.ts:172](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L172)
 
@@ -455,8 +455,8 @@ constructor(assetA: Asset, assetB: Asset, fee: number);
 
 **Parameters**
 
-- **`assetA`** — `Asset` (required) — The first asset in the Pool, it must respect the rule `assetA < assetB`. See `Asset.compare` for more details on how assets are sorted.
-- **`assetB`** — `Asset` (required) — The second asset in the Pool, it must respect the rule `assetA < assetB`. See `Asset.compare` for more details on how assets are sorted.
+- **`assetA`** — `Asset` (required) — The first asset in the Pool, it must respect the rule `assetA < assetB`. See [`Asset.compare`](#assetcompareasseta-assetb) for more details on how assets are sorted.
+- **`assetB`** — `Asset` (required) — The second asset in the Pool, it must respect the rule `assetA < assetB`. See [`Asset.compare`](#assetcompareasseta-assetb) for more details on how assets are sorted.
 - **`fee`** — `number` (required) — The liquidity pool fee. For now the only fee supported is `30`.
 
 **Source:** [src/base/liquidity_pool_asset.ts:27](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/liquidity_pool_asset.ts#L27)
@@ -552,9 +552,9 @@ toString(): string;
 
 Returns the `xdr.ChangeTrustAsset` object for this liquidity pool asset.
 
-Note: To convert from an ``Asset`` to `xdr.ChangeTrustAsset`
+Note: To convert from an [``Asset``](#asset) to `xdr.ChangeTrustAsset`
 please refer to the
-``Asset.toChangeTrustXdrObject`` method.
+[``Asset.toChangeTrustXdrObject``](#assettochangetrustxdrobject) method.
 
 ```ts
 toXdrObject(): ChangeTrustAsset;
@@ -676,9 +676,9 @@ toString(): string;
 
 Returns the `xdr.TrustLineAsset` object for this liquidity pool ID.
 
-Note: To convert from ``Asset`` to `xdr.TrustLineAsset` please
+Note: To convert from [``Asset``](#asset) to `xdr.TrustLineAsset` please
 refer to the
-``Asset.toTrustLineXdrObject`` method.
+[``Asset.toTrustLineXdrObject``](#assettotrustlinexdrobject) method.
 
 ```ts
 toXdrObject(): TrustLineAsset;

--- a/docs/reference/core-keys.md
+++ b/docs/reference/core-keys.md
@@ -55,6 +55,9 @@ constructor(keys: { publicKey?: string | Uint8Array<ArrayBufferLike>; secretKey:
 **Parameters**
 
 - **`keys`** — `{ publicKey?: string | Uint8Array<ArrayBufferLike>; secretKey: string | Uint8Array<ArrayBufferLike>; type: "ed25519" } | { publicKey: string | Uint8Array<ArrayBufferLike>; type: "ed25519" }` (required) — at least one of keys must be provided.
+    - `type`: public-key signature system name (currently only `ed25519` keys are supported)
+    - `publicKey`: raw public key
+    - `secretKey`: raw secret key (32-byte secret seed in ed25519)
 
 **Source:** [src/base/keypair.ts:60](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/keypair.ts#L60)
 

--- a/docs/reference/core-keys.md
+++ b/docs/reference/core-keys.md
@@ -376,10 +376,10 @@ xdrPublicKey(): PublicKeyEd25519;
 ## SignerKey
 
 A container class with helpers to convert between signer keys
-(`xdr.SignerKey`) and `StrKey`s.
+(`xdr.SignerKey`) and [`StrKey`](#strkey)s.
 
 It's primarily used for manipulating the `extraSigners` precondition on a
-`Transaction`.
+[`Transaction`](/reference/core-transactions/#transaction).
 
 ```ts
 class SignerKey {
@@ -391,7 +391,7 @@ class SignerKey {
 
 **See also**
 
-- `TransactionBuilder.setExtraSigners`
+- [`TransactionBuilder.setExtraSigners`](/reference/core-transactions/#transactionbuildersetextrasignersextrasigners)
 
 **Source:** [src/base/signerkey.ts:22](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/signerkey.ts#L22)
 

--- a/docs/reference/core-soroban-primitives.md
+++ b/docs/reference/core-soroban-primitives.md
@@ -36,7 +36,7 @@ constructor(address: string);
 
 **Parameters**
 
-- **`address`** — `string` (required) — a `StrKey` of the address value
+- **`address`** — `string` (required) — a [`StrKey`](/reference/core-keys/#strkey) of the address value
 
 **Source:** [src/base/address.ts:39](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/address.ts#L39)
 
@@ -392,8 +392,8 @@ Supports building `xdr.SorobanTransactionData` structures with various
 items set to specific values.
 
 This is recommended for when you are building
-`Operation.extendFootprintTtl` / `Operation.restoreFootprint`
-operations and need to `TransactionBuilder.setSorobanData` to avoid
+[`Operation.extendFootprintTtl`](/reference/core-transactions/#operationextendfootprintttl) / [`Operation.restoreFootprint`](/reference/core-transactions/#operationrestorefootprint)
+operations and need to [`TransactionBuilder.setSorobanData`](/reference/core-transactions/#transactionbuildersetsorobandatasorobandata) to avoid
 (re)building the entire data structure from scratch.
 
 ```ts
@@ -520,9 +520,9 @@ getReadWrite(): LedgerKey[];
 Sets the storage access footprint to be a certain set of ledger keys.
 
 You can also set each field explicitly via
-`SorobanDataBuilder.setReadOnly` and
-`SorobanDataBuilder.setReadWrite` or add to the existing footprint
-via `SorobanDataBuilder.appendFootprint`.
+[`SorobanDataBuilder.setReadOnly`](#sorobandatabuildersetreadonlyreadonly) and
+[`SorobanDataBuilder.setReadWrite`](#sorobandatabuildersetreadwritereadwrite) or add to the existing footprint
+via [`SorobanDataBuilder.appendFootprint`](#sorobandatabuilderappendfootprintreadonly-readwrite).
 
 Passing `null|undefined` to either parameter will IGNORE the existing
 values. If you want to clear them, pass `[]`, instead.
@@ -605,17 +605,17 @@ Actually authorizes an existing authorization entry using the given
 credentials and expiration details, returning a signed copy.
 
 This "fills out" the authorization entry with a signature, indicating to the
-`Operation.invokeHostFunction` its attached to that:
-  - a particular identity (i.e. signing `Keypair` or other signer)
+[`Operation.invokeHostFunction`](/reference/core-transactions/#operationinvokehostfunction) its attached to that:
+  - a particular identity (i.e. signing [`Keypair`](/reference/core-keys/#keypair) or other signer)
   - approving the execution of an invocation tree (i.e. a simulation-acquired
     `xdr.SorobanAuthorizedInvocation` or otherwise built)
   - on a particular network (uniquely identified by its passphrase, see
-    `Networks`)
+    [`Networks`](/reference/core-transactions/#networks))
   - until a particular ledger sequence is reached.
 
-This one lets you pass either a `Keypair` (or, more accurately,
+This one lets you pass either a [`Keypair`](/reference/core-keys/#keypair) (or, more accurately,
 anything with a `sign(Uint8Array): Uint8Array` method) or a callback function (see
-`SigningCallback`) to handle signing the envelope hash.
+[`SigningCallback`](#signingcallback)) to handle signing the envelope hash.
 
 ```ts
 authorizeEntry(entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallback, validUntilLedgerSeq: number, networkPassphrase: string, forAddress?: string): Promise<SorobanAuthorizationEntry>
@@ -624,8 +624,8 @@ authorizeEntry(entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallba
 **Parameters**
 
 - **`entry`** — `SorobanAuthorizationEntry` (required) — an unsigned authorization entry
-- **`signer`** — `Keypair | SigningCallback` (required) — either a `Keypair` instance or a function (see
-     `SigningCallback`) which receives the
+- **`signer`** — `Keypair | SigningCallback` (required) — either a [`Keypair`](/reference/core-keys/#keypair) instance or a function (see
+     [`SigningCallback`](#signingcallback)) which receives the
      `xdr.HashIdPreimage` input payload plus its 32-byte signing hash
      and returns EITHER
   
@@ -645,7 +645,7 @@ authorizeEntry(entry: SorobanAuthorizationEntry, signer: Keypair | SigningCallba
      until which this authorization entry should be valid (if
      `currentLedgerSeq==validUntil`, this is expired)
 - **`networkPassphrase`** — `string` (required) — the network passphrase is incorporated into the
-     signature (see `Networks` for options)
+     signature (see [`Networks`](/reference/core-transactions/#networks) for options)
   
   If using the `SigningCallback` variation, the signer is assumed to be
   the entry's credential address unless you use the variant that returns
@@ -729,7 +729,7 @@ authorizeInvocation(params: AuthorizeInvocationParams): Promise<SorobanAuthoriza
 
 Builds the `xdr.HashIdPreimage` whose hash a signer must sign to
 authorize `entry`. This is the low-level signature payload used by
-`authorizeEntry`, exposed for callers that drive signing themselves —
+[`authorizeEntry`](#authorizeentry), exposed for callers that drive signing themselves —
 most notably for `SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES`, where the
 client (not simulation) decides which delegates sign and how.
 
@@ -777,7 +777,7 @@ buildInvocationTree(root: SorobanAuthorizedInvocation): InvocationTree
 
 - **`root`** — `SorobanAuthorizedInvocation` (required) — the raw XDR of the invocation,
      likely acquired from transaction simulation. this is either from the
-     `Operation.invokeHostFunction` itself (the `func` field), or from
+     [`Operation.invokeHostFunction`](/reference/core-transactions/#operationinvokehostfunction) itself (the `func` field), or from
      the authorization entries (`xdr.SorobanAuthorizationEntry`, the
      `rootInvocation` field)
 
@@ -825,8 +825,8 @@ delegated authentication is account-specific policy known only to the client
 (much like a multisig policy). This helper just assembles the wrapper XDR;
 you supply the delegate tree (addresses and, optionally, signatures). To
 produce the signatures, build the shared payload with
-`buildAuthorizationEntryPreimage` on the returned entry and sign it,
-or fill each node afterwards with `authorizeEntry` (passing the
+[`buildAuthorizationEntryPreimage`](#buildauthorizationentrypreimage) on the returned entry and sign it,
+or fill each node afterwards with [`authorizeEntry`](#authorizeentry) (passing the
 signer's address as `forAddress`).
 
 Each delegates array (the top-level set and every `nestedDelegates`) is
@@ -840,7 +840,7 @@ buildWithDelegatesEntry(params: BuildWithDelegatesParams): SorobanAuthorizationE
 
 **Parameters**
 
-- **`params`** — `BuildWithDelegatesParams` (required) — see `BuildWithDelegatesParams`
+- **`params`** — `BuildWithDelegatesParams` (required) — see [`BuildWithDelegatesParams`](#buildwithdelegatesparams)
 
 **Throws**
 
@@ -866,7 +866,7 @@ For `SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES`, this conservatively
 requires *every* node (top-level and all delegates) to be signed. An
 account's policy may accept an unsigned top-level node when its delegates
 have signed (CAP-71-01); if you support that, check
-`inspectAuthEntry`'s `signers` yourself.
+[`inspectAuthEntry`](#inspectauthentry)'s `signers` yourself.
 
 ```ts
 checkAuthEntryReadiness(entry: SorobanAuthorizationEntry, currentLedgerSeq: number): AuthEntryReadiness
@@ -880,7 +880,7 @@ checkAuthEntryReadiness(entry: SorobanAuthorizationEntry, currentLedgerSeq: numb
 
 **Returns**
 
-a `AuthEntryReadiness`: `ready`, `expired`, and which
+a [`AuthEntryReadiness`](#authentryreadiness): `ready`, `expired`, and which
    addresses are still `unsignedBy`
 
 **Throws**
@@ -899,8 +899,8 @@ human-readable, and understandable structure.
 Each element in the returned list has the following properties:
  - `type`: one of `'system'`, `'contract'`, `'diagnostic'`
  - `contractId`: optionally, a `C...` encoded strkey
- - `topics`: a list of `scValToNative` invocations on the topics
- - `data`: a `scValToNative` invocation on the raw event data
+ - `topics`: a list of [`scValToNative`](#scvaltonative) invocations on the topics
+ - `data`: a [`scValToNative`](#scvaltonative) invocation on the raw event data
 
 ```ts
 humanizeEvents(events: ContractEvent[] | DiagnosticEvent[]): SorobanEvent[]
@@ -921,8 +921,8 @@ expiration ledger, and — for every node that can carry a signature (the
 top-level credentials plus any CAP-71 delegates) — whether it is signed and,
 when the payload uses the SDK's standard ed25519 format, by which keys.
 
-This is the read-side complement to `authorizeEntry` /
-`authorizeInvocation`: those fill entries with signatures, this
+This is the read-side complement to [`authorizeEntry`](#authorizeentry) /
+[`authorizeInvocation`](#authorizeinvocation): those fill entries with signatures, this
 inspects what an entry (e.g. one returned by transaction simulation, or
 received from a counterparty in a multi-party signing flow) requires and
 already carries, without reaching into raw XDR accessors.
@@ -937,7 +937,7 @@ inspectAuthEntry(entry: SorobanAuthorizationEntry): AuthEntryInfo
 
 **Returns**
 
-a `AuthEntryInfo` summary of the entry
+a [`AuthEntryInfo`](#authentryinfo) summary of the entry
 
 **Example**
 
@@ -967,13 +967,13 @@ The conversions are as follows:
  - xdr.ScVal → passthrough
  - null/undefined → scvVoid
  - string → scvString (a copy is made)
- - UintArray8 → scvBytes (a copy is made)
+ - Uint8Array → scvBytes (a copy is made)
  - boolean → scvBool
 
  - number/bigint → the smallest possible XDR integer type that will fit the
-   input value (if you want a specific type, use `ScInt`)
+   input value (if you want a specific type, use [`ScInt`](/reference/core-transactions/#scint))
 
- - `Address` or `Contract` → scvAddress (for contracts and
+ - [`Address`](#address) or [`Contract`](#contract) → scvAddress (for contracts and
    public keys)
 
  - `Array<T>` → scvVec after attempting to convert each item of type `T` to an
@@ -1002,7 +1002,7 @@ nativeToScVal(val: unknown, opts: NativeToScValOpts = {}): ScVal
       types for `val`:
   
       - when `val` is an integer-like type (i.e. number|bigint), this will be
-        forwarded to `ScInt` or forced to be u32/i32.
+        forwarded to [`ScInt`](/reference/core-transactions/#scint) or forced to be u32/i32.
   
       - when `val` is an array type, this is forwarded to the recursion
   
@@ -1194,7 +1194,7 @@ type AuthEntryCredentialType = "sourceAccount" | "address" | "addressV2" | "addr
 ### AuthEntryInfo
 
 A structured, read-only view of a `xdr.SorobanAuthorizationEntry`,
-returned by `inspectAuthEntry`.
+returned by [`inspectAuthEntry`](#inspectauthentry).
 
 ```ts
 interface AuthEntryInfo {
@@ -1252,7 +1252,7 @@ nonce: bigint | null;
 
 the (exclusive) ledger sequence until which the signature is valid, or
 `null` for source-account credentials. Note that unsigned entries commonly
-carry a placeholder (often `0`) until `authorizeEntry` sets it.
+carry a placeholder (often `0`) until [`authorizeEntry`](#authorizeentry) sets it.
 
 ```ts
 signatureExpirationLedger: number | null;
@@ -1265,7 +1265,7 @@ signatureExpirationLedger: number | null;
 whether every signer node carries a signature payload. Always `false` for
 source-account credentials (which have no signature nodes — they are
 instead covered by the transaction envelope signature; use
-`checkAuthEntryReadiness` for a submit check). For the delegates
+[`checkAuthEntryReadiness`](#checkauthentryreadiness) for a submit check). For the delegates
 variant note that an account's policy may accept an unsigned top-level
 node when its delegates have signed (CAP-71-01) — consult `signers` if you
 support that.
@@ -1290,7 +1290,7 @@ signers: AuthEntrySigner[];
 
 ### AuthEntryReadiness
 
-The result of `checkAuthEntryReadiness`.
+The result of [`checkAuthEntryReadiness`](#checkauthentryreadiness).
 
 ```ts
 interface AuthEntryReadiness {
@@ -1336,7 +1336,7 @@ unsignedBy: string[];
 ### AuthEntrySignature
 
 A single ed25519 signature parsed out of a credential node's signature
-value, in the map format written by `authorizeEntry`.
+value, in the map format written by [`authorizeEntry`](#authorizeentry).
 
 ```ts
 interface AuthEntrySignature {
@@ -1407,7 +1407,7 @@ rawSignature: ScVal;
 #### `authEntrySigner.signatures`
 
 the signature payload parsed as the SDK's standard ed25519 format (a vec
-of `{public_key, signature}` maps, see `authorizeEntry`), or `null`
+of `{public_key, signature}` maps, see [`authorizeEntry`](#authorizeentry)), or `null`
 when the payload has some other, signer-defined shape (as custom accounts
 such as WebAuthn/passkey wallets use). Of the two unsigned placeholder
 forms, an empty `scvVec` parses as `[]` while `scvVoid` (not a vec at all)
@@ -1437,14 +1437,14 @@ signed: boolean;
 
 This builds an entry from scratch, allowing you to express authorization as a
 function of:
-  - a particular identity (i.e. signing `Keypair` or other signer)
+  - a particular identity (i.e. signing [`Keypair`](/reference/core-keys/#keypair) or other signer)
   - approving the execution of an invocation tree (i.e. a simulation-acquired
     `xdr.SorobanAuthorizedInvocation` or otherwise built)
   - on a particular network (uniquely identified by its passphrase, see
-    `Networks`)
+    [`Networks`](/reference/core-transactions/#networks))
   - until a particular ledger sequence is reached.
 
-This is in contrast to `authorizeEntry`, which signs an existing entry.
+This is in contrast to [`authorizeEntry`](#authorizeentry), which signs an existing entry.
 
 ```ts
 interface AuthorizeInvocationParams {
@@ -1519,7 +1519,7 @@ validUntilLedgerSeq: number;
 
 ### BuildWithDelegatesParams
 
-Parameters for `buildWithDelegatesEntry`.
+Parameters for [`buildWithDelegatesEntry`](#buildwithdelegatesentry).
 
 ```ts
 interface BuildWithDelegatesParams {
@@ -1582,7 +1582,7 @@ Details about a contract creation invocation.
 - `type` indicates if this creation was a custom contract (`'wasm'`), a
   wrapping of an existing Stellar asset (`'sac'`), or a reference to an
   external executable (`'external'`, see CAP-85)
-- `asset` is set when `type=='sac'`, containing the canonical `Asset`
+- `asset` is set when `type=='sac'`, containing the canonical [`Asset`](/reference/core-assets/#asset)
   being wrapped by this Stellar Asset Contract
 - `wasm` is set when `type=='wasm'`, containing additional creation parameters
 - `external` is set when `type=='external'`, containing the referenced
@@ -1635,7 +1635,7 @@ wasm?: WasmCreateDetails;
 
 A delegate signer to attach to a
 `SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES` entry via
-`buildWithDelegatesEntry`.
+[`buildWithDelegatesEntry`](#buildwithdelegatesentry).
 
 ```ts
 interface DelegateSignature {
@@ -1670,7 +1670,7 @@ nestedDelegates?: DelegateSignature[];
 #### `delegateSignature.signature`
 
 the delegate's signature value. Defaults to a `scvVoid` placeholder, which
-you can fill afterwards with `authorizeEntry` (passing this address
+you can fill afterwards with [`authorizeEntry`](#authorizeentry) (passing this address
 as `forAddress`) or by editing the entry directly.
 
 ```ts
@@ -1686,7 +1686,7 @@ Details about a contract function execution invocation.
 - `source` is the strkey of the contract (`C...`) being invoked
 - `function` is the name of the function being invoked
 - `args` are the natively-represented parameters to the function invocation
-  (see `scValToNative` for rules on how they're represented as JS types)
+  (see [`scValToNative`](#scvaltonative) for rules on how they're represented as JS types)
 
 ```ts
 interface ExecuteInvocation {
@@ -1732,7 +1732,7 @@ Details about a contract creation from an external executable (CAP-85).
   `SCString`, so it is not always text: a lenient UTF-8 decode would render
   two distinct tags identically, and the tag is half of what identifies the
   code being deployed. Binary tags come back as raw bytes, matching
-  `scValToNative`
+  [`scValToNative`](#scvaltonative)
 - `address` is the strkey of the deployer and `salt` its hex-encoded salt,
   which together derive the new contract's ID
 

--- a/docs/reference/core-soroban-primitives.md
+++ b/docs/reference/core-soroban-primitives.md
@@ -342,7 +342,7 @@ static formatTokenAmount(amount: string, decimals: number): string;
 
 **Throws**
 
-- if the given amount has a decimal point already
+- a `TypeError` if the given amount has a decimal point already
 
 **Example**
 
@@ -352,7 +352,7 @@ formatTokenAmount("123000", 3) === "123.0";
 formatTokenAmount("123", 3) === "0.123";
 ```
 
-**Source:** [src/base/soroban.ts:19](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/soroban.ts#L19)
+**Source:** [src/base/soroban.ts:21](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/soroban.ts#L21)
 
 ### `Soroban.parseTokenAmount(value, decimals)`
 
@@ -384,7 +384,7 @@ const parsedAmtForSmartContract = parseTokenAmount(displayValueAmount, 5);
 parsedAmtForSmartContract === "12345600"
 ```
 
-**Source:** [src/base/soroban.ts:73](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/soroban.ts#L73)
+**Source:** [src/base/soroban.ts:77](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/soroban.ts#L77)
 
 ## SorobanDataBuilder
 
@@ -429,7 +429,7 @@ const newData = new SorobanDataBuilder()
   .build();
 ```
 
-**Source:** [src/base/sorobandata_builder.ts:34](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L34)
+**Source:** [src/base/sorobandata_builder.ts:36](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L36)
 
 ### `new SorobanDataBuilder(sorobanData)`
 
@@ -444,7 +444,7 @@ constructor(sorobanData?: string | Uint8Array<ArrayBufferLike> | SorobanTransact
        (it will be copied); if omitted or "falsy" (e.g. an empty string), it
        starts with an empty instance
 
-**Source:** [src/base/sorobandata_builder.ts:43](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L43)
+**Source:** [src/base/sorobandata_builder.ts:45](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L45)
 
 ### `SorobanDataBuilder.fromXdr(data)`
 
@@ -458,7 +458,7 @@ static fromXdr(data: string | Uint8Array<ArrayBufferLike>): SorobanTransactionDa
 
 - **`data`** — `string | Uint8Array<ArrayBufferLike>` (required) — raw input to decode
 
-**Source:** [src/base/sorobandata_builder.ts:74](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L74)
+**Source:** [src/base/sorobandata_builder.ts:76](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L76)
 
 ### `sorobanDataBuilder.appendFootprint(readOnly, readWrite)`
 
@@ -473,7 +473,7 @@ appendFootprint(readOnly: LedgerKey[], readWrite: LedgerKey[]): SorobanDataBuild
 - **`readOnly`** — `LedgerKey[]` (required) — read-only keys to add
 - **`readWrite`** — `LedgerKey[]` (required) — read-write keys to add
 
-**Source:** [src/base/sorobandata_builder.ts:137](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L137)
+**Source:** [src/base/sorobandata_builder.ts:139](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L139)
 
 ### `sorobanDataBuilder.build()`
 
@@ -483,7 +483,7 @@ Returns a copy of the final data structure.
 build(): SorobanTransactionData;
 ```
 
-**Source:** [src/base/sorobandata_builder.ts:218](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L218)
+**Source:** [src/base/sorobandata_builder.ts:220](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L220)
 
 ### `sorobanDataBuilder.getFootprint()`
 
@@ -493,7 +493,7 @@ Returns the storage access pattern.
 getFootprint(): LedgerFootprint;
 ```
 
-**Source:** [src/base/sorobandata_builder.ts:237](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L237)
+**Source:** [src/base/sorobandata_builder.ts:239](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L239)
 
 ### `sorobanDataBuilder.getReadOnly()`
 
@@ -503,7 +503,7 @@ Returns the read-only storage access pattern.
 getReadOnly(): LedgerKey[];
 ```
 
-**Source:** [src/base/sorobandata_builder.ts:227](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L227)
+**Source:** [src/base/sorobandata_builder.ts:229](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L229)
 
 ### `sorobanDataBuilder.getReadWrite()`
 
@@ -513,7 +513,7 @@ Returns the read-write storage access pattern.
 getReadWrite(): LedgerKey[];
 ```
 
-**Source:** [src/base/sorobandata_builder.ts:232](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L232)
+**Source:** [src/base/sorobandata_builder.ts:234](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L234)
 
 ### `sorobanDataBuilder.setFootprint(readOnly, readWrite)`
 
@@ -536,7 +536,7 @@ setFootprint(readOnly?: LedgerKey[] | null, readWrite?: LedgerKey[] | null): Sor
 - **`readOnly`** — `LedgerKey[] | null` (optional) — the set of ledger keys to set in the read-only portion of the transaction's `sorobanData`, or `null | undefined` to keep the existing keys
 - **`readWrite`** — `LedgerKey[] | null` (optional) — the set of ledger keys to set in the read-write portion of the transaction's `sorobanData`, or `null | undefined` to keep the existing keys
 
-**Source:** [src/base/sorobandata_builder.ts:161](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L161)
+**Source:** [src/base/sorobandata_builder.ts:163](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L163)
 
 ### `sorobanDataBuilder.setReadOnly(readOnly)`
 
@@ -550,7 +550,7 @@ setReadOnly(readOnly?: LedgerKey[]): SorobanDataBuilder;
 
 - **`readOnly`** — `LedgerKey[]` (optional) — read-only keys in the access footprint
 
-**Source:** [src/base/sorobandata_builder.ts:180](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L180)
+**Source:** [src/base/sorobandata_builder.ts:182](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L182)
 
 ### `sorobanDataBuilder.setReadWrite(readWrite)`
 
@@ -564,7 +564,7 @@ setReadWrite(readWrite?: LedgerKey[]): SorobanDataBuilder;
 
 - **`readWrite`** — `LedgerKey[]` (optional) — read-write keys in the access footprint
 
-**Source:** [src/base/sorobandata_builder.ts:200](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L200)
+**Source:** [src/base/sorobandata_builder.ts:202](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L202)
 
 ### `sorobanDataBuilder.setResourceFee(fee)`
 
@@ -578,7 +578,7 @@ setResourceFee(fee: IntLike): SorobanDataBuilder;
 
 - **`fee`** — `IntLike` (required) — the resource fee to set (int64)
 
-**Source:** [src/base/sorobandata_builder.ts:95](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L95)
+**Source:** [src/base/sorobandata_builder.ts:97](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L97)
 
 ### `sorobanDataBuilder.setResources(cpuInstrs, diskReadBytes, writeBytes)`
 
@@ -597,7 +597,7 @@ setResources(cpuInstrs: number, diskReadBytes: number, writeBytes: number): Soro
 - **`diskReadBytes`** — `number` (required) — number of bytes being read from disk
 - **`writeBytes`** — `number` (required) — number of bytes being written to disk/memory
 
-**Source:** [src/base/sorobandata_builder.ts:114](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L114)
+**Source:** [src/base/sorobandata_builder.ts:116](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/sorobandata_builder.ts#L116)
 
 ## authorizeEntry
 
@@ -964,22 +964,22 @@ native JavaScript types.
 
 The conversions are as follows:
 
- - xdr.ScVal -> passthrough
- - null/undefined -> scvVoid
- - string -> scvString (a copy is made)
- - UintArray8 -> scvBytes (a copy is made)
- - boolean -> scvBool
+ - xdr.ScVal → passthrough
+ - null/undefined → scvVoid
+ - string → scvString (a copy is made)
+ - UintArray8 → scvBytes (a copy is made)
+ - boolean → scvBool
 
- - number/bigint -> the smallest possible XDR integer type that will fit the
+ - number/bigint → the smallest possible XDR integer type that will fit the
    input value (if you want a specific type, use `ScInt`)
 
- - `Address` or `Contract` -> scvAddress (for contracts and
+ - `Address` or `Contract` → scvAddress (for contracts and
    public keys)
 
- - Array<T> -> scvVec after attempting to convert each item of type `T` to an
+ - `Array<T>` → scvVec after attempting to convert each item of type `T` to an
    xdr.ScVal (recursively). note that all values must be the same type!
 
- - object -> scvMap after attempting to convert each key and value to an
+ - object → scvMap after attempting to convert each key and value to an
    xdr.ScVal (recursively). note that there is no restriction on types
    matching anywhere (unlike arrays)
 
@@ -998,10 +998,36 @@ nativeToScVal(val: unknown, opts: NativeToScValOpts = {}): ScVal
 - **`val`** — `unknown` (required) — a native (or convertible) input value to wrap
 - **`opts`** — `NativeToScValOpts` (optional) (default: `{}`) — an optional set of hints around the type of
      conversion you'd like to see
+    - `type`: there is different behavior for different input
+      types for `val`:
+  
+      - when `val` is an integer-like type (i.e. number|bigint), this will be
+        forwarded to `ScInt` or forced to be u32/i32.
+  
+      - when `val` is an array type, this is forwarded to the recursion
+  
+      - when `val` is an object type (key-value entries), this should be an
+        object in which each key has a pair of types (to represent forced types
+        for the key and the value), where `null` (or a missing entry) indicates
+        the default interpretation(s) (refer to the examples, below)
+  
+      - when `val` is a `Map`, this can be a `[keyType, valType]` pair applied
+        to every entry, or (when all keys are strings) the same per-key spec
+        object used for plain objects
+  
+      - when `val` is a string type, this can be 'string' or 'symbol' to force
+        a particular interpretation of `val`.
+  
+      - when `val` is a bytes-like type, this can be 'string', 'symbol', or
+        'bytes' to force a particular interpretation
+  
+     As a simple example, `nativeToScVal("hello", {type: 'symbol'})` will
+     return an `scvSymbol`, whereas without the type it would have been an
+     `scvString`.
 
 **Throws**
 
-- if...
+- a `TypeError` if...
  - there are arrays with more than one type in them
  - there are values that do not have a sensible conversion (e.g. random XDR
    types, custom classes)
@@ -1049,7 +1075,7 @@ import {
   scValToNative,
   ScInt,
   xdr
-} from '@stellar/stellar-base';
+} from '@stellar/stellar-sdk';
 
 let gigaMap = {
   bool: true,
@@ -1085,22 +1111,22 @@ scValToNative(scv) == gigaMap;       // true
 
 - scValToNative
 
-**Source:** [src/base/scval.ts:168](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/scval.ts#L168)
+**Source:** [src/base/scval.ts:172](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/scval.ts#L172)
 
 ## scValToNative
 
 Given a smart contract value, attempt to convert it to a native type.
 Possible conversions include:
 
- - void -> `null`
- - u32, i32 -> `number`
- - u64, i64, u128, i128, u256, i256, timepoint, duration -> `bigint`
- - vec -> `Array` of any of the above (via recursion)
- - map -> key-value object of any of the above (via recursion)
- - bool -> `boolean`
- - bytes -> `Uint8Array`
- - symbol -> `string`
- - string -> `string` IF the underlying buffer can be decoded as ascii/utf8,
+ - void → `null`
+ - u32, i32 → `number`
+ - u64, i64, u128, i128, u256, i256, timepoint, duration → `bigint`
+ - vec → `Array` of any of the above (via recursion)
+ - map → key-value object of any of the above (via recursion)
+ - bool → `boolean`
+ - bytes → `Uint8Array`
+ - symbol → `string`
+ - string → `string` IF the underlying buffer can be decoded as ascii/utf8,
              `Uint8Array` of the raw contents in any error case
 
 If no viable conversion can be determined, this just "unwraps" the smart
@@ -1118,7 +1144,7 @@ scValToNative(scv: ScVal): any
 
 - nativeToScVal
 
-**Source:** [src/base/scval.ts:427](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/scval.ts#L427)
+**Source:** [src/base/scval.ts:431](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/scval.ts#L431)
 
 ## scvSortedMap
 
@@ -1132,7 +1158,7 @@ scvSortedMap(items: ScMapEntry[]): ScVal
 
 - **`items`** — `ScMapEntry[]` (required) — the unsorted map entries
 
-**Source:** [src/base/scval.ts:526](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/scval.ts#L526)
+**Source:** [src/base/scval.ts:530](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/scval.ts#L530)
 
 ## walkInvocationTree
 

--- a/docs/reference/core-transactions.md
+++ b/docs/reference/core-transactions.md
@@ -10,7 +10,7 @@ description: Build, sign, and inspect Stellar transactions with the TransactionB
 Create a new Account object.
 
 `Account` represents a single account in the Stellar network and its sequence
-number. Account tracks the sequence number as it is used by `TransactionBuilder`. See
+number. Account tracks the sequence number as it is used by [`TransactionBuilder`](#transactionbuilder). See
 [Accounts](https://developers.stellar.org/docs/glossary/accounts/) for
 more information about how accounts work in Stellar.
 
@@ -35,7 +35,7 @@ constructor(accountId: string, sequence: string);
 
 - **`accountId`** — `string` (required) — ID of the account (ex.
       `GB3KJPLFUYN5VL6R3GU3EGCGVCKFDSD7BEDX42HWG5BWFKB3KQGJJRMA`). If you
-      provide a muxed account address, this will throw; use `MuxedAccount` instead.
+      provide a muxed account address, this will throw; use [`MuxedAccount`](#muxedaccount) instead.
 - **`sequence`** — `string` (required) — current sequence number of the account
 
 **Source:** [src/base/account.ts:27](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/account.ts#L27)
@@ -153,12 +153,12 @@ const BASE_FEE: "100"
 
 ## FeeBumpTransaction
 
-Use `TransactionBuilder.buildFeeBumpTransaction` to build a
+Use [`TransactionBuilder.buildFeeBumpTransaction`](#transactionbuilderbuildfeebumptransactionfeesource-basefee-innertx-networkpassphrase) to build a
 FeeBumpTransaction object. If you have an object or base64-encoded string of
-the transaction envelope XDR use `TransactionBuilder.fromXdr`.
+the transaction envelope XDR use [`TransactionBuilder.fromXdr`](#transactionbuilderfromxdrenvelope-networkpassphrase).
 
-Once a `FeeBumpTransaction` has been created, its attributes and operations
-should not be changed. You should only add signatures (using `FeeBumpTransaction#sign`) before
+Once a [`FeeBumpTransaction`](#feebumptransaction) has been created, its attributes and operations
+should not be changed. You should only add signatures (using [`FeeBumpTransaction#sign`](#feebumptransactionsignkeypairs)) before
 submitting to the network or forwarding on to additional signers.
 
 ```ts
@@ -311,9 +311,9 @@ base64-encoded XDR string.
 transactions onto your account! Doing so will invalidate this pre-compiled
 transaction!
 - Send this XDR string to your other parties. They can use the instructions
-for `getKeypairSignature` to sign the transaction.
+for [`getKeypairSignature`](#feebumptransactiongetkeypairsignaturekeypair) to sign the transaction.
 - They should send you back their `publicKey` and the `signature` string
-from `getKeypairSignature`, both of which you pass to
+from [`getKeypairSignature`](#feebumptransactiongetkeypairsignaturekeypair), both of which you pass to
 this function.
 
 ```ts
@@ -329,13 +329,13 @@ addSignature(publicKey: string = "", signature: string = ""): void;
 
 ### `feeBumpTransaction.getKeypairSignature(keypair)`
 
-Signs a transaction with the given `Keypair`. Useful if someone sends
+Signs a transaction with the given [`Keypair`](/reference/core-keys/#keypair). Useful if someone sends
 you a transaction XDR for you to sign and return (see
-`addSignature` for more information).
+[`addSignature`](#feebumptransactionaddsignaturepublickey-signature) for more information).
 
 When you get a transaction XDR to sign....
 - Instantiate a `Transaction` object with the XDR
-- Use `Keypair` to generate a keypair object for your Stellar seed.
+- Use [`Keypair`](/reference/core-keys/#keypair) to generate a keypair object for your Stellar seed.
 - Run `getKeypairSignature` with that keypair
 - Send back the signature along with your publicKey (not your secret seed!)
 
@@ -371,7 +371,7 @@ hash(): Uint8Array;
 
 ### `feeBumpTransaction.sign(keypairs)`
 
-Signs the transaction with the given `Keypair`.
+Signs the transaction with the given [`Keypair`](/reference/core-keys/#keypair).
 
 ```ts
 sign(...keypairs: Keypair[]): void;
@@ -472,7 +472,7 @@ constructor(type: "none", value?: null);
 
 ### `Memo.fromXdrObject(object)`
 
-Returns `Memo` from XDR memo object.
+Returns [`Memo`](#memo) from XDR memo object.
 
 ```ts
 static fromXdrObject(object: Memo): Memo;
@@ -588,7 +588,7 @@ toXdrObject(): Memo;
 
 ## MemoHash
 
-Type of `Memo`.
+Type of [`Memo`](#memo).
 
 ```ts
 const MemoHash: "hash"
@@ -598,7 +598,7 @@ const MemoHash: "hash"
 
 ## MemoID
 
-Type of `Memo`.
+Type of [`Memo`](#memo).
 
 ```ts
 const MemoID: "id"
@@ -608,7 +608,7 @@ const MemoID: "id"
 
 ## MemoNone
 
-Type of `Memo`.
+Type of [`Memo`](#memo).
 
 ```ts
 const MemoNone: "none"
@@ -618,7 +618,7 @@ const MemoNone: "none"
 
 ## MemoReturn
 
-Type of `Memo`.
+Type of [`Memo`](#memo).
 
 ```ts
 const MemoReturn: "return"
@@ -628,7 +628,7 @@ const MemoReturn: "return"
 
 ## MemoText
 
-Type of `Memo`.
+Type of [`Memo`](#memo).
 
 ```ts
 const MemoText: "text"
@@ -660,9 +660,9 @@ the raw XDR.
 
 Because muxed accounts are purely an off-chain convention, they all share the
 sequence number tied to their underlying G... account. Thus, this object
-*requires* an `Account` instance to be passed in, so that muxed
+*requires* an [`Account`](#account) instance to be passed in, so that muxed
 instances of an account can collectively modify the sequence number whenever
-a muxed account is used as the source of a `Transaction` with `TransactionBuilder`.
+a muxed account is used as the source of a [`Transaction`](#transaction) with [`TransactionBuilder`](#transactionbuilder).
 
 ```ts
 class MuxedAccount implements TransactionSource {
@@ -693,7 +693,7 @@ constructor(baseAccount: Account, id: string);
 
 **Parameters**
 
-- **`baseAccount`** — `Account` (required) — the `Account` instance representing the
+- **`baseAccount`** — `Account` (required) — the [`Account`](#account) instance representing the
       underlying G... address
 - **`id`** — `string` (required) — a stringified uint64 value that represents the ID of the
       muxed account
@@ -711,7 +711,7 @@ static fromAddress(mAddress: string, sequenceNum: string): MuxedAccount;
 **Parameters**
 
 - **`mAddress`** — `string` (required) — an M-address to transform
-- **`sequenceNum`** — `string` (required) — the sequence number of the underlying `Account`, to use for the underlying base account `MuxedAccount.baseAccount`. If you're using the SDK, you can use
+- **`sequenceNum`** — `string` (required) — the sequence number of the underlying [`Account`](#account), to use for the underlying base account [`MuxedAccount.baseAccount`](#muxedaccountbaseaccount). If you're using the SDK, you can use
       `server.loadAccount` to fetch this if you don't know it.
 
 **Source:** [src/base/muxed_account.ts:96](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/muxed_account.ts#L96)
@@ -1199,7 +1199,7 @@ static createStellarAssetContract: (opts: CreateStellarAssetContractOpts) => Ope
 **Parameters**
 
 - **`opts`** — `CreateStellarAssetContractOpts` (required) — the set of parameters
-    - `asset`: the Stellar asset to wrap, either as an `Asset` object or in canonical form (SEP-11, `code:issuer`)
+    - `asset`: the Stellar asset to wrap, either as an [`Asset`](/reference/core-assets/#asset) object or in canonical form (SEP-11, `code:issuer`)
     - `auth`: an optional list outlining the tree of authorizations required for the upload
     - `source`: an optional source account
 
@@ -1249,7 +1249,7 @@ the exact ledger until the entries will live will only be determined
 when transaction has been applied.
 
 The footprint has to be specified in the transaction. See
-`TransactionBuilder`'s `opts.sorobanData` parameter, which is a
+[`TransactionBuilder`](#transactionbuilder)'s `opts.sorobanData` parameter, which is a
 `xdr.SorobanTransactionData` instance that contains fee data & resource
 usage as part of `xdr.SorobanResources`.
 
@@ -1548,8 +1548,8 @@ The ledger keys to restore are specified separately from the operation
 in read-write footprint of the transaction.
 
 It takes no parameters because the relevant footprint is derived from the
-transaction itself. See `TransactionBuilder`'s `opts.sorobanData`
-parameter (or `TransactionBuilder.setSorobanData`), which is a
+transaction itself. See [`TransactionBuilder`](#transactionbuilder)'s `opts.sorobanData`
+parameter (or [`TransactionBuilder.setSorobanData`](#transactionbuildersetsorobandatasorobandata)), which is a
 `xdr.SorobanTransactionData` instance that contains fee data & resource
 usage as part of `xdr.SorobanTransactionData`.
 
@@ -1817,7 +1817,7 @@ static setTrustLineFlags: (opts: SetTrustLineFlagsOpts) => Operation;
       - `authorizedToMaintainLiabilities`: authorize
         account to maintain and reduce liabilities for its credit
       - `clawbackEnabled`: stop claimable balances on
-        this trustlines from having clawbacks enabled (this flag can only be set
+        this trustline from having clawbacks enabled (this flag can only be set
         to false!)
     - `source`: The source account for the operation.
       Defaults to the transaction's source account.
@@ -1874,7 +1874,7 @@ bigints, strings, or numbers (whole numbers, or this will throw).
 
 If you need to create a native BigInt from a list of integer "parts" (for
 example, you have a series of encoded 32-bit integers that represent a larger
-value), you can use the lower level abstraction `XdrLargeInt`. For
+value), you can use the lower level abstraction [`XdrLargeInt`](#xdrlargeint). For
 example, you could do `new XdrLargeInt('u128', bytes...).toBigInt()`.
 
 ```ts
@@ -1973,7 +1973,7 @@ constructor(value: string | number | bigint, opts?: { type?: ScIntType; [key: st
 ### `ScInt.getType(scvType)`
 
 Convert the raw `ScValType` string (e.g. 'scvI128', generated by the XDR)
-to a type description for `XdrLargeInt` construction (e.g. 'i128')
+to a type description for [`XdrLargeInt`](#xdrlargeint) construction (e.g. 'i128')
 
 ```ts
 static getType(scvType: string): ScIntType | undefined;
@@ -1985,7 +1985,7 @@ static getType(scvType: string): ScIntType | undefined;
 
 **Returns**
 
-the corresponding `ScIntType` if it's an integer type, or
+the corresponding [`ScIntType`](#scinttype-1) if it's an integer type, or
    `undefined` if it's not an integer type
 
 **Source:** [src/base/numbers/xdr_large_int.ts:330](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/xdr_large_int.ts#L330)
@@ -2203,7 +2203,7 @@ const TimeoutInfinite: 0
 
 **See also**
 
-- - `TransactionBuilder#setTimeout`
+- - [`TransactionBuilder#setTimeout`](#transactionbuildersettimeouttimeoutseconds)
  - [Timeout](https://developers.stellar.org/api/resources/transactions/post/)
 
 **Source:** [src/base/transaction_builder.ts:76](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L76)
@@ -2258,7 +2258,7 @@ constructor(envelope: string | TransactionEnvelope, networkPassphrase: string);
 
 ### `transaction.extraSigners`
 
-Array of extra signers as XDR objects; use `SignerKey.encodeSignerKey`
+Array of extra signers as XDR objects; use [`SignerKey.encodeSignerKey`](/reference/core-keys/#signerkeyencodesignerkeysignerkey)
 to convert to StrKey strings.
 
 ```ts
@@ -2441,9 +2441,9 @@ base64-encoded XDR string.
 transactions onto your account! Doing so will invalidate this pre-compiled
 transaction!
 - Send this XDR string to your other parties. They can use the instructions
-for `getKeypairSignature` to sign the transaction.
+for [`getKeypairSignature`](#transactiongetkeypairsignaturekeypair) to sign the transaction.
 - They should send you back their `publicKey` and the `signature` string
-from `getKeypairSignature`, both of which you pass to
+from [`getKeypairSignature`](#transactiongetkeypairsignaturekeypair), both of which you pass to
 this function.
 
 ```ts
@@ -2482,13 +2482,13 @@ getClaimableBalanceId(opIndex: number): string;
 
 ### `transaction.getKeypairSignature(keypair)`
 
-Signs a transaction with the given `Keypair`. Useful if someone sends
+Signs a transaction with the given [`Keypair`](/reference/core-keys/#keypair). Useful if someone sends
 you a transaction XDR for you to sign and return (see
-`addSignature` for more information).
+[`addSignature`](#transactionaddsignaturepublickey-signature) for more information).
 
 When you get a transaction XDR to sign....
 - Instantiate a `Transaction` object with the XDR
-- Use `Keypair` to generate a keypair object for your Stellar seed.
+- Use [`Keypair`](/reference/core-keys/#keypair) to generate a keypair object for your Stellar seed.
 - Run `getKeypairSignature` with that keypair
 - Send back the signature along with your publicKey (not your secret seed!)
 
@@ -2524,7 +2524,7 @@ hash(): Uint8Array;
 
 ### `transaction.sign(keypairs)`
 
-Signs the transaction with the given `Keypair`.
+Signs the transaction with the given [`Keypair`](/reference/core-keys/#keypair).
 
 ```ts
 sign(...keypairs: Keypair[]): void;
@@ -2588,7 +2588,7 @@ toXdr(): string;
 ## TransactionBuilder
 
 <p>Transaction builder helps constructs a new [`Transaction`](#transaction) using the
-given `Account` as the transaction's "source account". The transaction
+given [`Account`](#account) as the transaction's "source account". The transaction
 will use the current sequence number of the given account as its sequence
 number and increment the given account's sequence number by one. The given
 source account must include a private key for signing the transaction or an
@@ -2598,7 +2598,7 @@ error will be thrown.</p>
 methods, and each returns the TransactionBuilder object so they can be
 chained together. After adding the desired operations, call the `build()`
 method on the `TransactionBuilder` to return a fully constructed
-`Transaction` that can be signed. The returned transaction will contain the
+[`Transaction`](#transaction) that can be signed. The returned transaction will contain the
 sequence number of the source account and include the signature from the
 source account.</p>
 
@@ -2611,7 +2611,7 @@ account's sequence number with
 [Server.loadAccount](https://stellar.github.io/js-stellar-sdk/Server.html#loadAccount)
 before creating another transaction.</p>
 
-<p>The following code example creates a new transaction with `Operation.createAccount` and `Operation.payment` operations. The
+<p>The following code example creates a new transaction with [`Operation.createAccount`](#operationcreateaccount) and [`Operation.payment`](#operationpayment) operations. The
 Transaction's source account first funds `destinationA`, then sends a payment
 to `destinationB`. The built transaction is then signed by
 `sourceKeypair`.</p>
@@ -2688,7 +2688,7 @@ constructor(sourceAccount: TransactionSource, opts: TransactionBuilderOptions = 
 
 ### `TransactionBuilder.buildFeeBumpTransaction(feeSource, baseFee, innerTx, networkPassphrase)`
 
-Builds a `FeeBumpTransaction`, enabling you to resubmit an existing
+Builds a [`FeeBumpTransaction`](#feebumptransaction), enabling you to resubmit an existing
 transaction with a higher fee.
 
 ```ts
@@ -2702,11 +2702,11 @@ static buildFeeBumpTransaction(feeSource: string | Keypair, baseFee: string, inn
       an account ID (in G... or M... form, but refer to `withMuxing`)
 - **`baseFee`** — `string` (required) — max fee willing to pay per operation
       in inner transaction (**in stroops**)
-- **`innerTx`** — `Transaction` (required) — `Transaction` to be bumped by
+- **`innerTx`** — `Transaction` (required) — [`Transaction`](#transaction) to be bumped by
       the fee bump transaction
 - **`networkPassphrase`** — `string` (required) — passphrase of the target
       Stellar network (e.g. "Public Global Stellar Network ; September 2015",
-      see `Networks`)
+      see [`Networks`](#networks))
 
 **See also**
 
@@ -2716,7 +2716,7 @@ static buildFeeBumpTransaction(feeSource: string | Keypair, baseFee: string, inn
 
 ### `TransactionBuilder.cloneFrom(tx, opts)`
 
-Creates a builder instance using an existing `Transaction` as a
+Creates a builder instance using an existing [`Transaction`](#transaction) as a
 template, ignoring any existing envelope signatures.
 
 Note that the sequence number WILL be cloned, so EITHER this transaction or
@@ -2734,13 +2734,13 @@ static cloneFrom(tx: Transaction, opts: Partial<TransactionBuilderOptions> = {})
 - **`tx`** — `Transaction` (required) — a "template" transaction to clone exactly
 - **`opts`** — `Partial<TransactionBuilderOptions>` (optional) (default: `{}`) — additional options to override the clone, e.g.
      `{fee: '1000'}` will override the existing base fee derived from `tx` (see
-     the `TransactionBuilder` constructor for detailed options)
+     the [`TransactionBuilder`](#transactionbuilder) constructor for detailed options)
 
 **Source:** [src/base/transaction_builder.ts:313](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L313)
 
 ### `TransactionBuilder.fromXdr(envelope, networkPassphrase)`
 
-Build a `Transaction` or `FeeBumpTransaction` from an
+Build a [`Transaction`](#transaction) or [`FeeBumpTransaction`](#feebumptransaction) from an
 xdr.TransactionEnvelope.
 
 ```ts
@@ -2753,7 +2753,7 @@ static fromXdr(envelope: string | TransactionEnvelope, networkPassphrase: string
       object or base64 encoded string.
 - **`networkPassphrase`** — `string` (required) — The network passphrase of the target
       Stellar network (e.g. "Public Global Stellar Network ; September
-      2015"), see `Networks`.
+      2015"), see [`Networks`](#networks).
 
 **Source:** [src/base/transaction_builder.ts:1259](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1259)
 
@@ -2863,7 +2863,7 @@ addMemo(memo: Memo): TransactionBuilder;
 
 **Parameters**
 
-- **`memo`** — `Memo` (required) — `Memo` object
+- **`memo`** — `Memo` (required) — [`Memo`](#memo) object
 
 **Source:** [src/base/transaction_builder.ts:445](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L445)
 
@@ -2891,7 +2891,7 @@ addOperationAt(operation: Operation, index: number): TransactionBuilder;
 
 **Parameters**
 
-- **`operation`** — `Operation` (required) — The xdr operation object to add, use `Operation` static methods.
+- **`operation`** — `Operation` (required) — The xdr operation object to add, use [`Operation`](#operation) static methods.
 - **`index`** — `number` (required) — The index at which to insert the operation.
 
 **Source:** [src/base/transaction_builder.ts:418](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L418)
@@ -2973,7 +2973,7 @@ setExtraSigners(extraSigners: string[]): TransactionBuilder;
 
 **Parameters**
 
-- **`extraSigners`** — `string[]` (required) — required extra signers (as `StrKey`s)
+- **`extraSigners`** — `string[]` (required) — required extra signers (as [`StrKey`](/reference/core-keys/#strkey)s)
 
 **Source:** [src/base/transaction_builder.ts:689](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L689)
 
@@ -3087,7 +3087,7 @@ the case of Soroban transactions, this is either an instance of
 `xdr.SorobanTransactionData` or a base64-encoded string of said
 structure. This is usually obtained from the simulation response based on a
 transaction with a Soroban operation (e.g.
-`Operation.invokeHostFunction`, providing necessary resource
+[`Operation.invokeHostFunction`](#operationinvokehostfunction), providing necessary resource
 and storage footprint estimations for contract invocation.
 
 ```ts
@@ -3101,7 +3101,7 @@ setSorobanData(sorobanData: string | SorobanTransactionData): TransactionBuilder
 
 **See also**
 
-- `SorobanDataBuilder`
+- [`SorobanDataBuilder`](/reference/core-soroban-primitives/#sorobandatabuilder)
 
 **Source:** [src/base/transaction_builder.ts:737](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L737)
 
@@ -3143,8 +3143,8 @@ Sets a timeout precondition on the transaction.
 
  A call to `TransactionBuilder.setTimeout` is **required** if Transaction
  does not have `max_time` set. If you don't want to set timeout, use
- `TimeoutInfinite`. In general you should set
- `TimeoutInfinite` only in smart contracts.
+ [`TimeoutInfinite`](#timeoutinfinite). In general you should set
+ [`TimeoutInfinite`](#timeoutinfinite) only in smart contracts.
 
  Please note that Horizon may still return <code>504 Gateway Timeout</code>
  error, even for short timeouts. In such case you need to resubmit the same
@@ -3159,12 +3159,12 @@ setTimeout(timeoutSeconds: number): TransactionBuilder;
 **Parameters**
 
 - **`timeoutSeconds`** — `number` (required) — Number of seconds the transaction is good.
-      Can't be negative. If the value is `TimeoutInfinite`, the
+      Can't be negative. If the value is [`TimeoutInfinite`](#timeoutinfinite), the
       transaction is good indefinitely.
 
 **See also**
 
-- - `TimeoutInfinite`
+- - [`TimeoutInfinite`](#timeoutinfinite)
  - https://developers.stellar.org/docs/tutorials/handling-errors/
 
 **Source:** [src/base/transaction_builder.ts:479](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L479)
@@ -3173,7 +3173,7 @@ setTimeout(timeoutSeconds: number): TransactionBuilder;
 
 A wrapper class to represent large XDR-encodable integers.
 
-This operates at a lower level than `ScInt` by forcing you to specify
+This operates at a lower level than [`ScInt`](#scint) by forcing you to specify
 the type / width / size in bits of the integer you're targeting, regardless
 of the input value(s) you provide.
 
@@ -3214,7 +3214,7 @@ constructor(type: ScIntType, values: XdrLargeIntValues);
 
 - **`type`** — `ScIntType` (required) — specifies a data type to use to represent the integer, one
      of: 'i64', 'u64', 'i128', 'u128', 'i256', 'u256', 'timepoint', and 'duration'
-     (see `XdrLargeInt.isType`)
+     (see [`XdrLargeInt.isType`](#xdrlargeintistypetype))
 - **`values`** — `XdrLargeIntValues` (required) — a single integer-like value, or a list of slices in
      **little-endian** order (parts[0] is the least-significant slice),
      matching the legacy `LargeInt` contract — e.g.
@@ -3227,7 +3227,7 @@ constructor(type: ScIntType, values: XdrLargeIntValues);
 ### `XdrLargeInt.getType(scvType)`
 
 Convert the raw `ScValType` string (e.g. 'scvI128', generated by the XDR)
-to a type description for `XdrLargeInt` construction (e.g. 'i128')
+to a type description for [`XdrLargeInt`](#xdrlargeint) construction (e.g. 'i128')
 
 ```ts
 static getType(scvType: string): ScIntType | undefined;
@@ -3239,7 +3239,7 @@ static getType(scvType: string): ScIntType | undefined;
 
 **Returns**
 
-the corresponding `ScIntType` if it's an integer type, or
+the corresponding [`ScIntType`](#scinttype-1) if it's an integer type, or
    `undefined` if it's not an integer type
 
 **Source:** [src/base/numbers/xdr_large_int.ts:330](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/xdr_large_int.ts#L330)
@@ -3522,7 +3522,7 @@ extractBaseAddress(address: string): string
 Transforms an opaque `xdr.ScVal` into a native bigint, if possible.
 
 If you then want to use this in the abstractions provided by this module,
-you can pass it to the constructor of `XdrLargeInt`.
+you can pass it to the constructor of [`XdrLargeInt`](#xdrlargeint).
 
 ```ts
 scValToBigInt(scv: ScVal): bigint
@@ -4462,16 +4462,16 @@ writeBytes: number;
 
 ### TransactionSource
 
-The contract that `TransactionBuilder` requires of a transaction's
+The contract that [`TransactionBuilder`](#transactionbuilder) requires of a transaction's
 source account: a way to read the account's address and sequence number, and
 to advance the sequence number in place (the builder calls
-`TransactionSource.incrementSequenceNumber` when it builds a
+[`TransactionSource.incrementSequenceNumber`](#transactionsourceincrementsequencenumber) when it builds a
 transaction).
 
-Both the concrete `Account` and `MuxedAccount` classes implement
+Both the concrete [`Account`](#account) and [`MuxedAccount`](#muxedaccount) classes implement
 this, as does Horizon's `AccountResponse`. Implement it yourself if you manage
 sequence numbers out-of-band (e.g. a server-side sequence pool) and want to
-pass a custom source to `TransactionBuilder`.
+pass a custom source to [`TransactionBuilder`](#transactionbuilder).
 
 This is intentionally a brand-free structural interface: assignability is by
 shape, not by class identity, so any account-like object that honors the
@@ -4500,7 +4500,7 @@ accountId(): string;
 
 #### `transactionSource.incrementSequenceNumber()`
 
-Increments the sequence number in place by one. `TransactionBuilder`
+Increments the sequence number in place by one. [`TransactionBuilder`](#transactionbuilder)
 calls this when building a transaction so that the next transaction built
 from the same source uses the next sequence number.
 

--- a/docs/reference/core-transactions.md
+++ b/docs/reference/core-transactions.md
@@ -915,6 +915,9 @@ static accountMerge: (opts: AccountMergeOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `AccountMergeOpts` (required) — options object
+    - `destination`: destination to merge the source account into
+    - `source`: operation source account (defaults to
+      transaction source)
 
 **Source:** [src/base/operation.ts:444](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operation.ts#L444)
 
@@ -932,6 +935,10 @@ static allowTrust: (opts: AllowTrustOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `AllowTrustOpts` (required) — Options object
+    - `trustor`: The trusting account (the one being authorized)
+    - `assetCode`: The asset code being authorized.
+    - `authorize`: `1` to authorize, `2` to authorize to maintain liabilities, and `0` to deauthorize.
+    - `source`: The source account (defaults to transaction source).
 
 **Source:** [src/base/operation.ts:445](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operation.ts#L445)
 
@@ -946,6 +953,8 @@ static beginSponsoringFutureReserves: (opts: BeginSponsoringFutureReservesOpts) 
 **Parameters**
 
 - **`opts`** — `BeginSponsoringFutureReservesOpts` (required) — Options object
+    - `sponsoredId`: The sponsored account id.
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **Example**
 
@@ -968,6 +977,8 @@ static bumpSequence: (opts: BumpSequenceOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `BumpSequenceOpts` (required) — Options object
+    - `bumpTo`: Sequence number to bump to.
+    - `source`: The optional source account.
 
 **Source:** [src/base/operation.ts:446](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operation.ts#L446)
 
@@ -983,6 +994,10 @@ static changeTrust: (opts: ChangeTrustOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `ChangeTrustOpts` (required) — Options object
+    - `asset`: The asset for the trust line.
+    - `limit`: The limit for the asset, defaults to max int64.
+      If the limit is set to "0" it deletes the trustline.
+    - `source`: The source account (defaults to transaction source).
 
 **Source:** [src/base/operation.ts:447](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operation.ts#L447)
 
@@ -997,6 +1012,8 @@ static claimClaimableBalance: (opts: ClaimClaimableBalanceOpts = ...) => Operati
 **Parameters**
 
 - **`opts`** — `ClaimClaimableBalanceOpts` (optional) (default: `...`) — Options object
+    - `balanceId`: The claimable balance id to be claimed.
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **Example**
 
@@ -1019,6 +1036,12 @@ static clawback: (opts: ClawbackOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `ClawbackOpts` (required) — Options object
+    - `asset`: The asset being clawed back.
+    - `amount`: The amount of the asset to claw back.
+    - `from`: The public key of the (optionally-muxed)
+      account to claw back from.
+    - `source`: The source account for the operation.
+      Defaults to the transaction's source account.
 
 **See also**
 
@@ -1037,6 +1060,8 @@ static clawbackClaimableBalance: (opts: ClawbackClaimableBalanceOpts = ...) => O
 **Parameters**
 
 - **`opts`** — `ClawbackClaimableBalanceOpts` (optional) (default: `...`) — Options object
+    - `balanceId`: The claimable balance ID to be clawed back.
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **Example**
 
@@ -1063,6 +1088,10 @@ static createAccount: (opts: CreateAccountOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `CreateAccountOpts` (required) — Options object
+    - `destination`: Destination account ID to create an account for.
+    - `startingBalance`: Amount in XLM the account should be funded for. Must be greater
+      than the `reserve balance amount`.
+    - `source`: The source account for the payment. Defaults to the transaction's source account.
 
 **Source:** [src/base/operation.ts:448](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operation.ts#L448)
 
@@ -1077,6 +1106,10 @@ static createClaimableBalance: (opts: CreateClaimableBalanceOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `CreateClaimableBalanceOpts` (required) — Options object
+    - `asset`: The asset for the claimable balance.
+    - `amount`: Amount.
+    - `claimants`: An array of Claimants
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **Example**
 
@@ -1114,6 +1147,12 @@ static createCustomContract: (opts: CreateCustomContractOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `CreateCustomContractOpts` (required) — the set of parameters
+    - `address`: the contract uploader address
+    - `wasmHash`: the SHA-256 hash of the contract WASM you're uploading
+    - `constructorArgs`: the optional parameters to pass to the constructor
+    - `salt`: an optional, 32-byte salt to distinguish deployment instances
+    - `auth`: an optional list outlining the tree of authorizations required for the call
+    - `source`: an optional source account
 
 **See also**
 
@@ -1135,6 +1174,13 @@ static createPassiveSellOffer: (opts: CreatePassiveSellOfferOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `CreatePassiveSellOfferOpts` (required) — Options object
+    - `selling`: What you're selling.
+    - `buying`: What you're buying.
+    - `amount`: The total amount you're selling. If 0, deletes the offer.
+    - `price`: Price of 1 unit of `selling` in terms of `buying`.
+      - `n`: If `opts.price` is an object: the price numerator
+      - `d`: If `opts.price` is an object: the price denominator
+    - `source`: The source account (defaults to transaction source).
 
 **Throws**
 
@@ -1153,6 +1199,9 @@ static createStellarAssetContract: (opts: CreateStellarAssetContractOpts) => Ope
 **Parameters**
 
 - **`opts`** — `CreateStellarAssetContractOpts` (required) — the set of parameters
+    - `asset`: the Stellar asset to wrap, either as an `Asset` object or in canonical form (SEP-11, `code:issuer`)
+    - `auth`: an optional list outlining the tree of authorizations required for the upload
+    - `source`: an optional source account
 
 **See also**
 
@@ -1174,6 +1223,7 @@ static endSponsoringFutureReserves: (opts: EndSponsoringFutureReservesOpts = {})
 **Parameters**
 
 - **`opts`** — `EndSponsoringFutureReservesOpts` (optional) (default: `{}`) — Options object
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **Example**
 
@@ -1210,6 +1260,9 @@ static extendFootprintTtl: (opts: ExtendFootprintTtlOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `ExtendFootprintTtlOpts` (required) — object holding operation parameters
+    - `extendTo`: the minimum TTL that all the entries in
+      the read-only footprint will have
+    - `source`: an optional source account
 
 **Source:** [src/base/operation.ts:476](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operation.ts#L476)
 
@@ -1224,6 +1277,7 @@ static inflation: (opts: InflationOpts = {}) => Operation;
 **Parameters**
 
 - **`opts`** — `InflationOpts` (optional) (default: `{}`) — Options object
+    - `source`: The optional source account.
 
 **Source:** [src/base/operation.ts:453](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operation.ts#L453)
 
@@ -1238,6 +1292,11 @@ static invokeContractFunction: (opts: InvokeContractFunctionOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `InvokeContractFunctionOpts` (required) — the set of parameters
+    - `contract`: a strkey-fied contract address (`C...`)
+    - `function`: the name of the contract fn to invoke
+    - `args`: parameters to pass to the function invocation
+    - `auth`: an optional list outlining the tree of authorizations required for the call
+    - `source`: an optional source account
 
 **See also**
 
@@ -1258,6 +1317,9 @@ static invokeHostFunction: (opts: InvokeHostFunctionOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `InvokeHostFunctionOpts` (required) — options object
+    - `func`: host function to execute (with its wrapped parameters)
+    - `auth`: list outlining the tree of authorizations required for the call
+    - `source`: an optional source account
 
 **See also**
 
@@ -1281,6 +1343,16 @@ static liquidityPoolDeposit: (opts: LiquidityPoolDepositOpts = ...) => Operation
 **Parameters**
 
 - **`opts`** — `LiquidityPoolDepositOpts` (optional) (default: `...`) — Options object
+    - `liquidityPoolId`: The liquidity pool ID.
+    - `maxAmountA`: Maximum amount of first asset to deposit.
+    - `maxAmountB`: Maximum amount of second asset to deposit.
+    - `minPrice`: Minimum depositA/depositB price.
+      - `n`: If `opts.minPrice` is an object: the price numerator
+      - `d`: If `opts.minPrice` is an object: the price denominator
+    - `maxPrice`: Maximum depositA/depositB price.
+      - `n`: If `opts.maxPrice` is an object: the price numerator
+      - `d`: If `opts.maxPrice` is an object: the price denominator
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **See also**
 
@@ -1299,6 +1371,11 @@ static liquidityPoolWithdraw: (opts: LiquidityPoolWithdrawOpts = ...) => Operati
 **Parameters**
 
 - **`opts`** — `LiquidityPoolWithdrawOpts` (optional) (default: `...`) — Options object
+    - `liquidityPoolId`: The liquidity pool ID.
+    - `amount`: Amount of pool shares to withdraw.
+    - `minAmountA`: Minimum amount of first asset to withdraw.
+    - `minAmountB`: Minimum amount of second asset to withdraw.
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **See also**
 
@@ -1318,6 +1395,14 @@ static manageBuyOffer: (opts: ManageBuyOfferOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `ManageBuyOfferOpts` (required) — Options object
+    - `selling`: What you're selling.
+    - `buying`: What you're buying.
+    - `buyAmount`: The total amount you're buying. If 0, deletes the offer.
+    - `price`: Price of 1 unit of `buying` in terms of `selling`.
+      - `n`: If `opts.price` is an object: the price numerator
+      - `d`: If `opts.price` is an object: the price denominator
+    - `offerId`: If `0`, will create a new offer (default). Otherwise, edits an existing offer.
+    - `source`: The source account (defaults to transaction source).
 
 **Throws**
 
@@ -1336,6 +1421,9 @@ static manageData: (opts: ManageDataOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `ManageDataOpts` (required) — Options object
+    - `name`: The name of the data entry.
+    - `value`: The value of the data entry.
+    - `source`: The optional source account.
 
 **Source:** [src/base/operation.ts:454](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operation.ts#L454)
 
@@ -1351,6 +1439,14 @@ static manageSellOffer: (opts: ManageSellOfferOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `ManageSellOfferOpts` (required) — Options object
+    - `selling`: What you're selling.
+    - `buying`: What you're buying.
+    - `amount`: The total amount you're selling. If 0, deletes the offer.
+    - `price`: Price of 1 unit of `selling` in terms of `buying`.
+      - `n`: If `opts.price` is an object: the price numerator
+      - `d`: If `opts.price` is an object: the price denominator
+    - `offerId`: If `0`, will create a new offer (default). Otherwise, edits an existing offer.
+    - `source`: The source account (defaults to transaction source).
 
 **Throws**
 
@@ -1375,6 +1471,14 @@ static pathPaymentStrictReceive: (opts: PathPaymentStrictReceiveOpts) => Operati
 **Parameters**
 
 - **`opts`** — `PathPaymentStrictReceiveOpts` (required) — Options object
+    - `sendAsset`: asset to pay with
+    - `sendMax`: maximum amount of sendAsset to send
+    - `destination`: destination account to send to
+    - `destAsset`: asset the destination will receive
+    - `destAmount`: amount the destination receives
+    - `path`: array of Asset objects to use as the path
+    - `source`: The source account for the payment.
+      Defaults to the transaction's source account.
 
 **See also**
 
@@ -1398,6 +1502,13 @@ static pathPaymentStrictSend: (opts: PathPaymentStrictSendOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `PathPaymentStrictSendOpts` (required) — Options object
+    - `sendAsset`: asset to pay with
+    - `sendAmount`: amount of sendAsset to send (excluding fees)
+    - `destination`: destination account to send to
+    - `destAsset`: asset the destination will receive
+    - `destMin`: minimum amount of destAsset to be received
+    - `path`: array of Asset objects to use as the path
+    - `source`: The source account for the payment. Defaults to the transaction's source account.
 
 **See also**
 
@@ -1416,6 +1527,11 @@ static payment: (opts: PaymentOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `PaymentOpts` (required) — options object
+    - `destination`: destination account ID
+    - `asset`: asset to send
+    - `amount`: amount to send
+    - `source`: The source account for the payment.
+      Defaults to the transaction's source account.
 
 **See also**
 
@@ -1444,6 +1560,7 @@ static restoreFootprint: (opts: RestoreFootprintOpts = {}) => Operation;
 **Parameters**
 
 - **`opts`** — `RestoreFootprintOpts` (optional) (default: `{}`) — an optional set of parameters
+    - `source`: an optional source account
 
 **Source:** [src/base/operation.ts:477](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operation.ts#L477)
 
@@ -1458,6 +1575,8 @@ static revokeAccountSponsorship: (opts: RevokeAccountSponsorshipOpts = ...) => O
 **Parameters**
 
 - **`opts`** — `RevokeAccountSponsorshipOpts` (optional) (default: `...`) — Options object
+    - `account`: The sponsored account ID.
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **Example**
 
@@ -1480,6 +1599,8 @@ static revokeClaimableBalanceSponsorship: (opts: RevokeClaimableBalanceSponsorsh
 **Parameters**
 
 - **`opts`** — `RevokeClaimableBalanceSponsorshipOpts` (optional) (default: `...`) — Options object
+    - `balanceId`: The sponsored claimable balance ID.
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **Example**
 
@@ -1502,6 +1623,9 @@ static revokeDataSponsorship: (opts: RevokeDataSponsorshipOpts = ...) => Operati
 **Parameters**
 
 - **`opts`** — `RevokeDataSponsorshipOpts` (optional) (default: `...`) — Options object
+    - `account`: The account ID which owns the data entry.
+    - `name`: The name of the data entry.
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **Example**
 
@@ -1525,6 +1649,8 @@ static revokeLiquidityPoolSponsorship: (opts: RevokeLiquidityPoolSponsorshipOpts
 **Parameters**
 
 - **`opts`** — `RevokeLiquidityPoolSponsorshipOpts` (optional) (default: `...`) — Options object.
+    - `liquidityPoolId`: The sponsored liquidity pool ID in 'hex' string.
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **Example**
 
@@ -1547,6 +1673,9 @@ static revokeOfferSponsorship: (opts: RevokeOfferSponsorshipOpts = ...) => Opera
 **Parameters**
 
 - **`opts`** — `RevokeOfferSponsorshipOpts` (optional) (default: `...`) — Options object
+    - `seller`: The account ID which created the offer.
+    - `offerId`: The offer ID.
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **Example**
 
@@ -1570,6 +1699,13 @@ static revokeSignerSponsorship: (opts: RevokeSignerSponsorshipOpts = ...) => Ope
 **Parameters**
 
 - **`opts`** — `RevokeSignerSponsorshipOpts` (optional) (default: `...`) — Options object
+    - `account`: The account ID where the signer sponsorship is being removed from.
+    - `signer`: The signer whose sponsorship is being removed. Exactly one of the following must be set:
+      - `ed25519PublicKey`: (optional) The ed25519 public key of the signer.
+      - `sha256Hash`: (optional) sha256 hash (Uint8Array or hex string).
+      - `preAuthTx`: (optional) Hash (Uint8Array or hex string) of transaction.
+      - `ed25519SignedPayload`: (optional) Signed payload signer (StrKey P... address).
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **Example**
 
@@ -1595,6 +1731,9 @@ static revokeTrustlineSponsorship: (opts: RevokeTrustlineSponsorshipOpts = ...) 
 **Parameters**
 
 - **`opts`** — `RevokeTrustlineSponsorshipOpts` (optional) (default: `...`) — Options object
+    - `account`: The account ID which owns the trustline.
+    - `asset`: The trustline asset.
+    - `source`: The source account for the operation. Defaults to the transaction's source account.
 
 **Example**
 
@@ -1629,6 +1768,22 @@ static setOptions: <T extends SignerOpts = never>(opts: SetOptionsOpts<T>) => Op
 **Parameters**
 
 - **`opts`** — `SetOptionsOpts<T>` (required) — Options object
+    - `inflationDest`: Set this account ID as the account's inflation destination.
+    - `clearFlags`: Bitmap integer for which account flags to clear.
+    - `setFlags`: Bitmap integer for which account flags to set.
+    - `masterWeight`: The master key weight.
+    - `lowThreshold`: The sum weight for the low threshold.
+    - `medThreshold`: The sum weight for the medium threshold.
+    - `highThreshold`: The sum weight for the high threshold.
+    - `signer`: Add or remove a signer from the account. The signer is
+      deleted if the weight is 0. Only one of `ed25519PublicKey`, `sha256Hash`, `preAuthTx` should be defined.
+      - `ed25519PublicKey`: The ed25519 public key of the signer.
+      - `sha256Hash`: sha256 hash (Uint8Array or hex string) of preimage that will unlock funds. Preimage should be used as signature of future transaction.
+      - `preAuthTx`: Hash (Uint8Array or hex string) of transaction that will unlock funds.
+      - `ed25519SignedPayload`: Signed payload signer (ed25519 public key + raw payload) for atomic transaction signature disclosure.
+      - `weight`: The weight of the new signer (0 to delete or 1-255)
+    - `homeDomain`: sets the home domain used for reverse federation lookup.
+    - `source`: The source account (defaults to transaction source).
 
 **See also**
 
@@ -1654,6 +1809,18 @@ static setTrustLineFlags: (opts: SetTrustLineFlagsOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `SetTrustLineFlagsOpts` (required) — Options object
+    - `trustor`: the account whose trustline this is
+    - `asset`: the asset on the trustline
+    - `flags`: the set of flags to modify
+      - `authorized`: authorize account to perform
+        transactions with its credit
+      - `authorizedToMaintainLiabilities`: authorize
+        account to maintain and reduce liabilities for its credit
+      - `clawbackEnabled`: stop claimable balances on
+        this trustlines from having clawbacks enabled (this flag can only be set
+        to false!)
+    - `source`: The source account for the operation.
+      Defaults to the transaction's source account.
 
 **See also**
 
@@ -1673,6 +1840,9 @@ static uploadContractWasm: (opts: UploadContractWasmOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `UploadContractWasmOpts` (required) — the set of parameters
+    - `wasm`: a WASM blob to upload to the ledger
+    - `auth`: an optional list outlining the tree of authorizations required for the upload
+    - `source`: an optional source account
 
 **See also**
 
@@ -1735,7 +1905,7 @@ class ScInt extends XdrLargeInt {
 **Example**
 
 ```ts
-import { xdr, ScInt, scValToBigInt } from "@stellar/stellar-base";
+import { xdr, ScInt, scValToBigInt } from "@stellar/stellar-sdk";
 
 // You have an ScVal from a contract and want to parse it into JS native.
 const value = xdr.ScVal.fromXdr(someXdr, "base64");
@@ -1777,7 +1947,7 @@ const scv = new xdr.ScVal.scvU256(i.raw);
 const scv = i.toI64();
 ```
 
-**Source:** [src/base/numbers/sc_int.ts:61](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/sc_int.ts#L61)
+**Source:** [src/base/numbers/sc_int.ts:63](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/sc_int.ts#L63)
 
 ### `new ScInt(value, opts)`
 
@@ -1794,8 +1964,11 @@ constructor(value: string | number | bigint, opts?: { type?: ScIntType; [key: st
      you can construct them directly without needing this wrapper, e.g.
      `xdr.ScVal.scvU32(1234)`.
 - **`opts`** — `{ type?: ScIntType; [key: string]: unknown }` (optional) — an optional object controlling optional parameters
+    - `type`: specify a type ('i64', 'u64', 'i128', 'u128', 'i256',
+      or 'u256') to override the default type selection. If not specified, the
+      smallest type that fits the value is used.
 
-**Source:** [src/base/numbers/sc_int.ts:74](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/sc_int.ts#L74)
+**Source:** [src/base/numbers/sc_int.ts:76](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/sc_int.ts#L76)
 
 ### `ScInt.getType(scvType)`
 
@@ -1879,7 +2052,7 @@ toI128(): ScVal;
 
 **Throws**
 
-- if the value cannot fit in 128 bits
+- a `RangeError` if the value cannot fit in 128 bits
 
 **Source:** [src/base/numbers/xdr_large_int.ts:182](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/xdr_large_int.ts#L182)
 
@@ -1893,7 +2066,7 @@ toI256(): ScVal;
 
 **Throws**
 
-- if the value cannot fit in a signed 256-bit integer
+- a `RangeError` if the value cannot fit in a signed 256-bit integer
 
 **Source:** [src/base/numbers/xdr_large_int.ts:217](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/xdr_large_int.ts#L217)
 
@@ -1907,7 +2080,7 @@ toI64(): ScVal;
 
 **Throws**
 
-- if the value cannot fit in 64 bits
+- a `RangeError` if the value cannot fit in 64 bits
 
 **Source:** [src/base/numbers/xdr_large_int.ts:150](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/xdr_large_int.ts#L150)
 
@@ -1942,7 +2115,7 @@ toNumber(): number;
 
 **Throws**
 
-- if the value can't fit into a Number
+- a `RangeError` if the value can't fit into a Number
 
 **Source:** [src/base/numbers/xdr_large_int.ts:129](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/xdr_large_int.ts#L129)
 
@@ -1986,7 +2159,7 @@ toU128(): ScVal;
 
 **Throws**
 
-- if the value cannot fit in 128 bits
+- a `RangeError` if the value cannot fit in 128 bits
 
 **Source:** [src/base/numbers/xdr_large_int.ts:201](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/xdr_large_int.ts#L201)
 
@@ -2424,7 +2597,8 @@ error will be thrown.</p>
 <p>Operations can be added to the transaction via their corresponding builder
 methods, and each returns the TransactionBuilder object so they can be
 chained together. After adding the desired operations, call the `build()`
-method on the `TransactionBuilder` to return a fully constructed [`Transaction`](#transaction) that can be signed. The returned transaction will contain the
+method on the `TransactionBuilder` to return a fully constructed
+`Transaction` that can be signed. The returned transaction will contain the
 sequence number of the source account and include the signature from the
 source account.</p>
 
@@ -2538,7 +2712,7 @@ static buildFeeBumpTransaction(feeSource: string | Keypair, baseFee: string, inn
 
 - https://developers.stellar.org/docs/glossary/fee-bumps/#replace-by-fee
 
-**Source:** [src/base/transaction_builder.ts:1144](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1144)
+**Source:** [src/base/transaction_builder.ts:1146](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1146)
 
 ### `TransactionBuilder.cloneFrom(tx, opts)`
 
@@ -2559,7 +2733,7 @@ static cloneFrom(tx: Transaction, opts: Partial<TransactionBuilderOptions> = {})
 
 - **`tx`** — `Transaction` (required) — a "template" transaction to clone exactly
 - **`opts`** — `Partial<TransactionBuilderOptions>` (optional) (default: `{}`) — additional options to override the clone, e.g.
-     {fee: '1000'} will override the existing base fee derived from `tx` (see
+     `{fee: '1000'}` will override the existing base fee derived from `tx` (see
      the `TransactionBuilder` constructor for detailed options)
 
 **Source:** [src/base/transaction_builder.ts:313](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L313)
@@ -2581,7 +2755,7 @@ static fromXdr(envelope: string | TransactionEnvelope, networkPassphrase: string
       Stellar network (e.g. "Public Global Stellar Network ; September
       2015"), see `Networks`.
 
-**Source:** [src/base/transaction_builder.ts:1257](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1257)
+**Source:** [src/base/transaction_builder.ts:1259](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1259)
 
 ### `transactionBuilder.baseFee`
 
@@ -2739,7 +2913,7 @@ addSacTransferOperation(destination: string, asset: Asset, amount: string | bigi
 - **`amount`** — `string | bigint` (required) — the amount of tokens to be transferred in 7 decimals. IE 1 token with 7 decimals of precision would be represented as "1_0000000"
 - **`sorobanFees`** — `SorobanFees` (optional) — optional Soroban fees for the transaction to override the default fees used
 
-**Source:** [src/base/transaction_builder.ts:752](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L752)
+**Source:** [src/base/transaction_builder.ts:754](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L754)
 
 ### `transactionBuilder.build()`
 
@@ -2750,7 +2924,7 @@ number by 1.
 build(): Transaction;
 ```
 
-**Source:** [src/base/transaction_builder.ts:972](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L972)
+**Source:** [src/base/transaction_builder.ts:974](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L974)
 
 ### `transactionBuilder.clearOperationAt(index)`
 
@@ -2784,7 +2958,7 @@ Checks whether any v2 preconditions have been set on this builder.
 hasV2Preconditions(): boolean;
 ```
 
-**Source:** [src/base/transaction_builder.ts:1111](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1111)
+**Source:** [src/base/transaction_builder.ts:1113](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L1113)
 
 ### `transactionBuilder.setExtraSigners(extraSigners)`
 
@@ -2801,7 +2975,7 @@ setExtraSigners(extraSigners: string[]): TransactionBuilder;
 
 - **`extraSigners`** — `string[]` (required) — required extra signers (as `StrKey`s)
 
-**Source:** [src/base/transaction_builder.ts:687](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L687)
+**Source:** [src/base/transaction_builder.ts:689](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L689)
 
 ### `transactionBuilder.setLedgerbounds(minLedger, maxLedger)`
 
@@ -2829,7 +3003,9 @@ setLedgerbounds(minLedger: number, maxLedger: number): TransactionBuilder;
 If you want to prepare a transaction which will be valid only while the
 account sequence number is
 
-    minAccountSequence <= sourceAccountSequence < tx.seqNum
+```
+minAccountSequence <= sourceAccountSequence < tx.seqNum
+```
 
 Note that after execution the account's sequence number is always raised to
 `tx.seqNum`. Internally this will set the `minAccountSequence`
@@ -2843,10 +3019,10 @@ setMinAccountSequence(minAccountSequence: string): TransactionBuilder;
 
 - **`minAccountSequence`** — `string` (required) — The minimum source account sequence
       number this transaction is valid for. If the value is `0` (the
-      default), the transaction is valid when `sourceAccount's sequence
-      number == tx.seqNum- 1`.
+      default), the transaction is valid when
+      `sourceAccount's sequence number == tx.seqNum - 1`.
 
-**Source:** [src/base/transaction_builder.ts:612](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L612)
+**Source:** [src/base/transaction_builder.ts:614](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L614)
 
 ### `transactionBuilder.setMinAccountSequenceAge(durationInSeconds)`
 
@@ -2865,7 +3041,7 @@ setMinAccountSequenceAge(durationInSeconds: bigint): TransactionBuilder;
       will become valid. If the value is `0`, the transaction is unrestricted
       by the account sequence age. Cannot be negative.
 
-**Source:** [src/base/transaction_builder.ts:634](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L634)
+**Source:** [src/base/transaction_builder.ts:636](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L636)
 
 ### `transactionBuilder.setMinAccountSequenceLedgerGap(gap)`
 
@@ -2884,7 +3060,7 @@ setMinAccountSequenceLedgerGap(gap: number): TransactionBuilder;
       If the value is `0`, the transaction is unrestricted by the account
       sequence ledger. Cannot be negative.
 
-**Source:** [src/base/transaction_builder.ts:663](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L663)
+**Source:** [src/base/transaction_builder.ts:665](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L665)
 
 ### `transactionBuilder.setNetworkPassphrase(networkPassphrase)`
 
@@ -2899,7 +3075,7 @@ setNetworkPassphrase(networkPassphrase: string): TransactionBuilder;
 - **`networkPassphrase`** — `string` (required) — passphrase of the target Stellar
       network (e.g. "Public Global Stellar Network ; September 2015").
 
-**Source:** [src/base/transaction_builder.ts:713](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L713)
+**Source:** [src/base/transaction_builder.ts:715](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L715)
 
 ### `transactionBuilder.setSorobanData(sorobanData)`
 
@@ -2923,7 +3099,11 @@ setSorobanData(sorobanData: string | SorobanTransactionData): TransactionBuilder
 - **`sorobanData`** — `string | SorobanTransactionData` (required) — the `xdr.SorobanTransactionData` as a raw xdr
      object or a base64 string to be decoded
 
-**Source:** [src/base/transaction_builder.ts:735](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L735)
+**See also**
+
+- `SorobanDataBuilder`
+
+**Source:** [src/base/transaction_builder.ts:737](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/transaction_builder.ts#L737)
 
 ### `transactionBuilder.setTimebounds(minEpochOrDate, maxEpochOrDate)`
 
@@ -2963,7 +3143,8 @@ Sets a timeout precondition on the transaction.
 
  A call to `TransactionBuilder.setTimeout` is **required** if Transaction
  does not have `max_time` set. If you don't want to set timeout, use
- [`TimeoutInfinite`](#timeoutinfinite). In general you should set [`TimeoutInfinite`](#timeoutinfinite) only in smart contracts.
+ `TimeoutInfinite`. In general you should set
+ `TimeoutInfinite` only in smart contracts.
 
  Please note that Horizon may still return <code>504 Gateway Timeout</code>
  error, even for short timeouts. In such case you need to resubmit the same
@@ -3125,7 +3306,7 @@ toI128(): ScVal;
 
 **Throws**
 
-- if the value cannot fit in 128 bits
+- a `RangeError` if the value cannot fit in 128 bits
 
 **Source:** [src/base/numbers/xdr_large_int.ts:182](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/xdr_large_int.ts#L182)
 
@@ -3139,7 +3320,7 @@ toI256(): ScVal;
 
 **Throws**
 
-- if the value cannot fit in a signed 256-bit integer
+- a `RangeError` if the value cannot fit in a signed 256-bit integer
 
 **Source:** [src/base/numbers/xdr_large_int.ts:217](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/xdr_large_int.ts#L217)
 
@@ -3153,7 +3334,7 @@ toI64(): ScVal;
 
 **Throws**
 
-- if the value cannot fit in 64 bits
+- a `RangeError` if the value cannot fit in 64 bits
 
 **Source:** [src/base/numbers/xdr_large_int.ts:150](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/xdr_large_int.ts#L150)
 
@@ -3188,7 +3369,7 @@ toNumber(): number;
 
 **Throws**
 
-- if the value can't fit into a Number
+- a `RangeError` if the value can't fit into a Number
 
 **Source:** [src/base/numbers/xdr_large_int.ts:129](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/xdr_large_int.ts#L129)
 
@@ -3232,7 +3413,7 @@ toU128(): ScVal;
 
 **Throws**
 
-- if the value cannot fit in 128 bits
+- a `RangeError` if the value cannot fit in 128 bits
 
 **Source:** [src/base/numbers/xdr_large_int.ts:201](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/xdr_large_int.ts#L201)
 
@@ -3353,7 +3534,7 @@ scValToBigInt(scv: ScVal): bigint
 
 **Throws**
 
-- if the `scv` input value doesn't represent an integer
+- a `TypeError` if the `scv` input value doesn't represent an integer
 
 **Example**
 
@@ -3365,7 +3546,7 @@ new ScInt(bigi);               // if you don't care about types, and
 new XdrLargeInt('i128', bigi); // if you do
 ```
 
-**Source:** [src/base/numbers/index.ts:28](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/index.ts#L28)
+**Source:** [src/base/numbers/index.ts:30](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/numbers/index.ts#L30)
 
 ## Types
 

--- a/docs/reference/network-horizon.md
+++ b/docs/reference/network-horizon.md
@@ -7,11 +7,11 @@ description: Client for the Stellar Horizon REST API — accounts, payments, pat
 
 ## Horizon.AccountResponse
 
-Do not create this object directly, use `Horizon.Server#loadAccount`.
+Do not create this object directly, use [`Horizon.Server#loadAccount`](#serverloadaccountaccountid).
 
 Returns information and links relating to a single account.
 The balances section in the returned JSON will also list all the trust lines this account has set up.
-It also contains `BaseAccount` object and exposes it's methods so can be used in `TransactionBuilder`.
+It also contains [`BaseAccount`](/reference/core-transactions/#account) object and exposes it's methods so can be used in [`TransactionBuilder`](/reference/core-transactions/#transactionbuilder).
 
 ```ts
 class AccountResponse implements TransactionSource {
@@ -502,7 +502,7 @@ checkMemoRequired(transaction: Transaction | FeeBumpTransaction): Promise<void>;
 **Returns**
 
 - If any of the destination account
-requires a memo, the promise will throw `AccountRequiresMemoError`.
+requires a memo, the promise will throw [`AccountRequiresMemoError`](/reference/errors/#accountrequiresmemoerror).
 
 **See also**
 
@@ -599,9 +599,9 @@ Promise that resolves to the base fee.
 ### `server.fetchTimebounds(seconds, _isRetry)`
 
 Get timebounds for N seconds from now, when you're creating a transaction
-with `TransactionBuilder`.
+with [`TransactionBuilder`](/reference/core-transactions/#transactionbuilder).
 
-By default, `TransactionBuilder` uses the current local time, but
+By default, [`TransactionBuilder`](/reference/core-transactions/#transactionbuilder) uses the current local time, but
 your machine's local time could be different from Horizon's. This gives you
 more assurance that your timebounds will reflect what you want.
 
@@ -715,7 +715,7 @@ New `LiquidityPoolCallBuilder`
 ### `server.loadAccount(accountId)`
 
 Fetches an account's most current state in the ledger, then creates and
-returns an `AccountResponse` object.
+returns an [`AccountResponse`](#horizonaccountresponse) object.
 
 ```ts
 loadAccount(accountId: string): Promise<AccountResponse>;
@@ -727,7 +727,7 @@ loadAccount(accountId: string): Promise<AccountResponse>;
 
 **Returns**
 
-Returns a promise to the `AccountResponse` object
+Returns a promise to the [`AccountResponse`](#horizonaccountresponse) object
 with populated sequence number.
 
 **Source:** [src/horizon/server.ts:799](https://github.com/stellar/js-stellar-sdk/blob/main/src/horizon/server.ts#L799)
@@ -956,7 +956,7 @@ Submits an asynchronous transaction to the network. Unlike the synchronous versi
 and waits for the transaction to be ingested in Horizon, this endpoint relays the response from
 core directly back to the user.
 
-By default, this function calls `HorizonServer.checkMemoRequired`, you can
+By default, this function calls [`HorizonServer.checkMemoRequired`](#servercheckmemorequiredtransaction), you can
 skip this check by setting the option `skipMemoRequiredCheck` to `true`.
 
 ```ts
@@ -974,8 +974,8 @@ submitAsyncTransaction(transaction: Transaction | FeeBumpTransaction, opts: Subm
 **Returns**
 
 Promise that resolves with the response from Horizon. Rejects
-with a `TransactionFailedError` when Horizon reports transaction
-result codes, a `BadResponseError` for any other HTTP error
+with a [`TransactionFailedError`](/reference/errors/#transactionfailederror) when Horizon reports transaction
+result codes, a [`BadResponseError`](/reference/errors/#badresponseerror) for any other HTTP error
 response (the underlying client error is preserved as `cause` on both),
 or the original error for network-level failures.
 
@@ -989,7 +989,7 @@ or the original error for network-level failures.
 
 Submits a transaction to the network.
 
-By default this function calls `Horizon.Server.checkMemoRequired`, you can
+By default this function calls [`Horizon.Server.checkMemoRequired`](#servercheckmemorequiredtransaction), you can
 skip this check by setting the option `skipMemoRequiredCheck` to `true`.
 
 If you submit any number of `manageOffer` operations, this will add an
@@ -1024,8 +1024,8 @@ submitTransaction(transaction: Transaction | FeeBumpTransaction, opts: SubmitTra
 **Returns**
 
 Promise that resolves with the response from Horizon. Rejects
-with a `TransactionFailedError` when Horizon reports transaction
-result codes, a `BadResponseError` for any other HTTP error
+with a [`TransactionFailedError`](/reference/errors/#transactionfailederror) when Horizon reports transaction
+result codes, a [`BadResponseError`](/reference/errors/#badresponseerror) for any other HTTP error
 response (the underlying client error is preserved as `cause` on both),
 or the original error for network-level failures.
 
@@ -6889,7 +6889,7 @@ interface Options {
 
 #### `options.allowHttp`
 
-Allow connecting to http servers, default: `false`. This must be set to false in production deployments! You can also use `Config` class to set this globally.
+Allow connecting to http servers, default: `false`. This must be set to false in production deployments! You can also use [`Config`](/reference/cross-cutting/#config) class to set this globally.
 
 ```ts
 allowHttp?: boolean;

--- a/docs/reference/network-rpc.md
+++ b/docs/reference/network-rpc.md
@@ -306,7 +306,7 @@ fundAddress(address: string, friendbotUrl?: string): Promise<GetSuccessfulTransa
      account (G...) or contract (C...) address.
 - **`friendbotUrl`** — `string` (optional) — (optional) Optionally, an explicit Friendbot URL
      (by default: this calls the Stellar RPC
-     `getNetwork` method to try to
+     [`getNetwork`](#servergetnetwork) method to try to
      discover this network's Friendbot url).
 
 **Returns**
@@ -348,7 +348,7 @@ console.log("Contract funded! Hash:", tx.txHash);
 Fetch a minimal set of current info about a Stellar account.
 
 Needed to get the current sequence number for the account so you can build
-a successful transaction with `TransactionBuilder`.
+a successful transaction with [`TransactionBuilder`](/reference/core-transactions/#transactionbuilder).
 
 ```ts
 getAccount(address: string): Promise<Account>;
@@ -360,7 +360,7 @@ getAccount(address: string): Promise<Account>;
 
 **Returns**
 
-A promise which resolves to the `Account`
+A promise which resolves to the [`Account`](/reference/core-transactions/#account)
 object with a populated sequence number
 
 **Example**
@@ -414,8 +414,8 @@ server.getAccountEntry(accountId).then((account) => {
 
 Fetch the balance of an asset held by an account or contract.
 
-The `address` argument may be provided as a string (as a `StrKey`),
-`Address`, or `Contract`.
+The `address` argument may be provided as a string (as a [`StrKey`](/reference/core-keys/#strkey)),
+[`Address`](/reference/core-soroban-primitives/#address), or [`Contract`](/reference/core-soroban-primitives/#contract).
 
 ```ts
 getAssetBalance(address: string | Address | Contract, asset: Asset, networkPassphrase?: string): Promise<BalanceResponse>;
@@ -429,8 +429,8 @@ getAssetBalance(address: string | Address | Contract, asset: Asset, networkPassp
 - **`networkPassphrase`** — `string` (optional) — (optional) optionally, when requesting the
      balance of a contract, the network passphrase to which this token
      applies. If omitted and necessary, a request about network information
-     will be made (see `getNetwork`), since contract IDs for assets are
-     specific to a network. You can refer to `Networks` for a list of
+     will be made (see [`getNetwork`](#servergetnetwork)), since contract IDs for assets are
+     specific to a network. You can refer to [`Networks`](/reference/core-transactions/#networks) for a list of
      built-in passphrases, e.g., `Networks.TESTNET`.
 
 **Returns**
@@ -498,7 +498,7 @@ Reads the current value of contract data ledger entries directly.
 
 Allows you to directly inspect the current state of a contract. This is a
 backup way to access your contract data which may not be available via
-events or `rpc.Server.simulateTransaction`.
+events or [`rpc.Server.simulateTransaction`](#serversimulatetransactiontx-addlresources-authmode-useupgradedauth).
 
 ```ts
 getContractData(contract: string | Address | Contract, key: ScVal, durability: Durability = Durability.Persistent): Promise<LedgerEntryResult>;
@@ -507,12 +507,12 @@ getContractData(contract: string | Address | Contract, key: ScVal, durability: D
 **Parameters**
 
 - **`contract`** — `string | Address | Contract` (required) — The contract ID containing the
-     data to load as a strkey (`C...` form), a `Contract`, or an
-     `Address` instance
+     data to load as a strkey (`C...` form), a [`Contract`](/reference/core-soroban-primitives/#contract), or an
+     [`Address`](/reference/core-soroban-primitives/#address) instance
 - **`key`** — `ScVal` (required) — The key of the contract data to load
 - **`durability`** — `Durability` (optional) (default: `Durability.Persistent`) — (optional) The "durability
      keyspace" that this ledger key belongs to, which is either 'temporary'
-     or 'persistent' (the default), see `rpc.Durability`.
+     or 'persistent' (the default), see [`rpc.Durability`](#rpcdurability).
 
 **Returns**
 
@@ -581,11 +581,11 @@ Lists a contract's callable methods and their signatures.
 A discovery helper for tooling, dapps, and agents that need to inspect an
 arbitrary contract without knowing its interface up front. It resolves the
 contract's spec (embedded in the Wasm for regular contracts, or the
-built-in spec for Stellar Asset Contracts — see `contract.Client.from`)
+built-in spec for Stellar Asset Contracts — see [`contract.Client.from`](/reference/contracts-client/#clientfromoptions))
 and reports each declared function's name, inputs, and outputs. No method
 is invoked or simulated; this performs only the spec lookup.
 
-The complement to `queryContract`: list methods here, then call a
+The complement to [`queryContract`](#serverquerycontractcontractid-method-args-networkpassphrase): list methods here, then call a
 read-only one with `server.queryContract(contractId, method, args?)`.
 
 ```ts
@@ -596,8 +596,8 @@ getContractMethods(contractId: string, networkPassphrase?: string): Promise<Cont
 
 - **`contractId`** — `string` (required) — the contract to inspect (`C...`)
 - **`networkPassphrase`** — `string` (optional) — (optional) the network passphrase. If omitted, a
-     request about network information will be made (see `getNetwork`).
-     You can refer to `Networks` for a list of built-in passphrases,
+     request about network information will be made (see [`getNetwork`](#servergetnetwork)).
+     You can refer to [`Networks`](/reference/core-transactions/#networks) for a list of built-in passphrases,
      e.g., `Networks.TESTNET`.
 
 **Returns**
@@ -629,9 +629,9 @@ code of the contract.
 
 This only works for Wasm-based contracts, including one created from a
 CAP-85 external executable reference, whose reference is resolved to a Wasm
-hash first (see `getExternalRefWasmHash`). A built-in Stellar Asset
+hash first (see [`getExternalRefWasmHash`](#servergetexternalrefwasmhashref)). A built-in Stellar Asset
 Contract (SAC) has no Wasm bytecode on-chain, so this throws for a SAC; use
-`contract.Client.from` to build a client from the embedded SAC spec.
+[`contract.Client.from`](/reference/contracts-client/#clientfromoptions) to build a client from the embedded SAC spec.
 
 ```ts
 getContractWasmByContractId(contractId: string): Promise<Uint8Array<ArrayBufferLike>>;
@@ -708,12 +708,12 @@ server.getContractWasmByHash(wasmHash).then(wasmBytes => {
 
 Fetch all events that match a given set of filters.
 
-The given filters (see `Api.EventFilter`
+The given filters (see [`Api.EventFilter`](#rpcapieventfilter)
 for detailed fields) are combined only in a logical OR fashion, and all of
 the fields in each filter are optional.
 
 To page through events, use the `pagingToken` field on the relevant
-`Api.EventResponse` object to set the `cursor` parameter.
+[`Api.EventResponse`](#rpcapieventresponse) object to set the `cursor` parameter.
 
 ```ts
 getEvents(request: GetEventsRequest): Promise<GetEventsResponse>;
@@ -721,7 +721,7 @@ getEvents(request: GetEventsRequest): Promise<GetEventsResponse>;
 
 **Parameters**
 
-- **`request`** — `GetEventsRequest` (required) — Event filters `Api.GetEventsRequest`,
+- **`request`** — `GetEventsRequest` (required) — Event filters [`Api.GetEventsRequest`](#rpcapigeteventsrequest),
 
 **Returns**
 
@@ -834,7 +834,7 @@ getHealth(): Promise<GetHealthResponse>;
 **Returns**
 
 A promise which resolves to the
-`Api.GetHealthResponse` object with the status of the
+[`Api.GetHealthResponse`](#rpcapigethealthresponse) object with the status of the
 server (e.g. "healthy").
 
 **Example**
@@ -890,7 +890,7 @@ code, accounts, or any other ledger entries.
 
 To fetch a contract's WASM byte-code, built the appropriate
 `xdr.LedgerKeyContractCode` ledger entry key (or see
-`Contract.getFootprint`).
+[`Contract.getFootprint`](/reference/core-soroban-primitives/#contractgetfootprint)).
 
 ```ts
 getLedgerEntries(...keys: LedgerKey[]): Promise<GetLedgerEntriesResponse>;
@@ -956,12 +956,12 @@ getLedgers(request: GetLedgersRequest): Promise<GetLedgersResponse>;
 
 **Parameters**
 
-- **`request`** — `GetLedgersRequest` (required) — The request parameters for fetching ledgers. `Api.GetLedgersRequest`
+- **`request`** — `GetLedgersRequest` (required) — The request parameters for fetching ledgers. [`Api.GetLedgersRequest`](#rpcapigetledgersrequest)
 
 **Returns**
 
 A promise that resolves to the
-   ledgers response containing an array of ledger data and pagination info. `Api.GetLedgersResponse`
+   ledgers response containing an array of ledger data and pagination info. [`Api.GetLedgersResponse`](#rpcapigetledgersresponse)
 
 **Throws**
 
@@ -1040,11 +1040,11 @@ server.getNetwork().then((network) => {
 
 ### `server.getSACBalance(address, sac, networkPassphrase)`
 
-**Deprecated.** Use `getAssetBalance`, instead
+**Deprecated.** Use [`getAssetBalance`](#servergetassetbalanceaddress-asset-networkpassphrase), instead
 
 Returns a contract's balance of a particular SAC asset, if any.
 
-This is a convenience wrapper around `Server.getLedgerEntries`.
+This is a convenience wrapper around [`Server.getLedgerEntries`](#servergetledgerentrieskeys).
 
 ```ts
 getSACBalance(address: string | Address, sac: Asset, networkPassphrase?: string): Promise<BalanceResponse>;
@@ -1058,8 +1058,8 @@ getSACBalance(address: string | Address, sac: Asset, networkPassphrase?: string)
      you are querying from the given `contract`.
 - **`networkPassphrase`** — `string` (optional) — (optional) optionally, the network passphrase to
      which this token applies. If omitted, a request about network
-     information will be made (see `getNetwork`), since contract IDs
-     for assets are specific to a network. You can refer to `Networks`
+     information will be made (see [`getNetwork`](#servergetnetwork)), since contract IDs
+     for assets are specific to a network. You can refer to [`Networks`](/reference/core-transactions/#networks)
      for a list of built-in passphrases, e.g., `Networks.TESTNET`.
 
 **Returns**
@@ -1173,7 +1173,7 @@ server.getTransactions({
 
 ### `server.getTrustline(account, asset)`
 
-**Deprecated.** Use `getAssetBalance`, instead
+**Deprecated.** Use [`getAssetBalance`](#servergetassetbalanceaddress-asset-networkpassphrase), instead
 
 Fetch the full trustline entry for a Stellar account.
 
@@ -1282,10 +1282,10 @@ from simulation. It is advisable to check the fee on returned transaction
 and validate or take appropriate measures for interaction with user to
 confirm it is acceptable.
 
-You can call the `rpc.Server.simulateTransaction` method
+You can call the [`rpc.Server.simulateTransaction`](#serversimulatetransactiontx-addlresources-authmode-useupgradedauth) method
 directly first if you want to inspect estimated fees for a given
 transaction in detail first, then re-assemble it manually or via
-`rpc.assembleTransaction`.
+[`rpc.assembleTransaction`](#rpcassembletransaction).
 
 ```ts
 prepareTransaction(tx: Transaction | FeeBumpTransaction): Promise<Transaction>;
@@ -1362,13 +1362,13 @@ server.sendTransaction(transaction).then(result => {
 Performs a read-only call to a contract method and returns the decoded result.
 
 This is a convenience wrapper for one-line contract state queries: it builds
-a `contract.Client` for the contract, simulates the method call, and
+a [`contract.Client`](/reference/contracts-client/#contractclient) for the contract, simulates the method call, and
 returns the spec-decoded return value — no manual transaction assembly,
 signing, or submission required.
 
 Works for both Wasm contracts and built-in Stellar Asset Contracts (SACs):
 the embedded SAC spec is used automatically for SACs (see
-`contract.Client.from`). The query reuses this server's transport
+[`contract.Client.from`](/reference/contracts-client/#clientfromoptions)). The query reuses this server's transport
 (headers, interceptors, `allowHttp`).
 
 ```ts
@@ -1382,8 +1382,8 @@ queryContract<T = any>(contractId: string, method: string, args: Record<string, 
 - **`args`** — `Record<string, unknown>` (optional) (default: `{}`) — named arguments for the method, keyed by parameter name
      (omit for methods that take no arguments)
 - **`networkPassphrase`** — `string` (optional) — (optional) the network passphrase. If omitted, a
-     request about network information will be made (see `getNetwork`).
-     You can refer to `Networks` for a list of built-in passphrases,
+     request about network information will be made (see [`getNetwork`](#servergetnetwork)).
+     You can refer to [`Networks`](/reference/core-transactions/#networks) for a list of built-in passphrases,
      e.g., `Networks.TESTNET`.
 
 **Returns**
@@ -1417,7 +1417,7 @@ const { result: balance } = await server.queryContract<bigint>(
 
 ### `server.requestAirdrop(address, friendbotUrl)`
 
-**Deprecated.** Use `Server.fundAddress` instead, which supports both
+**Deprecated.** Use [`Server.fundAddress`](#serverfundaddressaddress-friendboturl) instead, which supports both
    account (G...) and contract (C...) addresses.
 
 Fund a new account using the network's Friendbot faucet, if any.
@@ -1432,12 +1432,12 @@ requestAirdrop(address: string | Pick<Account, "accountId">, friendbotUrl?: stri
      want to create and fund with Friendbot
 - **`friendbotUrl`** — `string` (optional) — (optional) Optionally, an explicit address for
      friendbot (by default: this calls the Soroban RPC
-     `getNetwork` method to try to
+     [`getNetwork`](#servergetnetwork) method to try to
      discover this network's Friendbot url).
 
 **Returns**
 
-An `Account` object for the created
+An [`Account`](/reference/core-transactions/#account) object for the created
    account, or the existing account if it's already funded with the
    populated sequence number (note that the account will not be "topped
    off" if it already exists)
@@ -1461,7 +1461,7 @@ server
 **See also**
 
 - - `Friendbot docs`
- - `Friendbot.Api.Response`
+ - [`Friendbot.Api.Response`](/reference/network-friendbot/#friendbotapiresponse)
 
 **Source:** [src/rpc/server.ts:1613](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1613)
 
@@ -1471,7 +1471,7 @@ Submit a real transaction to the Stellar network.
 
 Unlike Horizon, RPC does not wait for transaction completion. It
 simply validates the transaction and enqueues it. Clients should call
-`rpc.Server.getTransaction` to learn about transaction
+[`rpc.Server.getTransaction`](#servergettransactionhash) to learn about transaction
 success/failure.
 
 ```ts
@@ -1605,11 +1605,11 @@ server.simulateTransaction(transaction).then((sim) => {
 
 Combines the given raw transaction alongside the simulation results.
 If the given transaction already has authorization entries in a host
-function invocation (see `Operation.invokeHostFunction`), **the
+function invocation (see [`Operation.invokeHostFunction`](/reference/core-transactions/#operationinvokehostfunction)), **the
 simulation entries are ignored**.
 
 If the given transaction already has authorization entries in a host function
-invocation (see `Operation.invokeHostFunction`), **the simulation
+invocation (see [`Operation.invokeHostFunction`](/reference/core-transactions/#operationinvokehostfunction)), **the simulation
 entries are ignored**.
 
 ```ts
@@ -1619,7 +1619,7 @@ assembleTransaction(raw: Transaction | FeeBumpTransaction, simulation: SimulateT
 **Parameters**
 
 - **`raw`** — `Transaction | FeeBumpTransaction` (required) — the initial transaction, w/o simulation applied
-- **`simulation`** — `SimulateTransactionResponse | RawSimulateTransactionResponse` (required) — the Soroban RPC simulation result (see `rpc.Server.simulateTransaction`)
+- **`simulation`** — `SimulateTransactionResponse | RawSimulateTransactionResponse` (required) — the Soroban RPC simulation result (see [`rpc.Server.simulateTransaction`](#serversimulatetransactiontx-addlresources-authmode-useupgradedauth))
 
 **Returns**
 
@@ -1627,8 +1627,8 @@ a new, cloned transaction with the proper auth and resource (fee, footprint) sim
 
 **See also**
 
-- - `rpc.Server.simulateTransaction`
- - `rpc.Server.prepareTransaction`
+- - [`rpc.Server.simulateTransaction`](#serversimulatetransactiontx-addlresources-authmode-useupgradedauth)
+ - [`rpc.Server.prepareTransaction`](#serverpreparetransactiontx)
 
 **Source:** [src/rpc/transaction.ts:45](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/transaction.ts#L45)
 
@@ -1863,7 +1863,7 @@ outputs: string[];
 
 ### rpc.Api.ContractMethodInput
 
-A single input parameter of a `ContractMethod`.
+A single input parameter of a [`ContractMethod`](#rpcapicontractmethod).
 
 ```ts
 interface ContractMethodInput {
@@ -2457,7 +2457,7 @@ sequence: number;
 
 ### rpc.Api.GetLedgerEntriesResponse
 
-An XDR-parsed version of `RawLedgerEntryResult`
+An XDR-parsed version of [`RawLedgerEntryResult`](#rpcapirawledgerentryresult)
 
 ```ts
 interface GetLedgerEntriesResponse {
@@ -4301,7 +4301,7 @@ latestLedger: number;
 
 ### rpc.Api.SimulateTransactionResponse
 
-Simplifies `RawSimulateTransactionResponse` into separate interfaces
+Simplifies [`RawSimulateTransactionResponse`](#rpcapirawsimulatetransactionresponse) into separate interfaces
 based on status:
   - on success, this includes all fields, though `result` is only present
     if an invocation was simulated (since otherwise there's nothing to
@@ -4707,7 +4707,7 @@ type GetEventsRequest = Api.GetEventsRequest
 
 **See also**
 
-- `Api.GetEventsRequest`
+- [`Api.GetEventsRequest`](#rpcapigeteventsrequest)
 
 **Source:** [src/rpc/server.ts:85](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L85)
 

--- a/docs/reference/network-rpc.md
+++ b/docs/reference/network-rpc.md
@@ -205,7 +205,7 @@ _getEvents(request: GetEventsRequest): Promise<RawGetEventsResponse>;
 
 - **`request`** — `GetEventsRequest` (required)
 
-**Source:** [src/rpc/server.ts:1256](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1256)
+**Source:** [src/rpc/server.ts:1255](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1255)
 
 ### `server._getLatestLedger()`
 
@@ -213,7 +213,7 @@ _getEvents(request: GetEventsRequest): Promise<RawGetEventsResponse>;
 _getLatestLedger(): Promise<RawGetLatestLedgerResponse>;
 ```
 
-**Source:** [src/rpc/server.ts:1327](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1327)
+**Source:** [src/rpc/server.ts:1326](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1326)
 
 ### `server._getLedgerEntries(keys)`
 
@@ -225,7 +225,7 @@ _getLedgerEntries(...keys: LedgerKey[]): Promise<RawGetLedgerEntriesResponse>;
 
 - **`...keys`** — `LedgerKey[]` (required)
 
-**Source:** [src/rpc/server.ts:1021](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1021)
+**Source:** [src/rpc/server.ts:1020](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1020)
 
 ### `server._getLedgers(request)`
 
@@ -237,7 +237,7 @@ _getLedgers(request: GetLedgersRequest): Promise<RawGetLedgersResponse>;
 
 - **`request`** — `GetLedgersRequest` (required)
 
-**Source:** [src/rpc/server.ts:1930](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1930)
+**Source:** [src/rpc/server.ts:1929](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1929)
 
 ### `server._getTransaction(hash)`
 
@@ -249,7 +249,7 @@ _getTransaction(hash: string): Promise<RawGetTransactionResponse>;
 
 - **`hash`** — `string` (required)
 
-**Source:** [src/rpc/server.ts:1144](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1144)
+**Source:** [src/rpc/server.ts:1143](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1143)
 
 ### `server._getTransactions(request)`
 
@@ -261,7 +261,7 @@ _getTransactions(request: GetTransactionsRequest): Promise<RawGetTransactionsRes
 
 - **`request`** — `GetTransactionsRequest` (required)
 
-**Source:** [src/rpc/server.ts:1195](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1195)
+**Source:** [src/rpc/server.ts:1194](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1194)
 
 ### `server._sendTransaction(transaction)`
 
@@ -273,7 +273,7 @@ _sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<RawSend
 
 - **`transaction`** — `Transaction | FeeBumpTransaction` (required)
 
-**Source:** [src/rpc/server.ts:1569](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1569)
+**Source:** [src/rpc/server.ts:1568](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1568)
 
 ### `server._simulateTransaction(transaction, addlResources, authMode, useUpgradedAuth)`
 
@@ -288,7 +288,7 @@ _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResource
 - **`authMode`** — `SimulationAuthMode` (optional)
 - **`useUpgradedAuth`** — `boolean` (optional)
 
-**Source:** [src/rpc/server.ts:1414](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1414)
+**Source:** [src/rpc/server.ts:1413](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1413)
 
 ### `server.fundAddress(address, friendbotUrl)`
 
@@ -341,7 +341,7 @@ console.log("Contract funded! Hash:", tx.txHash);
 
 - `Friendbot docs`
 
-**Source:** [src/rpc/server.ts:1689](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1689)
+**Source:** [src/rpc/server.ts:1688](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1688)
 
 ### `server.getAccount(address)`
 
@@ -376,7 +376,7 @@ server.getAccount(accountId).then((account) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:241](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L241)
+**Source:** [src/rpc/server.ts:240](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L240)
 
 ### `server.getAccountEntry(address)`
 
@@ -408,7 +408,7 @@ server.getAccountEntry(accountId).then((account) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:264](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L264)
+**Source:** [src/rpc/server.ts:263](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L263)
 
 ### `server.getAssetBalance(address, asset, networkPassphrase)`
 
@@ -454,7 +454,7 @@ const balance = await server.getAssetBalance("GD...", usdc);
 console.log(balance.balanceEntry?.amount);
 ```
 
-**Source:** [src/rpc/server.ts:425](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L425)
+**Source:** [src/rpc/server.ts:424](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L424)
 
 ### `server.getClaimableBalance(id)`
 
@@ -490,7 +490,7 @@ server.getClaimableBalance(id).then((entry) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:356](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L356)
+**Source:** [src/rpc/server.ts:355](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L355)
 
 ### `server.getContractData(contract, key, durability)`
 
@@ -538,7 +538,7 @@ server.getContractData(contractId, key, Durability.Temporary).then(data => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:526](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L526)
+**Source:** [src/rpc/server.ts:525](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L525)
 
 ### `server.getContractInstance(contractId)`
 
@@ -572,7 +572,7 @@ const instance = await server.getContractInstance(
 console.log(instance.executable.type);
 ```
 
-**Source:** [src/rpc/server.ts:595](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L595)
+**Source:** [src/rpc/server.ts:594](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L594)
 
 ### `server.getContractMethods(contractId, networkPassphrase)`
 
@@ -617,7 +617,7 @@ const methods = await server.getContractMethods(
 // ]
 ```
 
-**Source:** [src/rpc/server.ts:944](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L944)
+**Source:** [src/rpc/server.ts:943](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L943)
 
 ### `server.getContractWasmByContractId(contractId)`
 
@@ -662,7 +662,7 @@ server.getContractWasmByContractId(contractId).then(wasmBytes => {
 });
 ```
 
-**Source:** [src/rpc/server.ts:721](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L721)
+**Source:** [src/rpc/server.ts:720](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L720)
 
 ### `server.getContractWasmByHash(wasmHash, format)`
 
@@ -702,7 +702,7 @@ server.getContractWasmByHash(wasmHash).then(wasmBytes => {
 });
 ```
 
-**Source:** [src/rpc/server.ts:776](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L776)
+**Source:** [src/rpc/server.ts:775](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L775)
 
 ### `server.getEvents(request)`
 
@@ -760,7 +760,7 @@ server.getEvents({
 
 - `getEvents docs`
 
-**Source:** [src/rpc/server.ts:1250](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1250)
+**Source:** [src/rpc/server.ts:1249](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1249)
 
 ### `server.getExternalRefWasmHash(ref)`
 
@@ -802,7 +802,7 @@ if (instance.executable.type === "contractExecutableExternalRef") {
 }
 ```
 
-**Source:** [src/rpc/server.ts:650](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L650)
+**Source:** [src/rpc/server.ts:649](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L649)
 
 ### `server.getFeeStats()`
 
@@ -821,7 +821,7 @@ the fee stats
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getFeeStats
 
-**Source:** [src/rpc/server.ts:1735](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1735)
+**Source:** [src/rpc/server.ts:1734](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1734)
 
 ### `server.getHealth()`
 
@@ -849,7 +849,7 @@ server.getHealth().then((health) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:484](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L484)
+**Source:** [src/rpc/server.ts:483](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L483)
 
 ### `server.getLatestLedger()`
 
@@ -879,7 +879,7 @@ server.getLatestLedger().then((response) => {
 
 - `getLatestLedger docs`
 
-**Source:** [src/rpc/server.ts:1323](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1323)
+**Source:** [src/rpc/server.ts:1322](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1322)
 
 ### `server.getLedgerEntries(keys)`
 
@@ -929,7 +929,7 @@ server.getLedgerEntries([key]).then(response => {
 - - `getLedgerEntries docs`
  - RpcServer._getLedgerEntries
 
-**Source:** [src/rpc/server.ts:1017](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1017)
+**Source:** [src/rpc/server.ts:1016](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1016)
 
 ### `server.getLedgerEntry(key)`
 
@@ -941,7 +941,7 @@ getLedgerEntry(key: LedgerKey): Promise<LedgerEntryResult>;
 
 - **`key`** — `LedgerKey` (required)
 
-**Source:** [src/rpc/server.ts:1032](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1032)
+**Source:** [src/rpc/server.ts:1031](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1031)
 
 ### `server.getLedgers(request)`
 
@@ -1007,7 +1007,7 @@ const nextPage = await server.getLedgers({
 
 - `getLedgers docs`
 
-**Source:** [src/rpc/server.ts:1914](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1914)
+**Source:** [src/rpc/server.ts:1913](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1913)
 
 ### `server.getNetwork()`
 
@@ -1036,7 +1036,7 @@ server.getNetwork().then((network) => {
 
 - `getNetwork docs`
 
-**Source:** [src/rpc/server.ts:1297](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1297)
+**Source:** [src/rpc/server.ts:1296](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1296)
 
 ### `server.getSACBalance(address, sac, networkPassphrase)`
 
@@ -1095,7 +1095,7 @@ console.log(
 - - getLedgerEntries
  - https://developers.stellar.org/docs/tokens/stellar-asset-contract
 
-**Source:** [src/rpc/server.ts:1799](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1799)
+**Source:** [src/rpc/server.ts:1798](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1798)
 
 ### `server.getTransaction(hash)`
 
@@ -1133,7 +1133,7 @@ server.getTransaction(transactionHash).then((tx) => {
 
 - `getTransaction docs`
 
-**Source:** [src/rpc/server.ts:1117](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1117)
+**Source:** [src/rpc/server.ts:1116](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1116)
 
 ### `server.getTransactions(request)`
 
@@ -1169,7 +1169,7 @@ server.getTransactions({
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getTransactions
 
-**Source:** [src/rpc/server.ts:1177](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1177)
+**Source:** [src/rpc/server.ts:1176](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1176)
 
 ### `server.getTrustline(account, asset)`
 
@@ -1208,7 +1208,7 @@ server.getTrustline(accountId, asset).then((entry) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:308](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L308)
+**Source:** [src/rpc/server.ts:307](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L307)
 
 ### `server.getVersionInfo()`
 
@@ -1226,7 +1226,7 @@ the version info
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getVersionInfo
 
-**Source:** [src/rpc/server.ts:1749](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1749)
+**Source:** [src/rpc/server.ts:1748](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1748)
 
 ### `server.pollTransaction(hash, opts)`
 
@@ -1266,7 +1266,7 @@ const txStatus = await server.pollTransaction(h, {
 }); // this will take 5,050 seconds to complete
 ```
 
-**Source:** [src/rpc/server.ts:1070](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1070)
+**Source:** [src/rpc/server.ts:1069](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1069)
 
 ### `server.prepareTransaction(tx)`
 
@@ -1355,7 +1355,7 @@ server.sendTransaction(transaction).then(result => {
 - - module:rpc.assembleTransaction
  - `simulateTransaction docs`
 
-**Source:** [src/rpc/server.ts:1508](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1508)
+**Source:** [src/rpc/server.ts:1507](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1507)
 
 ### `server.queryContract(contractId, method, args, networkPassphrase)`
 
@@ -1413,7 +1413,7 @@ const { result: balance } = await server.queryContract<bigint>(
 );
 ```
 
-**Source:** [src/rpc/server.ts:859](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L859)
+**Source:** [src/rpc/server.ts:858](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L858)
 
 ### `server.requestAirdrop(address, friendbotUrl)`
 
@@ -1463,7 +1463,7 @@ server
 - - `Friendbot docs`
  - `Friendbot.Api.Response`
 
-**Source:** [src/rpc/server.ts:1614](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1614)
+**Source:** [src/rpc/server.ts:1613](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1613)
 
 ### `server.sendTransaction(transaction)`
 
@@ -1524,7 +1524,7 @@ server.sendTransaction(transaction).then((result) => {
 - - `transaction docs`
  - `sendTransaction docs`
 
-**Source:** [src/rpc/server.ts:1563](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1563)
+**Source:** [src/rpc/server.ts:1562](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1562)
 
 ### `server.simulateTransaction(tx, addlResources, authMode, useUpgradedAuth)`
 
@@ -1599,7 +1599,7 @@ server.simulateTransaction(transaction).then((sim) => {
  - module:rpc.Server#prepareTransaction
  - module:rpc.assembleTransaction
 
-**Source:** [src/rpc/server.ts:1400](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1400)
+**Source:** [src/rpc/server.ts:1399](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1399)
 
 ## rpc.assembleTransaction
 

--- a/docs/reference/seps-federation.md
+++ b/docs/reference/seps-federation.md
@@ -227,7 +227,7 @@ A promise that resolves to the federation record
 
 ### Federation.Api.Options
 
-Options for configuring connections to federation servers. You can also use `Config` class to set this globally.
+Options for configuring connections to federation servers. You can also use [`Config`](/reference/cross-cutting/#config) class to set this globally.
 
 ```ts
 interface Options {

--- a/docs/reference/seps-federation.md
+++ b/docs/reference/seps-federation.md
@@ -13,7 +13,7 @@ The maximum size of response from a federation server
 const FEDERATION_RESPONSE_MAX_SIZE: number
 ```
 
-**Source:** [src/federation/server.ts:18](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L18)
+**Source:** [src/federation/server.ts:16](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L16)
 
 ## Federation.Server
 
@@ -32,7 +32,7 @@ class Server {
 }
 ```
 
-**Source:** [src/federation/server.ts:29](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L29)
+**Source:** [src/federation/server.ts:27](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L27)
 
 ### `new Server(serverURL, domain, opts)`
 
@@ -46,7 +46,7 @@ constructor(serverURL: string, domain: string, opts: Options = {});
 - **`domain`** — `string` (required)
 - **`opts`** — `Options` (optional) (default: `{}`)
 
-**Source:** [src/federation/server.ts:140](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L140)
+**Source:** [src/federation/server.ts:138](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L138)
 
 ### `Server.createForDomain(domain, opts)`
 
@@ -90,7 +90,7 @@ StellarSdk.FederationServer.createForDomain('acme.com')
 
 - <a href="https://developers.stellar.org/docs/issuing-assets/publishing-asset-info" target="_blank">Stellar.toml doc</a>
 
-**Source:** [src/federation/server.ts:126](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L126)
+**Source:** [src/federation/server.ts:124](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L124)
 
 ### `Server.resolve(value, opts)`
 
@@ -139,7 +139,7 @@ StellarSdk.FederationServer.resolve('bob*stellar.org')
 - - <a href="https://developers.stellar.org/docs/learn/encyclopedia/federation" target="_blank">Federation doc</a>
  - <a href="https://developers.stellar.org/docs/issuing-assets/publishing-asset-info" target="_blank">Stellar.toml doc</a>
 
-**Source:** [src/federation/server.ts:75](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L75)
+**Source:** [src/federation/server.ts:73](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L73)
 
 ### `server.resolveAccountId(accountId)`
 
@@ -167,7 +167,7 @@ A promise that resolves to the federation record
 
 - <a href="https://developers.stellar.org/docs/encyclopedia/federation" target="_blank">Federation doc</a>
 
-**Source:** [src/federation/server.ts:197](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L197)
+**Source:** [src/federation/server.ts:195](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L195)
 
 ### `server.resolveAddress(address)`
 
@@ -193,7 +193,7 @@ A promise that resolves to the federation record
 
 - <a href="https://developers.stellar.org/docs/encyclopedia/federation" target="_blank">Federation doc</a>
 
-**Source:** [src/federation/server.ts:169](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L169)
+**Source:** [src/federation/server.ts:167](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L167)
 
 ### `server.resolveTransactionId(transactionId)`
 
@@ -221,7 +221,7 @@ A promise that resolves to the federation record
 
 - <a href="https://developers.stellar.org/docs/glossary/federation/" target="_blank">Federation doc</a>
 
-**Source:** [src/federation/server.ts:214](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L214)
+**Source:** [src/federation/server.ts:212](https://github.com/stellar/js-stellar-sdk/blob/main/src/federation/server.ts#L212)
 
 ## Types
 

--- a/docs/reference/seps-toml.md
+++ b/docs/reference/seps-toml.md
@@ -16,7 +16,7 @@ class Resolver {
 }
 ```
 
-**Source:** [src/stellartoml/index.ts:18](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L18)
+**Source:** [src/stellartoml/index.ts:16](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L16)
 
 ### `new Resolver()`
 
@@ -59,7 +59,7 @@ StellarSdk.StellarToml.Resolver.resolve('acme.com')
 
 - `Stellar.toml doc`
 
-**Source:** [src/stellartoml/index.ts:40](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L40)
+**Source:** [src/stellartoml/index.ts:38](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L38)
 
 ## StellarToml.STELLAR_TOML_MAX_SIZE
 
@@ -69,7 +69,7 @@ The maximum size of stellar.toml file, in bytes
 const STELLAR_TOML_MAX_SIZE: number
 ```
 
-**Source:** [src/stellartoml/index.ts:13](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L13)
+**Source:** [src/stellartoml/index.ts:11](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L11)
 
 ## Types
 
@@ -79,7 +79,7 @@ const STELLAR_TOML_MAX_SIZE: number
 type ContractId = string
 ```
 
-**Source:** [src/stellartoml/index.ts:103](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L103)
+**Source:** [src/stellartoml/index.ts:101](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L101)
 
 ### StellarToml.Api.Currency
 
@@ -113,7 +113,7 @@ interface Currency {
 }
 ```
 
-**Source:** [src/stellartoml/index.ts:136](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L136)
+**Source:** [src/stellartoml/index.ts:134](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L134)
 
 #### `currency.anchor_asset`
 
@@ -121,7 +121,7 @@ interface Currency {
 anchor_asset?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:157](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L157)
+**Source:** [src/stellartoml/index.ts:155](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L155)
 
 #### `currency.anchor_asset_type`
 
@@ -129,7 +129,7 @@ anchor_asset?: string;
 anchor_asset_type?: "fiat" | "crypto" | "nft" | "stock" | "bond" | "commodity" | "realestate" | "other";
 ```
 
-**Source:** [src/stellartoml/index.ts:148](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L148)
+**Source:** [src/stellartoml/index.ts:146](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L146)
 
 #### `currency.approval_criteria`
 
@@ -137,7 +137,7 @@ anchor_asset_type?: "fiat" | "crypto" | "nft" | "stock" | "bond" | "commodity" |
 approval_criteria?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:169](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L169)
+**Source:** [src/stellartoml/index.ts:167](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L167)
 
 #### `currency.approval_server`
 
@@ -145,7 +145,7 @@ approval_criteria?: string;
 approval_server?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:168](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L168)
+**Source:** [src/stellartoml/index.ts:166](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L166)
 
 #### `currency.attestation_of_reserve`
 
@@ -153,7 +153,7 @@ approval_server?: string;
 attestation_of_reserve?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:158](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L158)
+**Source:** [src/stellartoml/index.ts:156](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L156)
 
 #### `currency.attestation_of_reserve_amount`
 
@@ -161,7 +161,7 @@ attestation_of_reserve?: string;
 attestation_of_reserve_amount?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:159](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L159)
+**Source:** [src/stellartoml/index.ts:157](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L157)
 
 #### `currency.attestation_of_reserve_last_audit`
 
@@ -169,7 +169,7 @@ attestation_of_reserve_amount?: string;
 attestation_of_reserve_last_audit?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:160](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L160)
+**Source:** [src/stellartoml/index.ts:158](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L158)
 
 #### `currency.code`
 
@@ -177,7 +177,7 @@ attestation_of_reserve_last_audit?: string;
 code?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:137](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L137)
+**Source:** [src/stellartoml/index.ts:135](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L135)
 
 #### `currency.code_template`
 
@@ -185,7 +185,7 @@ code?: string;
 code_template?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:138](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L138)
+**Source:** [src/stellartoml/index.ts:136](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L136)
 
 #### `currency.collateral_address_messages`
 
@@ -193,7 +193,7 @@ code_template?: string;
 collateral_address_messages?: string[];
 ```
 
-**Source:** [src/stellartoml/index.ts:166](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L166)
+**Source:** [src/stellartoml/index.ts:164](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L164)
 
 #### `currency.collateral_address_signatures`
 
@@ -201,7 +201,7 @@ collateral_address_messages?: string[];
 collateral_address_signatures?: string[];
 ```
 
-**Source:** [src/stellartoml/index.ts:167](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L167)
+**Source:** [src/stellartoml/index.ts:165](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L165)
 
 #### `currency.collateral_addresses`
 
@@ -209,7 +209,7 @@ collateral_address_signatures?: string[];
 collateral_addresses?: string[];
 ```
 
-**Source:** [src/stellartoml/index.ts:165](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L165)
+**Source:** [src/stellartoml/index.ts:163](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L163)
 
 #### `currency.conditions`
 
@@ -217,7 +217,7 @@ collateral_addresses?: string[];
 conditions?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:144](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L144)
+**Source:** [src/stellartoml/index.ts:142](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L142)
 
 #### `currency.desc`
 
@@ -225,7 +225,7 @@ conditions?: string;
 desc?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:143](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L143)
+**Source:** [src/stellartoml/index.ts:141](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L141)
 
 #### `currency.display_decimals`
 
@@ -233,7 +233,7 @@ desc?: string;
 display_decimals?: number;
 ```
 
-**Source:** [src/stellartoml/index.ts:140](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L140)
+**Source:** [src/stellartoml/index.ts:138](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L138)
 
 #### `currency.fixed_number`
 
@@ -241,7 +241,7 @@ display_decimals?: number;
 fixed_number?: number;
 ```
 
-**Source:** [src/stellartoml/index.ts:145](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L145)
+**Source:** [src/stellartoml/index.ts:143](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L143)
 
 #### `currency.image`
 
@@ -249,7 +249,7 @@ fixed_number?: number;
 image?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:163](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L163)
+**Source:** [src/stellartoml/index.ts:161](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L161)
 
 #### `currency.is_asset_anchored`
 
@@ -257,7 +257,7 @@ image?: string;
 is_asset_anchored?: boolean;
 ```
 
-**Source:** [src/stellartoml/index.ts:147](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L147)
+**Source:** [src/stellartoml/index.ts:145](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L145)
 
 #### `currency.is_unlimited`
 
@@ -265,7 +265,7 @@ is_asset_anchored?: boolean;
 is_unlimited?: boolean;
 ```
 
-**Source:** [src/stellartoml/index.ts:161](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L161)
+**Source:** [src/stellartoml/index.ts:159](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L159)
 
 #### `currency.issuer`
 
@@ -273,7 +273,7 @@ is_unlimited?: boolean;
 issuer?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:139](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L139)
+**Source:** [src/stellartoml/index.ts:137](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L137)
 
 #### `currency.max_number`
 
@@ -281,7 +281,7 @@ issuer?: string;
 max_number?: number;
 ```
 
-**Source:** [src/stellartoml/index.ts:146](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L146)
+**Source:** [src/stellartoml/index.ts:144](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L144)
 
 #### `currency.name`
 
@@ -289,7 +289,7 @@ max_number?: number;
 name?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:142](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L142)
+**Source:** [src/stellartoml/index.ts:140](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L140)
 
 #### `currency.redemption_instructions`
 
@@ -297,7 +297,7 @@ name?: string;
 redemption_instructions?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:162](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L162)
+**Source:** [src/stellartoml/index.ts:160](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L160)
 
 #### `currency.regulated`
 
@@ -305,7 +305,7 @@ redemption_instructions?: string;
 regulated?: boolean;
 ```
 
-**Source:** [src/stellartoml/index.ts:164](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L164)
+**Source:** [src/stellartoml/index.ts:162](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L162)
 
 #### `currency.status`
 
@@ -313,7 +313,7 @@ regulated?: boolean;
 status?: "live" | "dead" | "test" | "private";
 ```
 
-**Source:** [src/stellartoml/index.ts:141](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L141)
+**Source:** [src/stellartoml/index.ts:139](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L139)
 
 ### StellarToml.Api.Documentation
 
@@ -339,7 +339,7 @@ interface Documentation {
 }
 ```
 
-**Source:** [src/stellartoml/index.ts:105](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L105)
+**Source:** [src/stellartoml/index.ts:103](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L103)
 
 #### `documentation.ORG_DBA`
 
@@ -347,7 +347,7 @@ interface Documentation {
 ORG_DBA?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:107](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L107)
+**Source:** [src/stellartoml/index.ts:105](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L105)
 
 #### `documentation.ORG_DESCRIPTION`
 
@@ -355,7 +355,7 @@ ORG_DBA?: string;
 ORG_DESCRIPTION?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:114](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L114)
+**Source:** [src/stellartoml/index.ts:112](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L112)
 
 #### `documentation.ORG_GITHUB`
 
@@ -363,7 +363,7 @@ ORG_DESCRIPTION?: string;
 ORG_GITHUB?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:122](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L122)
+**Source:** [src/stellartoml/index.ts:120](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L120)
 
 #### `documentation.ORG_KEYBASE`
 
@@ -371,7 +371,7 @@ ORG_GITHUB?: string;
 ORG_KEYBASE?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:120](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L120)
+**Source:** [src/stellartoml/index.ts:118](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L118)
 
 #### `documentation.ORG_LICENSE_NUMBER`
 
@@ -379,7 +379,7 @@ ORG_KEYBASE?: string;
 ORG_LICENSE_NUMBER?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:111](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L111)
+**Source:** [src/stellartoml/index.ts:109](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L109)
 
 #### `documentation.ORG_LICENSE_TYPE`
 
@@ -387,7 +387,7 @@ ORG_LICENSE_NUMBER?: string;
 ORG_LICENSE_TYPE?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:113](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L113)
+**Source:** [src/stellartoml/index.ts:111](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L111)
 
 #### `documentation.ORG_LICENSING_AUTHORITY`
 
@@ -395,7 +395,7 @@ ORG_LICENSE_TYPE?: string;
 ORG_LICENSING_AUTHORITY?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:112](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L112)
+**Source:** [src/stellartoml/index.ts:110](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L110)
 
 #### `documentation.ORG_LOGO`
 
@@ -403,7 +403,7 @@ ORG_LICENSING_AUTHORITY?: string;
 ORG_LOGO?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:110](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L110)
+**Source:** [src/stellartoml/index.ts:108](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L108)
 
 #### `documentation.ORG_NAME`
 
@@ -411,7 +411,7 @@ ORG_LOGO?: string;
 ORG_NAME?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:106](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L106)
+**Source:** [src/stellartoml/index.ts:104](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L104)
 
 #### `documentation.ORG_OFFICIAL_EMAIL`
 
@@ -419,7 +419,7 @@ ORG_NAME?: string;
 ORG_OFFICIAL_EMAIL?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:118](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L118)
+**Source:** [src/stellartoml/index.ts:116](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L116)
 
 #### `documentation.ORG_PHONE_NUMBER`
 
@@ -427,7 +427,7 @@ ORG_OFFICIAL_EMAIL?: string;
 ORG_PHONE_NUMBER?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:109](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L109)
+**Source:** [src/stellartoml/index.ts:107](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L107)
 
 #### `documentation.ORG_PHONE_NUMBER_ATTESTATION`
 
@@ -435,7 +435,7 @@ ORG_PHONE_NUMBER?: string;
 ORG_PHONE_NUMBER_ATTESTATION?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:117](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L117)
+**Source:** [src/stellartoml/index.ts:115](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L115)
 
 #### `documentation.ORG_PHYSICAL_ADDRESS`
 
@@ -443,7 +443,7 @@ ORG_PHONE_NUMBER_ATTESTATION?: string;
 ORG_PHYSICAL_ADDRESS?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:115](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L115)
+**Source:** [src/stellartoml/index.ts:113](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L113)
 
 #### `documentation.ORG_PHYSICAL_ADDRESS_ATTESTATION`
 
@@ -451,7 +451,7 @@ ORG_PHYSICAL_ADDRESS?: string;
 ORG_PHYSICAL_ADDRESS_ATTESTATION?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:116](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L116)
+**Source:** [src/stellartoml/index.ts:114](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L114)
 
 #### `documentation.ORG_SUPPORT_EMAIL`
 
@@ -459,7 +459,7 @@ ORG_PHYSICAL_ADDRESS_ATTESTATION?: string;
 ORG_SUPPORT_EMAIL?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:119](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L119)
+**Source:** [src/stellartoml/index.ts:117](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L117)
 
 #### `documentation.ORG_TWITTER`
 
@@ -467,7 +467,7 @@ ORG_SUPPORT_EMAIL?: string;
 ORG_TWITTER?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:121](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L121)
+**Source:** [src/stellartoml/index.ts:119](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L119)
 
 #### `documentation.ORG_URL`
 
@@ -475,7 +475,7 @@ ORG_TWITTER?: string;
 ORG_URL?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:108](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L108)
+**Source:** [src/stellartoml/index.ts:106](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L106)
 
 ### StellarToml.Api.ISODateTime
 
@@ -483,7 +483,7 @@ ORG_URL?: string;
 type ISODateTime = string
 ```
 
-**Source:** [src/stellartoml/index.ts:104](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L104)
+**Source:** [src/stellartoml/index.ts:102](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L102)
 
 ### StellarToml.Api.Principal
 
@@ -500,7 +500,7 @@ interface Principal {
 }
 ```
 
-**Source:** [src/stellartoml/index.ts:125](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L125)
+**Source:** [src/stellartoml/index.ts:123](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L123)
 
 #### `principal.email`
 
@@ -508,7 +508,7 @@ interface Principal {
 email: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:127](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L127)
+**Source:** [src/stellartoml/index.ts:125](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L125)
 
 #### `principal.github`
 
@@ -516,7 +516,7 @@ email: string;
 github?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:128](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L128)
+**Source:** [src/stellartoml/index.ts:126](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L126)
 
 #### `principal.id_photo_hash`
 
@@ -524,7 +524,7 @@ github?: string;
 id_photo_hash?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:132](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L132)
+**Source:** [src/stellartoml/index.ts:130](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L130)
 
 #### `principal.keybase`
 
@@ -532,7 +532,7 @@ id_photo_hash?: string;
 keybase?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:129](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L129)
+**Source:** [src/stellartoml/index.ts:127](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L127)
 
 #### `principal.name`
 
@@ -540,7 +540,7 @@ keybase?: string;
 name: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:126](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L126)
+**Source:** [src/stellartoml/index.ts:124](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L124)
 
 #### `principal.telegram`
 
@@ -548,7 +548,7 @@ name: string;
 telegram?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:130](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L130)
+**Source:** [src/stellartoml/index.ts:128](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L128)
 
 #### `principal.twitter`
 
@@ -556,7 +556,7 @@ telegram?: string;
 twitter?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:131](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L131)
+**Source:** [src/stellartoml/index.ts:129](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L129)
 
 #### `principal.verification_photo_hash`
 
@@ -564,7 +564,7 @@ twitter?: string;
 verification_photo_hash?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:133](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L133)
+**Source:** [src/stellartoml/index.ts:131](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L131)
 
 ### StellarToml.Api.PublicKey
 
@@ -572,7 +572,7 @@ verification_photo_hash?: string;
 type PublicKey = string
 ```
 
-**Source:** [src/stellartoml/index.ts:102](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L102)
+**Source:** [src/stellartoml/index.ts:100](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L100)
 
 ### StellarToml.Api.StellarToml
 
@@ -600,7 +600,7 @@ interface StellarToml {
 }
 ```
 
-**Source:** [src/stellartoml/index.ts:184](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L184)
+**Source:** [src/stellartoml/index.ts:182](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L182)
 
 #### `stellarToml.ACCOUNTS`
 
@@ -608,7 +608,7 @@ interface StellarToml {
 ACCOUNTS?: string[];
 ```
 
-**Source:** [src/stellartoml/index.ts:186](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L186)
+**Source:** [src/stellartoml/index.ts:184](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L184)
 
 #### `stellarToml.ANCHOR_QUOTE_SERVER`
 
@@ -616,7 +616,7 @@ ACCOUNTS?: string[];
 ANCHOR_QUOTE_SERVER?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:199](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L199)
+**Source:** [src/stellartoml/index.ts:197](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L197)
 
 #### `stellarToml.CURRENCIES`
 
@@ -624,7 +624,7 @@ ANCHOR_QUOTE_SERVER?: string;
 CURRENCIES?: Currency[];
 ```
 
-**Source:** [src/stellartoml/index.ts:202](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L202)
+**Source:** [src/stellartoml/index.ts:200](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L200)
 
 #### `stellarToml.DIRECT_PAYMENT_SERVER`
 
@@ -632,7 +632,7 @@ CURRENCIES?: Currency[];
 DIRECT_PAYMENT_SERVER?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:198](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L198)
+**Source:** [src/stellartoml/index.ts:196](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L196)
 
 #### `stellarToml.DOCUMENTATION`
 
@@ -640,7 +640,7 @@ DIRECT_PAYMENT_SERVER?: string;
 DOCUMENTATION?: Documentation;
 ```
 
-**Source:** [src/stellartoml/index.ts:200](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L200)
+**Source:** [src/stellartoml/index.ts:198](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L198)
 
 #### `stellarToml.FEDERATION_SERVER`
 
@@ -648,7 +648,7 @@ DOCUMENTATION?: Documentation;
 FEDERATION_SERVER?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:194](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L194)
+**Source:** [src/stellartoml/index.ts:192](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L192)
 
 #### `stellarToml.HORIZON_URL`
 
@@ -656,7 +656,7 @@ FEDERATION_SERVER?: string;
 HORIZON_URL?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:196](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L196)
+**Source:** [src/stellartoml/index.ts:194](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L194)
 
 #### `stellarToml.KYC_SERVER`
 
@@ -664,7 +664,7 @@ HORIZON_URL?: string;
 KYC_SERVER?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:190](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L190)
+**Source:** [src/stellartoml/index.ts:188](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L188)
 
 #### `stellarToml.NETWORK_PASSPHRASE`
 
@@ -672,7 +672,7 @@ KYC_SERVER?: string;
 NETWORK_PASSPHRASE?: Networks;
 ```
 
-**Source:** [src/stellartoml/index.ts:187](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L187)
+**Source:** [src/stellartoml/index.ts:185](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L185)
 
 #### `stellarToml.PRINCIPALS`
 
@@ -680,7 +680,7 @@ NETWORK_PASSPHRASE?: Networks;
 PRINCIPALS?: Principal[];
 ```
 
-**Source:** [src/stellartoml/index.ts:201](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L201)
+**Source:** [src/stellartoml/index.ts:199](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L199)
 
 #### `stellarToml.SIGNING_KEY`
 
@@ -688,7 +688,7 @@ PRINCIPALS?: Principal[];
 SIGNING_KEY?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:195](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L195)
+**Source:** [src/stellartoml/index.ts:193](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L193)
 
 #### `stellarToml.TRANSFER_SERVER`
 
@@ -696,7 +696,7 @@ SIGNING_KEY?: string;
 TRANSFER_SERVER?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:189](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L189)
+**Source:** [src/stellartoml/index.ts:187](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L187)
 
 #### `stellarToml.TRANSFER_SERVER_SEP0024`
 
@@ -704,7 +704,7 @@ TRANSFER_SERVER?: string;
 TRANSFER_SERVER_SEP0024?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:188](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L188)
+**Source:** [src/stellartoml/index.ts:186](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L186)
 
 #### `stellarToml.URI_REQUEST_SIGNING_KEY`
 
@@ -712,7 +712,7 @@ TRANSFER_SERVER_SEP0024?: string;
 URI_REQUEST_SIGNING_KEY?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:197](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L197)
+**Source:** [src/stellartoml/index.ts:195](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L195)
 
 #### `stellarToml.VALIDATORS`
 
@@ -720,7 +720,7 @@ URI_REQUEST_SIGNING_KEY?: string;
 VALIDATORS?: Validator[];
 ```
 
-**Source:** [src/stellartoml/index.ts:203](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L203)
+**Source:** [src/stellartoml/index.ts:201](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L201)
 
 #### `stellarToml.VERSION`
 
@@ -728,7 +728,7 @@ VALIDATORS?: Validator[];
 VERSION?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:185](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L185)
+**Source:** [src/stellartoml/index.ts:183](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L183)
 
 #### `stellarToml.WEB_AUTH_CONTRACT_ID`
 
@@ -736,7 +736,7 @@ VERSION?: string;
 WEB_AUTH_CONTRACT_ID?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:193](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L193)
+**Source:** [src/stellartoml/index.ts:191](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L191)
 
 #### `stellarToml.WEB_AUTH_ENDPOINT`
 
@@ -744,7 +744,7 @@ WEB_AUTH_CONTRACT_ID?: string;
 WEB_AUTH_ENDPOINT?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:191](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L191)
+**Source:** [src/stellartoml/index.ts:189](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L189)
 
 #### `stellarToml.WEB_AUTH_FOR_CONTRACTS_ENDPOINT`
 
@@ -752,7 +752,7 @@ WEB_AUTH_ENDPOINT?: string;
 WEB_AUTH_FOR_CONTRACTS_ENDPOINT?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:192](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L192)
+**Source:** [src/stellartoml/index.ts:190](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L190)
 
 ### StellarToml.Api.StellarTomlResolveOptions
 
@@ -764,7 +764,7 @@ interface StellarTomlResolveOptions {
 }
 ```
 
-**Source:** [src/stellartoml/index.ts:96](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L96)
+**Source:** [src/stellartoml/index.ts:94](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L94)
 
 #### `stellarTomlResolveOptions.allowedRedirects`
 
@@ -772,7 +772,7 @@ interface StellarTomlResolveOptions {
 allowedRedirects?: number;
 ```
 
-**Source:** [src/stellartoml/index.ts:99](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L99)
+**Source:** [src/stellartoml/index.ts:97](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L97)
 
 #### `stellarTomlResolveOptions.allowHttp`
 
@@ -780,7 +780,7 @@ allowedRedirects?: number;
 allowHttp?: boolean;
 ```
 
-**Source:** [src/stellartoml/index.ts:97](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L97)
+**Source:** [src/stellartoml/index.ts:95](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L95)
 
 #### `stellarTomlResolveOptions.timeout`
 
@@ -788,7 +788,7 @@ allowHttp?: boolean;
 timeout?: number;
 ```
 
-**Source:** [src/stellartoml/index.ts:98](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L98)
+**Source:** [src/stellartoml/index.ts:96](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L96)
 
 ### StellarToml.Api.Url
 
@@ -796,7 +796,7 @@ timeout?: number;
 type Url = string
 ```
 
-**Source:** [src/stellartoml/index.ts:101](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L101)
+**Source:** [src/stellartoml/index.ts:99](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L99)
 
 ### StellarToml.Api.Validator
 
@@ -810,7 +810,7 @@ interface Validator {
 }
 ```
 
-**Source:** [src/stellartoml/index.ts:173](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L173)
+**Source:** [src/stellartoml/index.ts:171](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L171)
 
 #### `validator.ALIAS`
 
@@ -818,7 +818,7 @@ interface Validator {
 ALIAS?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:174](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L174)
+**Source:** [src/stellartoml/index.ts:172](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L172)
 
 #### `validator.DISPLAY_NAME`
 
@@ -826,7 +826,7 @@ ALIAS?: string;
 DISPLAY_NAME?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:175](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L175)
+**Source:** [src/stellartoml/index.ts:173](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L173)
 
 #### `validator.HISTORY`
 
@@ -834,7 +834,7 @@ DISPLAY_NAME?: string;
 HISTORY?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:178](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L178)
+**Source:** [src/stellartoml/index.ts:176](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L176)
 
 #### `validator.HOST`
 
@@ -842,7 +842,7 @@ HISTORY?: string;
 HOST?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:177](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L177)
+**Source:** [src/stellartoml/index.ts:175](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L175)
 
 #### `validator.PUBLIC_KEY`
 
@@ -850,4 +850,4 @@ HOST?: string;
 PUBLIC_KEY?: string;
 ```
 
-**Source:** [src/stellartoml/index.ts:176](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L176)
+**Source:** [src/stellartoml/index.ts:174](https://github.com/stellar/js-stellar-sdk/blob/main/src/stellartoml/index.ts#L174)

--- a/docs/reference/seps-webauth.md
+++ b/docs/reference/seps-webauth.md
@@ -116,8 +116,8 @@ It does not verify that the transaction has been signed by the client or that
 any signatures other than the server's on the transaction are valid. Use one
 of the following functions to completely verify the transaction:
 
-- `WebAuth.verifyChallengeTxThreshold`
-- `WebAuth.verifyChallengeTxSigners`
+- [`WebAuth.verifyChallengeTxThreshold`](#webauthverifychallengetxthreshold)
+- [`WebAuth.verifyChallengeTxSigners`](#webauthverifychallengetxsigners)
 
 ```ts
 readChallengeTx(challengeTx: string, serverAccountID: string, networkPassphrase: string, homeDomains: string | string[], webAuthDomain: string): { clientAccountID: string; matchedHomeDomain: string; memo: string | null; tx: Transaction }
@@ -128,7 +128,7 @@ readChallengeTx(challengeTx: string, serverAccountID: string, networkPassphrase:
 - **`challengeTx`** — `string` (required) — SEP0010 challenge transaction in base64.
 - **`serverAccountID`** — `string` (required) — The server's stellar account (public key).
 - **`networkPassphrase`** — `string` (required) — The network passphrase, e.g.: 'Test SDF
-     Network ; September 2015' (see `Networks`)
+     Network ; September 2015' (see [`Networks`](/reference/core-transactions/#networks))
 - **`homeDomains`** — `string | string[]` (required) — The home domain that is expected
      to be included in the first Manage Data operation's string key. If an
      array is provided, one of the domain names in the array must match.
@@ -165,7 +165,7 @@ ignored.
 
 Errors will be raised if:
 - The transaction is invalid according to
-`WebAuth.readChallengeTx`.
+[`WebAuth.readChallengeTx`](#webauthreadchallengetx).
 - No client signatures are found on the transaction.
 - One or more signatures in the transaction are not identifiable as the
 server account or one of the signers provided in the arguments.
@@ -179,7 +179,7 @@ verifyChallengeTxSigners(challengeTx: string, serverAccountID: string, networkPa
 - **`challengeTx`** — `string` (required) — SEP0010 challenge transaction in base64.
 - **`serverAccountID`** — `string` (required) — The server's stellar account (public key).
 - **`networkPassphrase`** — `string` (required) — The network passphrase, e.g.: 'Test SDF
-     Network ; September 2015' (see `Networks`).
+     Network ; September 2015' (see [`Networks`](/reference/core-transactions/#networks)).
 - **`signers`** — `string[]` (required) — The signers public keys. This list should
      contain the public keys for all signers that have signed the transaction.
 - **`homeDomains`** — `string | string[]` (required) — The home domain(s) that should
@@ -251,7 +251,7 @@ ignored.
 
 Errors will be raised if:
 - The transaction is invalid according to
-`WebAuth.readChallengeTx`.
+[`WebAuth.readChallengeTx`](#webauthreadchallengetx).
 - No client signatures are found on the transaction.
 - One or more signatures in the transaction are not identifiable as the
 server account or one of the signers provided in the arguments.
@@ -266,7 +266,7 @@ verifyChallengeTxThreshold(challengeTx: string, serverAccountID: string, network
 - **`challengeTx`** — `string` (required) — SEP0010 challenge transaction in base64.
 - **`serverAccountID`** — `string` (required) — The server's stellar account (public key).
 - **`networkPassphrase`** — `string` (required) — The network passphrase, e.g.: 'Test SDF
-     Network ; September 2015' (see `Networks`).
+     Network ; September 2015' (see [`Networks`](/reference/core-transactions/#networks)).
 - **`threshold`** — `number` (required) — The required signatures threshold for verifying
      this transaction.
 - **`signerSummary`** — `AccountRecordSigners[]` (required) — a map of all

--- a/scripts/build-docs.ts
+++ b/scripts/build-docs.ts
@@ -220,6 +220,11 @@ interface SummaryDisplayPart {
   kind: "text" | "code" | "inline-tag";
   text: string;
   tag?: string;
+  // For `{@link}` parts TypeDoc emits either a numeric reflection id (when
+  // it resolved the reference itself) or a string symbol path (when it could
+  // not, e.g. an external name). Both forms have to resolve — see
+  // `buildLinkResolver`.
+  target?: string | number;
 }
 
 interface Comment {
@@ -822,10 +827,16 @@ function validateAnchors(files: RenderedFile[]): void {
         continue;
       }
 
-      const cross = url.match(/^\.?\/?([\w-]+)\.md(?:#(.+))?$/);
+      // Both shapes a cross-file reference link can take: the root-absolute
+      // `/reference/<slug>/#anchor` this generator emits, and a relative
+      // `<slug>.md#anchor`. The relative form is not emitted any more but is
+      // still matched so a hand-written one cannot slip past unvalidated.
+      const cross = url.match(
+        /^(?:\/reference\/([\w-]+)\/?|\.?\/?([\w-]+)\.md)(?:#(.+))?$/,
+      );
       if (cross !== null) {
-        const targetSlug = cross[1];
-        const targetAnchor = cross[2];
+        const targetSlug = cross[1] ?? cross[2];
+        const targetAnchor = cross[3];
         const targetIds = anchorsBySlug.get(targetSlug);
         if (targetIds === undefined) {
           problems.push(
@@ -858,11 +869,18 @@ interface ResolvedLink {
 }
 
 interface LinkResolver {
-  resolve(target: string, currentBucket: BucketName): string | undefined;
+  resolve(
+    target: string | number,
+    currentBucket: BucketName,
+  ): string | undefined;
 }
 
 function buildLinkResolver(records: SymbolRecord[]): LinkResolver {
   const map = new Map<string, ResolvedLink>();
+  // Reflection id → link, for `{@link}` parts TypeDoc already resolved to an
+  // id rather than a name. Without this every such reference falls back to
+  // plain inline code, which is most of them.
+  const byId = new Map<number, ResolvedLink>();
 
   // Group by bucket (one rendered file per bucket) so each file gets its
   // own slugger and dedup namespace.
@@ -882,19 +900,27 @@ function buildLinkResolver(records: SymbolRecord[]): LinkResolver {
     slugger.slug(bucket); // the leading `# <bucket>` page heading
 
     const register = (record: SymbolRecord): void => {
-      map.set(record.qname, {
+      // Each anchor is slugged exactly once and the resulting link shared
+      // between both indexes: `slugger.slug` is stateful (it appends
+      // `-1`/`-2` on repeats), so slugging twice would desync the anchors
+      // from what `renderFile` emits.
+      const link: ResolvedLink = {
         bucket,
         slug,
         anchor: slugger.slug(record.qname),
-      });
+      };
+      map.set(record.qname, link);
+      byId.set(record.refl.id, link);
       for (const m of sortMembers(record.members ?? [])) {
         const memberQname = `${record.qname}.${m.name}`;
         const headingText = memberHeadingText(m, record.refl.name);
-        map.set(memberQname, {
+        const memberLink: ResolvedLink = {
           bucket,
           slug,
           anchor: slugger.slug(headingText),
-        });
+        };
+        map.set(memberQname, memberLink);
+        byId.set(m.id, memberLink);
       }
     };
 
@@ -908,16 +934,21 @@ function buildLinkResolver(records: SymbolRecord[]): LinkResolver {
 
   return {
     resolve(target, currentBucket) {
-      const entry = map.get(target);
+      const entry =
+        typeof target === "number" ? byId.get(target) : map.get(target);
       if (entry === undefined) return undefined;
       // Same-file links keep the relative path empty; cross-file links
       // emit `./<slug>.md#<anchor>` so raw markdown viewers (e.g. plain
       // GitHub view) follow the link to the right file regardless of
       // any specific docs-platform URL scheme.
       const anchor = `#${entry.anchor}`;
+      // Cross-file links must be root-absolute (`/reference/<slug>/#anchor`),
+      // matching the form the authored guides use. A relative `./<slug>.md`
+      // link breaks on the built site — Astro does not rewrite it — and
+      // `build-llms.ts` rejects that shape outright.
       return entry.bucket === currentBucket
         ? anchor
-        : `./${entry.slug}.md${anchor}`;
+        : `/reference/${entry.slug}/${anchor}`;
     },
   };
 }
@@ -949,7 +980,7 @@ let currentBuilderMembers: Map<string, ChainableMethod[]> | undefined;
 const BACKTICKED_LINK_RE =
   /^`?\{@(?:link|linkcode|linkplain)\s+([^}|]+?)(?:\s*\|\s*([^}]+?))?\s*\}`?$/;
 
-function resolveLinkPart(target: string, display: string): string {
+function resolveLinkPart(target: string | number, display: string): string {
   if (currentLinkResolver !== undefined && currentRenderBucket !== undefined) {
     const url = currentLinkResolver.resolve(target, currentRenderBucket);
     if (url !== undefined) {
@@ -992,10 +1023,11 @@ function renderSummary(parts: SummaryDisplayPart[] | undefined): string {
         ) {
           // `{@link Foo | display}` parts arrive with `text` already
           // resolved to the display text by TypeDoc; `target` carries
-          // the symbol path. Use `target` for resolution and `text`
-          // for display, falling back to `text` for both when
-          // `target` is absent.
-          const target = (p as SummaryDisplayPart & { target?: string }).target;
+          // the symbol path or reflection id. Resolve on `target` and
+          // display `text` — never fall back to `text` for resolution
+          // when a target is present, since for the piped form it holds
+          // the display string rather than the symbol.
+          const target = p.target;
           return resolveLinkPart(target ?? p.text, p.text);
         }
         return `{${p.tag} ${p.text}}`;
@@ -1446,6 +1478,20 @@ function renderFile(
 // builders' `{@link Horizon.Server.x}` cross-references don't resolve in
 // isolation and would otherwise trip `treatWarningsAsErrors`.
 function buildCallBuilderMembers(): Map<string, ChainableMethod[]> {
+  // This pass renders summaries from its own typedoc run, whose reflection
+  // ids are a different id space that overlaps api.json's. If the resolver
+  // were already built, `renderSummary` would resolve those ids against the
+  // main pass and silently emit links to unrelated symbols (id 2 here is
+  // `AccountCallBuilder`; in api.json it is `captureStackTrace`). Callers
+  // must run this before `currentLinkResolver` is assigned.
+  if (currentLinkResolver !== undefined) {
+    throw new Error(
+      "buildCallBuilderMembers must run before the link resolver is built: " +
+        "its reflection ids come from a separate typedoc pass and would " +
+        "resolve against the wrong symbols.",
+    );
+  }
+
   const horizonDir = join(REPO_ROOT, "src/horizon");
   // `*_builder.ts` covers both the `*_call_builder.ts` query builders and
   // `friendbot_builder.ts`; `Server.friendbot()` returns a FriendbotBuilder

--- a/src/base/asset.ts
+++ b/src/base/asset.ts
@@ -238,7 +238,7 @@ export class Asset {
    *  - `native`,
    *  - `credit_alphanum4`,
    *  - `credit_alphanum12`
-   * @throws {Error} Throws `Error` if asset type is unsupported.
+   * @throws if asset type is unsupported.
    */
   getAssetType(): AssetType {
     switch (this.getRawAssetType().value) {
@@ -303,7 +303,7 @@ export class Asset {
   /**
    * Compares two assets according to the criteria:
    *
-   *  1. First compare the type (native < alphanum4 < alphanum12).
+   *  1. First compare the type (`native < alphanum4 < alphanum12`).
    *  2. If the types are equal, compare the assets codes.
    *  3. If the asset codes are equal, compare the issuers.
    *

--- a/src/base/get_liquidity_pool_id.ts
+++ b/src/base/get_liquidity_pool_id.ts
@@ -34,9 +34,9 @@ export const LiquidityPoolFeeV18 = 30;
  *
  * @param liquidityPoolType - A string representing the liquidity pool type.
  * @param liquidityPoolParameters - The liquidity pool parameters.
- * @param liquidityPoolParameters.assetA - The first asset in the Pool, it must respect the rule assetA < assetB.
- * @param liquidityPoolParameters.assetB - The second asset in the Pool, it must respect the rule assetA < assetB.
- * @param liquidityPoolParameters.fee - The liquidity pool fee. For now the only fee supported is `30`.
+ *   - `assetA`: The first asset in the Pool, it must respect the rule `assetA < assetB`.
+ *   - `assetB`: The second asset in the Pool, it must respect the rule `assetA < assetB`.
+ *   - `fee`: The liquidity pool fee. For now the only fee supported is `30`.
  */
 export function getLiquidityPoolId(
   liquidityPoolType: LiquidityPoolType,

--- a/src/base/keypair.ts
+++ b/src/base/keypair.ts
@@ -53,9 +53,9 @@ export class Keypair {
 
   /**
    * @param keys - at least one of keys must be provided.
-   * @param keys.type - public-key signature system name (currently only `ed25519` keys are supported)
-   * @param keys.publicKey - raw public key
-   * @param keys.secretKey - raw secret key (32-byte secret seed in ed25519)
+   *   - `type`: public-key signature system name (currently only `ed25519` keys are supported)
+   *   - `publicKey`: raw public key
+   *   - `secretKey`: raw secret key (32-byte secret seed in ed25519)
    */
   constructor(
     keys:
@@ -172,7 +172,7 @@ export class Keypair {
    * You will get a different type of muxed account depending on whether or not
    * you pass an ID.
    *
-   * @param [id] - stringified integer indicating the underlying muxed
+   * @param id - stringified integer indicating the underlying muxed
    *     ID of the new account object
    */
   xdrMuxedAccount(id?: string): MuxedAccount {
@@ -221,7 +221,7 @@ export class Keypair {
    *
    * The secret key is encoded in Stellar format (e.g., `SDAK....`).
    *
-   * @throws {Error} if no secret key is available
+   * @throws if no secret key is available
    */
   secret(): string {
     if (!this._secretSeed) {
@@ -238,7 +238,7 @@ export class Keypair {
   /**
    * Returns raw secret key bytes.
    *
-   * @throws {Error} if no secret seed is available
+   * @throws if no secret seed is available
    */
   rawSecretKey(): Uint8Array {
     if (!this._secretSeed) {
@@ -258,7 +258,7 @@ export class Keypair {
    * Signs data.
    *
    * @param data - data to sign
-   * @throws {Error} if no secret key is available
+   * @throws if no secret key is available
    */
   sign(data: Uint8Array): Uint8Array {
     if (!this._secretKey) {

--- a/src/base/liquidity_pool_asset.ts
+++ b/src/base/liquidity_pool_asset.ts
@@ -20,8 +20,8 @@ export class LiquidityPoolAsset {
   fee: number;
 
   /**
-   * @param assetA - The first asset in the Pool, it must respect the rule assetA < assetB. See {@link Asset.compare} for more details on how assets are sorted.
-   * @param assetB - The second asset in the Pool, it must respect the rule assetA < assetB. See {@link Asset.compare} for more details on how assets are sorted.
+   * @param assetA - The first asset in the Pool, it must respect the rule `assetA < assetB`. See {@link Asset.compare} for more details on how assets are sorted.
+   * @param assetB - The second asset in the Pool, it must respect the rule `assetA < assetB`. See {@link Asset.compare} for more details on how assets are sorted.
    * @param fee - The liquidity pool fee. For now the only fee supported is `30`.
    */
   constructor(assetA: Asset, assetB: Asset, fee: number) {
@@ -71,9 +71,9 @@ export class LiquidityPoolAsset {
   /**
    * Returns the `xdr.ChangeTrustAsset` object for this liquidity pool asset.
    *
-   * Note: To convert from an {@link Asset `Asset`} to `xdr.ChangeTrustAsset`
+   * Note: To convert from an {@link Asset | `Asset`} to `xdr.ChangeTrustAsset`
    * please refer to the
-   * {@link Asset.toChangeTrustXdrObject `Asset.toChangeTrustXdrObject`} method.
+   * {@link Asset.toChangeTrustXdrObject | `Asset.toChangeTrustXdrObject`} method.
    */
   toXdrObject(): ChangeTrustAsset {
     const lpConstantProductParamsXdr =

--- a/src/base/liquidity_pool_id.ts
+++ b/src/base/liquidity_pool_id.ts
@@ -42,9 +42,9 @@ export class LiquidityPoolId {
   /**
    * Returns the `xdr.TrustLineAsset` object for this liquidity pool ID.
    *
-   * Note: To convert from {@link Asset `Asset`} to `xdr.TrustLineAsset` please
+   * Note: To convert from {@link Asset | `Asset`} to `xdr.TrustLineAsset` please
    * refer to the
-   * {@link Asset.toTrustLineXdrObject `Asset.toTrustLineXdrObject`} method.
+   * {@link Asset.toTrustLineXdrObject | `Asset.toTrustLineXdrObject`} method.
    */
   toXdrObject(): TrustLineAsset {
     const xdrPoolId = new PoolId(this.liquidityPoolId);

--- a/src/base/numbers/index.ts
+++ b/src/base/numbers/index.ts
@@ -15,15 +15,17 @@ export type { ScIntType };
  * you can pass it to the constructor of {@link XdrLargeInt}.
  *
  * @example
+ * ```ts
  * let scv = contract.call("add", x, y); // assume it returns an xdr.ScVal
  * let bigi = scValToBigInt(scv);
  *
  * new ScInt(bigi);               // if you don't care about types, and
  * new XdrLargeInt('i128', bigi); // if you do
+ * ```
  *
  * @param scv - the XDR smart contract value to convert
  *
- * @throws {TypeError} if the `scv` input value doesn't represent an integer
+ * @throws a `TypeError` if the `scv` input value doesn't represent an integer
  */
 export function scValToBigInt(scv: ScVal): bigint {
   const switchName = scv.type;

--- a/src/base/numbers/sc_int.ts
+++ b/src/base/numbers/sc_int.ts
@@ -12,7 +12,8 @@ import { XdrLargeInt, type ScIntType } from "./xdr_large_int.js";
  * example, you could do `new XdrLargeInt('u128', bytes...).toBigInt()`.
  *
  * @example
- * import { xdr, ScInt, scValToBigInt } from "@stellar/stellar-base";
+ * ```ts
+ * import { xdr, ScInt, scValToBigInt } from "@stellar/stellar-sdk";
  *
  * // You have an ScVal from a contract and want to parse it into JS native.
  * const value = xdr.ScVal.fromXdr(someXdr, "base64");
@@ -52,8 +53,9 @@ import { XdrLargeInt, type ScIntType } from "./xdr_large_int.js";
  *
  * // Or reinterpret it as a different type (size permitting):
  * const scv = i.toI64();
+ * ```
  *
- * @throws {TypeError} if the `value` is invalid (e.g. floating point), too
+ * @throws a `TypeError` if the `value` is invalid (e.g. floating point), too
  *    large (i.e. exceeds a 256-bit value), doesn't fit in the `opts.type`,
  *    the signedness of `opts.type` doesn't match the input `value`, or a
  *    string `value` can't be parsed as a big integer
@@ -67,9 +69,9 @@ export class ScInt extends XdrLargeInt {
    *    you can construct them directly without needing this wrapper, e.g.
    *    `xdr.ScVal.scvU32(1234)`.
    * @param opts - an optional object controlling optional parameters
-   * @param opts.type - specify a type ('i64', 'u64', 'i128', 'u128', 'i256',
-   *    or 'u256') to override the default type selection. If not specified, the
-   *    smallest type that fits the value is used.
+   *   - `type`: specify a type ('i64', 'u64', 'i128', 'u128', 'i256',
+   *     or 'u256') to override the default type selection. If not specified, the
+   *     smallest type that fits the value is used.
    */
   constructor(
     value: bigint | number | string,

--- a/src/base/numbers/xdr_large_int.ts
+++ b/src/base/numbers/xdr_large_int.ts
@@ -124,7 +124,7 @@ export class XdrLargeInt {
   /**
    * Converts to a native JS number.
    *
-   * @throws {RangeError} if the value can't fit into a Number
+   * @throws a `RangeError` if the value can't fit into a Number
    */
   toNumber(): number {
     const bi = this.value;
@@ -145,7 +145,7 @@ export class XdrLargeInt {
   /**
    * The integer encoded with `ScValType = I64`.
    *
-   * @throws {RangeError} if the value cannot fit in 64 bits
+   * @throws a `RangeError` if the value cannot fit in 64 bits
    */
   toI64(): ScVal {
     this._sizeCheck(64);
@@ -177,7 +177,7 @@ export class XdrLargeInt {
   /**
    * The integer encoded with `ScValType = I128`.
    *
-   * @throws {RangeError} if the value cannot fit in 128 bits
+   * @throws a `RangeError` if the value cannot fit in 128 bits
    */
   toI128(): ScVal {
     this._sizeCheck(128);
@@ -196,7 +196,7 @@ export class XdrLargeInt {
   /**
    * The integer encoded with `ScValType = U128`.
    *
-   * @throws {RangeError} if the value cannot fit in 128 bits
+   * @throws a `RangeError` if the value cannot fit in 128 bits
    */
   toU128(): ScVal {
     this._sizeCheck(128);
@@ -212,7 +212,7 @@ export class XdrLargeInt {
   /**
    * The integer encoded with `ScValType = I256`
    *
-   * @throws {RangeError} if the value cannot fit in a signed 256-bit integer
+   * @throws a `RangeError` if the value cannot fit in a signed 256-bit integer
    */
   toI256(): ScVal {
     const v = this.value;

--- a/src/base/operations/account_merge.ts
+++ b/src/base/operations/account_merge.ts
@@ -7,8 +7,8 @@ import { setSourceAccount } from "../util/operations.js";
  * Transfers native balance to destination account.
  *
  * @param opts - options object
- * @param opts.destination - destination to merge the source account into
- * @param opts.source - operation source account (defaults to
+ *   - `destination`: destination to merge the source account into
+ *   - `source`: operation source account (defaults to
  *     transaction source)
  */
 export function accountMerge(opts: AccountMergeOpts): Operation {

--- a/src/base/operations/allow_trust.ts
+++ b/src/base/operations/allow_trust.ts
@@ -20,10 +20,10 @@ import { setSourceAccount } from "../util/operations.js";
  * account's credit for a given asset.
  *
  * @param opts - Options object
- * @param opts.trustor - The trusting account (the one being authorized)
- * @param opts.assetCode - The asset code being authorized.
- * @param opts.authorize - `1` to authorize, `2` to authorize to maintain liabilities, and `0` to deauthorize.
- * @param opts.source - The source account (defaults to transaction source).
+ *   - `trustor`: The trusting account (the one being authorized)
+ *   - `assetCode`: The asset code being authorized.
+ *   - `authorize`: `1` to authorize, `2` to authorize to maintain liabilities, and `0` to deauthorize.
+ *   - `source`: The source account (defaults to transaction source).
  */
 export function allowTrust(opts: AllowTrustOpts): Operation {
   if (!StrKey.isValidEd25519PublicKey(opts.trustor)) {

--- a/src/base/operations/begin_sponsoring_future_reserves.ts
+++ b/src/base/operations/begin_sponsoring_future_reserves.ts
@@ -14,13 +14,15 @@ import { setSourceAccount } from "../util/operations.js";
 /**
  * Create a "begin sponsoring future reserves" operation.
  * @param opts - Options object
- * @param opts.sponsoredId - The sponsored account id.
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `sponsoredId`: The sponsored account id.
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  *
  * @example
+ * ```ts
  * const op = Operation.beginSponsoringFutureReserves({
  *   sponsoredId: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
  * });
+ * ```
  *
  */
 export function beginSponsoringFutureReserves(

--- a/src/base/operations/bump_sequence.ts
+++ b/src/base/operations/bump_sequence.ts
@@ -11,8 +11,8 @@ import { BumpSequenceOpts, OperationAttributes } from "./types.js";
 /**
  * This operation bumps sequence number.
  * @param opts - Options object
- * @param opts.bumpTo - Sequence number to bump to.
- * @param opts.source - The optional source account.
+ *   - `bumpTo`: Sequence number to bump to.
+ *   - `source`: The optional source account.
  */
 export function bumpSequence(opts: BumpSequenceOpts): Operation {
   if (typeof opts.bumpTo !== "string") {

--- a/src/base/operations/change_trust.ts
+++ b/src/base/operations/change_trust.ts
@@ -22,10 +22,10 @@ const MAX_INT64 = "9223372036854775807";
  * given asset from the source account to another.
  *
  * @param opts - Options object
- * @param opts.asset - The asset for the trust line.
- * @param opts.limit - The limit for the asset, defaults to max int64.
- *                     If the limit is set to "0" it deletes the trustline.
- * @param opts.source - The source account (defaults to transaction source).
+ *   - `asset`: The asset for the trust line.
+ *   - `limit`: The limit for the asset, defaults to max int64.
+ *     If the limit is set to "0" it deletes the trustline.
+ *   - `source`: The source account (defaults to transaction source).
  */
 export function changeTrust(opts: ChangeTrustOpts): Operation {
   // Accept `line` as an alias for `asset` so that the output of

--- a/src/base/operations/claim_claimable_balance.ts
+++ b/src/base/operations/claim_claimable_balance.ts
@@ -10,13 +10,15 @@ import { ClaimClaimableBalanceOpts, OperationAttributes } from "./types.js";
 /**
  * Create a new claim claimable balance operation.
  * @param opts - Options object
- * @param opts.balanceId - The claimable balance id to be claimed.
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `balanceId`: The claimable balance id to be claimed.
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  *
  * @example
+ * ```ts
  * const op = Operation.claimClaimableBalance({
  *   balanceId: '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
  * });
+ * ```
  */
 export function claimClaimableBalance(
   opts: ClaimClaimableBalanceOpts = {} as ClaimClaimableBalanceOpts,

--- a/src/base/operations/clawback.ts
+++ b/src/base/operations/clawback.ts
@@ -18,11 +18,11 @@ import {
  *
  *
  * @param opts - Options object
- * @param opts.asset - The asset being clawed back.
- * @param opts.amount - The amount of the asset to claw back.
- * @param opts.from - The public key of the (optionally-muxed)
+ *   - `asset`: The asset being clawed back.
+ *   - `amount`: The amount of the asset to claw back.
+ *   - `from`: The public key of the (optionally-muxed)
  *     account to claw back from.
- * @param opts.source - The source account for the operation.
+ *   - `source`: The source account for the operation.
  *     Defaults to the transaction's source account.
  *
  * @see https://github.com/stellar/stellar-protocol/blob/master/core/cap-0035.md#clawback-operation

--- a/src/base/operations/clawback_claimable_balance.ts
+++ b/src/base/operations/clawback_claimable_balance.ts
@@ -12,13 +12,15 @@ import { ClawbackClaimableBalanceOpts, OperationAttributes } from "./types.js";
  * Creates a clawback operation for a claimable balance.
  *
  * @param opts - Options object
- * @param opts.balanceId - The claimable balance ID to be clawed back.
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `balanceId`: The claimable balance ID to be clawed back.
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  *
  * @example
+ * ```ts
  * const op = Operation.clawbackClaimableBalance({
  *   balanceId: '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
  * });
+ * ```
  *
  * @see https://github.com/stellar/stellar-protocol/blob/master/core/cap-0035.md#clawback-claimable-balance-operation
  */

--- a/src/base/operations/create_account.ts
+++ b/src/base/operations/create_account.ts
@@ -13,10 +13,10 @@ import {
  * Create and fund a non-existent account.
  *
  * @param opts - Options object
- * @param opts.destination - Destination account ID to create an account for.
- * @param opts.startingBalance - Amount in XLM the account should be funded for. Must be greater
+ *   - `destination`: Destination account ID to create an account for.
+ *   - `startingBalance`: Amount in XLM the account should be funded for. Must be greater
  *     than the {@link https://developers.stellar.org/docs/glossary/fees/ | reserve balance amount}.
- * @param opts.source - The source account for the payment. Defaults to the transaction's source account.
+ *   - `source`: The source account for the payment. Defaults to the transaction's source account.
  */
 export function createAccount(opts: CreateAccountOpts): Operation {
   if (!StrKey.isValidEd25519PublicKey(opts.destination)) {

--- a/src/base/operations/create_claimable_balance.ts
+++ b/src/base/operations/create_claimable_balance.ts
@@ -20,12 +20,13 @@ import {
  *
  *
  * @param opts - Options object
- * @param opts.asset - The asset for the claimable balance.
- * @param opts.amount - Amount.
- * @param opts.claimants - An array of Claimants
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `asset`: The asset for the claimable balance.
+ *   - `amount`: Amount.
+ *   - `claimants`: An array of Claimants
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  *
  * @example
+ * ```ts
  * const asset = new Asset(
  *   'USD',
  *   'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
@@ -43,6 +44,7 @@ import {
  *   amount,
  *   claimants
  * });
+ * ```
  */
 export function createClaimableBalance(
   opts: CreateClaimableBalanceOpts,

--- a/src/base/operations/create_passive_sell_offer.ts
+++ b/src/base/operations/create_passive_sell_offer.ts
@@ -21,14 +21,14 @@ import { CreatePassiveSellOfferOpts, OperationAttributes } from "./types.js";
  * just used as 1:1 exchanges for path payments. Use manage offer to manage
  * this offer after using this operation to create it.
  * @param opts - Options object
- * @param opts.selling - What you're selling.
- * @param opts.buying - What you're buying.
- * @param opts.amount - The total amount you're selling. If 0, deletes the offer.
- * @param opts.price - Price of 1 unit of `selling` in terms of `buying`.
- * @param opts.price.n - If `opts.price` is an object: the price numerator
- * @param opts.price.d - If `opts.price` is an object: the price denominator
- * @param opts.source - The source account (defaults to transaction source).
- * @throws {Error} when the best rational approximation of `price` cannot be found.
+ *   - `selling`: What you're selling.
+ *   - `buying`: What you're buying.
+ *   - `amount`: The total amount you're selling. If 0, deletes the offer.
+ *   - `price`: Price of 1 unit of `selling` in terms of `buying`.
+ *     - `n`: If `opts.price` is an object: the price numerator
+ *     - `d`: If `opts.price` is an object: the price denominator
+ *   - `source`: The source account (defaults to transaction source).
+ * @throws when the best rational approximation of `price` cannot be found.
  */
 export function createPassiveSellOffer(
   opts: CreatePassiveSellOfferOpts,

--- a/src/base/operations/end_sponsoring_future_reserves.ts
+++ b/src/base/operations/end_sponsoring_future_reserves.ts
@@ -8,10 +8,12 @@ import {
 /**
  * Create an "end sponsoring future reserves" operation.
  * @param opts - Options object
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  *
  * @example
+ * ```ts
  * const op = Operation.endSponsoringFutureReserves();
+ * ```
  *
  */
 export function endSponsoringFutureReserves(

--- a/src/base/operations/extend_footprint_ttl.ts
+++ b/src/base/operations/extend_footprint_ttl.ts
@@ -28,9 +28,9 @@ import { ExtendFootprintTtlOpts, OperationAttributes } from "./types.js";
  *
  *
  * @param opts - object holding operation parameters
- * @param opts.extendTo - the minimum TTL that all the entries in
- *    the read-only footprint will have
- * @param opts.source - an optional source account
+ *   - `extendTo`: the minimum TTL that all the entries in
+ *     the read-only footprint will have
+ *   - `source`: an optional source account
  */
 export function extendFootprintTtl(opts: ExtendFootprintTtlOpts): Operation {
   if ((opts.extendTo ?? -1) <= 0) {

--- a/src/base/operations/inflation.ts
+++ b/src/base/operations/inflation.ts
@@ -5,7 +5,7 @@ import { InflationOpts, OperationAttributes } from "./types.js";
 /**
  * This operation generates the inflation.
  * @param opts - Options object
- * @param opts.source - The optional source account.
+ *   - `source`: The optional source account.
  */
 export function inflation(opts: InflationOpts = {}): Operation {
   const opAttributes: OperationAttributes = {

--- a/src/base/operations/invoke_host_function.ts
+++ b/src/base/operations/invoke_host_function.ts
@@ -31,9 +31,9 @@ import { setSourceAccount } from "../util/operations.js";
  *
  *
  * @param opts - options object
- * @param opts.func - host function to execute (with its wrapped parameters)
- * @param opts.auth - list outlining the tree of authorizations required for the call
- * @param opts.source - an optional source account
+ *   - `func`: host function to execute (with its wrapped parameters)
+ *   - `auth`: list outlining the tree of authorizations required for the call
+ *   - `source`: an optional source account
  *
  * @see https://soroban.stellar.org/docs/fundamentals-and-concepts/invoking-contracts-with-transactions#function
  * @see Operation.invokeContractFunction
@@ -91,11 +91,11 @@ export function invokeHostFunction(opts: InvokeHostFunctionOpts): Operation {
  *
  *
  * @param opts - the set of parameters
- * @param opts.contract - a strkey-fied contract address (`C...`)
- * @param opts.function - the name of the contract fn to invoke
- * @param opts.args - parameters to pass to the function invocation
- * @param opts.auth - an optional list outlining the tree of authorizations required for the call
- * @param opts.source - an optional source account
+ *   - `contract`: a strkey-fied contract address (`C...`)
+ *   - `function`: the name of the contract fn to invoke
+ *   - `args`: parameters to pass to the function invocation
+ *   - `auth`: an optional list outlining the tree of authorizations required for the call
+ *   - `source`: an optional source account
  *
  * @see Operation.invokeHostFunction
  * @see Contract.call
@@ -131,12 +131,12 @@ export function invokeContractFunction(
  *
  *
  * @param opts - the set of parameters
- * @param opts.address - the contract uploader address
- * @param opts.wasmHash - the SHA-256 hash of the contract WASM you're uploading
- * @param opts.constructorArgs - the optional parameters to pass to the constructor
- * @param opts.salt - an optional, 32-byte salt to distinguish deployment instances
- * @param opts.auth - an optional list outlining the tree of authorizations required for the call
- * @param opts.source - an optional source account
+ *   - `address`: the contract uploader address
+ *   - `wasmHash`: the SHA-256 hash of the contract WASM you're uploading
+ *   - `constructorArgs`: the optional parameters to pass to the constructor
+ *   - `salt`: an optional, 32-byte salt to distinguish deployment instances
+ *   - `auth`: an optional list outlining the tree of authorizations required for the call
+ *   - `source`: an optional source account
  *
  * @see https://soroban.stellar.org/docs/fundamentals-and-concepts/invoking-contracts-with-transactions#function
  */
@@ -182,9 +182,9 @@ export function createCustomContract(
  *
  *
  * @param opts - the set of parameters
- * @param opts.asset - the Stellar asset to wrap, either as an {@link Asset} object or in canonical form (SEP-11, `code:issuer`)
- * @param opts.auth - an optional list outlining the tree of authorizations required for the upload
- * @param opts.source - an optional source account
+ *   - `asset`: the Stellar asset to wrap, either as an {@link Asset} object or in canonical form (SEP-11, `code:issuer`)
+ *   - `auth`: an optional list outlining the tree of authorizations required for the upload
+ *   - `source`: an optional source account
  *
  * @see https://stellar.org/protocol/sep-11#alphanum4-alphanum12
  * @see https://soroban.stellar.org/docs/fundamentals-and-concepts/invoking-contracts-with-transactions
@@ -232,9 +232,9 @@ export function createStellarAssetContract(
  *
  *
  * @param opts - the set of parameters
- * @param opts.wasm - a WASM blob to upload to the ledger
- * @param opts.auth - an optional list outlining the tree of authorizations required for the upload
- * @param opts.source - an optional source account
+ *   - `wasm`: a WASM blob to upload to the ledger
+ *   - `auth`: an optional list outlining the tree of authorizations required for the upload
+ *   - `source`: an optional source account
  *
  * @see https://soroban.stellar.org/docs/fundamentals-and-concepts/invoking-contracts-with-transactions#function
  */

--- a/src/base/operations/liquidity_pool_deposit.ts
+++ b/src/base/operations/liquidity_pool_deposit.ts
@@ -23,16 +23,16 @@ import { LiquidityPoolDepositOpts, OperationAttributes } from "./types.js";
  * @see https://developers.stellar.org/docs/start/list-of-operations/#liquidity-pool-deposit
  *
  * @param opts - Options object
- * @param opts.liquidityPoolId - The liquidity pool ID.
- * @param opts.maxAmountA - Maximum amount of first asset to deposit.
- * @param opts.maxAmountB - Maximum amount of second asset to deposit.
- * @param opts.minPrice - Minimum depositA/depositB price.
- * @param opts.minPrice.n - If `opts.minPrice` is an object: the price numerator
- * @param opts.minPrice.d - If `opts.minPrice` is an object: the price denominator
- * @param opts.maxPrice - Maximum depositA/depositB price.
- * @param opts.maxPrice.n - If `opts.maxPrice` is an object: the price numerator
- * @param opts.maxPrice.d - If `opts.maxPrice` is an object: the price denominator
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `liquidityPoolId`: The liquidity pool ID.
+ *   - `maxAmountA`: Maximum amount of first asset to deposit.
+ *   - `maxAmountB`: Maximum amount of second asset to deposit.
+ *   - `minPrice`: Minimum depositA/depositB price.
+ *     - `n`: If `opts.minPrice` is an object: the price numerator
+ *     - `d`: If `opts.minPrice` is an object: the price denominator
+ *   - `maxPrice`: Maximum depositA/depositB price.
+ *     - `n`: If `opts.maxPrice` is an object: the price numerator
+ *     - `d`: If `opts.maxPrice` is an object: the price denominator
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  */
 export function liquidityPoolDeposit(
   opts: LiquidityPoolDepositOpts = {} as LiquidityPoolDepositOpts,

--- a/src/base/operations/liquidity_pool_withdraw.ts
+++ b/src/base/operations/liquidity_pool_withdraw.ts
@@ -19,11 +19,11 @@ import { LiquidityPoolWithdrawOpts, OperationAttributes } from "./types.js";
  * @see https://developers.stellar.org/docs/start/list-of-operations/#liquidity-pool-withdraw
  *
  * @param opts - Options object
- * @param opts.liquidityPoolId - The liquidity pool ID.
- * @param opts.amount - Amount of pool shares to withdraw.
- * @param opts.minAmountA - Minimum amount of first asset to withdraw.
- * @param opts.minAmountB - Minimum amount of second asset to withdraw.
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `liquidityPoolId`: The liquidity pool ID.
+ *   - `amount`: Amount of pool shares to withdraw.
+ *   - `minAmountA`: Minimum amount of first asset to withdraw.
+ *   - `minAmountB`: Minimum amount of second asset to withdraw.
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  */
 export function liquidityPoolWithdraw(
   opts: LiquidityPoolWithdrawOpts = {} as LiquidityPoolWithdrawOpts,

--- a/src/base/operations/manage_buy_offer.ts
+++ b/src/base/operations/manage_buy_offer.ts
@@ -19,15 +19,15 @@ import { ManageBuyOfferOpts, OperationAttributes } from "./types.js";
  * Returns a XDR ManageBuyOfferOp. A "manage buy offer" operation creates, updates, or
  * deletes a buy offer.
  * @param opts - Options object
- * @param opts.selling - What you're selling.
- * @param opts.buying - What you're buying.
- * @param opts.buyAmount - The total amount you're buying. If 0, deletes the offer.
- * @param opts.price - Price of 1 unit of `buying` in terms of `selling`.
- * @param opts.price.n - If `opts.price` is an object: the price numerator
- * @param opts.price.d - If `opts.price` is an object: the price denominator
- * @param opts.offerId - If `0`, will create a new offer (default). Otherwise, edits an existing offer.
- * @param opts.source - The source account (defaults to transaction source).
- * @throws {Error} when the best rational approximation of `price` cannot be found.
+ *   - `selling`: What you're selling.
+ *   - `buying`: What you're buying.
+ *   - `buyAmount`: The total amount you're buying. If 0, deletes the offer.
+ *   - `price`: Price of 1 unit of `buying` in terms of `selling`.
+ *     - `n`: If `opts.price` is an object: the price numerator
+ *     - `d`: If `opts.price` is an object: the price denominator
+ *   - `offerId`: If `0`, will create a new offer (default). Otherwise, edits an existing offer.
+ *   - `source`: The source account (defaults to transaction source).
+ * @throws when the best rational approximation of `price` cannot be found.
  */
 export function manageBuyOffer(opts: ManageBuyOfferOpts): Operation {
   const selling: Asset = opts.selling.toXdrObject();

--- a/src/base/operations/manage_data.ts
+++ b/src/base/operations/manage_data.ts
@@ -12,9 +12,9 @@ import { ManageDataOpts, OperationAttributes } from "./types.js";
 /**
  * This operation adds data entry to the ledger.
  * @param opts - Options object
- * @param opts.name - The name of the data entry.
- * @param opts.value - The value of the data entry.
- * @param opts.source - The optional source account.
+ *   - `name`: The name of the data entry.
+ *   - `value`: The value of the data entry.
+ *   - `source`: The optional source account.
  */
 export function manageData(opts: ManageDataOpts): Operation {
   if (!(typeof opts.name === "string" && opts.name.length <= 64)) {

--- a/src/base/operations/manage_sell_offer.ts
+++ b/src/base/operations/manage_sell_offer.ts
@@ -19,15 +19,15 @@ import { ManageSellOfferOpts, OperationAttributes } from "./types.js";
  * Returns a XDR ManageSellOfferOp. A "manage sell offer" operation creates, updates, or
  * deletes an offer.
  * @param opts - Options object
- * @param opts.selling - What you're selling.
- * @param opts.buying - What you're buying.
- * @param opts.amount - The total amount you're selling. If 0, deletes the offer.
- * @param opts.price - Price of 1 unit of `selling` in terms of `buying`.
- * @param opts.price.n - If `opts.price` is an object: the price numerator
- * @param opts.price.d - If `opts.price` is an object: the price denominator
- * @param opts.offerId - If `0`, will create a new offer (default). Otherwise, edits an existing offer.
- * @param opts.source - The source account (defaults to transaction source).
- * @throws {Error} when the best rational approximation of `price` cannot be found.
+ *   - `selling`: What you're selling.
+ *   - `buying`: What you're buying.
+ *   - `amount`: The total amount you're selling. If 0, deletes the offer.
+ *   - `price`: Price of 1 unit of `selling` in terms of `buying`.
+ *     - `n`: If `opts.price` is an object: the price numerator
+ *     - `d`: If `opts.price` is an object: the price denominator
+ *   - `offerId`: If `0`, will create a new offer (default). Otherwise, edits an existing offer.
+ *   - `source`: The source account (defaults to transaction source).
+ * @throws when the best rational approximation of `price` cannot be found.
  */
 export function manageSellOffer(opts: ManageSellOfferOpts): Operation {
   const selling: Asset = opts.selling.toXdrObject();

--- a/src/base/operations/path_payment_strict_receive.ts
+++ b/src/base/operations/path_payment_strict_receive.ts
@@ -25,13 +25,13 @@ import {
  * @see https://developers.stellar.org/docs/start/list-of-operations/#path-payment-strict-receive
  *
  * @param opts - Options object
- * @param opts.sendAsset - asset to pay with
- * @param opts.sendMax - maximum amount of sendAsset to send
- * @param opts.destination - destination account to send to
- * @param opts.destAsset - asset the destination will receive
- * @param opts.destAmount - amount the destination receives
- * @param opts.path - array of Asset objects to use as the path
- * @param opts.source - The source account for the payment.
+ *   - `sendAsset`: asset to pay with
+ *   - `sendMax`: maximum amount of sendAsset to send
+ *   - `destination`: destination account to send to
+ *   - `destAsset`: asset the destination will receive
+ *   - `destAmount`: amount the destination receives
+ *   - `path`: array of Asset objects to use as the path
+ *   - `source`: The source account for the payment.
  *     Defaults to the transaction's source account.
  */
 export function pathPaymentStrictReceive(

--- a/src/base/operations/path_payment_strict_send.ts
+++ b/src/base/operations/path_payment_strict_send.ts
@@ -26,13 +26,13 @@ import {
  * @see https://developers.stellar.org/docs/start/list-of-operations/#path-payment-strict-send
  *
  * @param opts - Options object
- * @param opts.sendAsset - asset to pay with
- * @param opts.sendAmount - amount of sendAsset to send (excluding fees)
- * @param opts.destination - destination account to send to
- * @param opts.destAsset - asset the destination will receive
- * @param opts.destMin - minimum amount of destAsset to be received
- * @param opts.path - array of Asset objects to use as the path
- * @param opts.source - The source account for the payment. Defaults to the transaction's source account.
+ *   - `sendAsset`: asset to pay with
+ *   - `sendAmount`: amount of sendAsset to send (excluding fees)
+ *   - `destination`: destination account to send to
+ *   - `destAsset`: asset the destination will receive
+ *   - `destMin`: minimum amount of destAsset to be received
+ *   - `path`: array of Asset objects to use as the path
+ *   - `source`: The source account for the payment. Defaults to the transaction's source account.
  */
 export function pathPaymentStrictSend(
   opts: PathPaymentStrictSendOpts,

--- a/src/base/operations/payment.ts
+++ b/src/base/operations/payment.ts
@@ -19,10 +19,10 @@ import {
  * @see https://developers.stellar.org/docs/start/list-of-operations/#payment
  *
  * @param opts - options object
- * @param opts.destination - destination account ID
- * @param opts.asset - asset to send
- * @param opts.amount - amount to send
- * @param opts.source - The source account for the payment.
+ *   - `destination`: destination account ID
+ *   - `asset`: asset to send
+ *   - `amount`: amount to send
+ *   - `source`: The source account for the payment.
  *     Defaults to the transaction's source account.
  */
 export function payment(opts: PaymentOpts): Operation {

--- a/src/base/operations/restore_footprint.ts
+++ b/src/base/operations/restore_footprint.ts
@@ -22,7 +22,7 @@ import { OperationAttributes, RestoreFootprintOpts } from "./types.js";
  *
  *
  * @param opts - an optional set of parameters
- * @param opts.source - an optional source account
+ *   - `source`: an optional source account
  */
 export function restoreFootprint(opts: RestoreFootprintOpts = {}): Operation {
   const op = new RestoreFootprintOp({

--- a/src/base/operations/revoke_sponsorship.ts
+++ b/src/base/operations/revoke_sponsorship.ts
@@ -38,13 +38,15 @@ import { setSourceAccount } from "../util/operations.js";
  * Create a "revoke sponsorship" operation for an account.
  *
  * @param opts - Options object
- * @param opts.account - The sponsored account ID.
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `account`: The sponsored account ID.
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  *
  * @example
+ * ```ts
  * const op = Operation.revokeAccountSponsorship({
  *   account: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
  * });
+ * ```
  */
 export function revokeAccountSponsorship(
   opts: RevokeAccountSponsorshipOpts = {} as RevokeAccountSponsorshipOpts,
@@ -73,11 +75,12 @@ export function revokeAccountSponsorship(
  * Create a "revoke sponsorship" operation for a trustline.
  *
  * @param opts - Options object
- * @param opts.account - The account ID which owns the trustline.
- * @param opts.asset - The trustline asset.
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `account`: The account ID which owns the trustline.
+ *   - `asset`: The trustline asset.
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  *
  * @example
+ * ```ts
  * const op = Operation.revokeTrustlineSponsorship({
  *   account: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7',
  *   asset: new StellarBase.LiquidityPoolId(
@@ -85,6 +88,7 @@ export function revokeAccountSponsorship(
  *     'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7'
  *   )
  * });
+ * ```
  */
 export function revokeTrustlineSponsorship(
   opts: RevokeTrustlineSponsorshipOpts = {} as RevokeTrustlineSponsorshipOpts,
@@ -124,15 +128,17 @@ export function revokeTrustlineSponsorship(
  * Create a "revoke sponsorship" operation for an offer.
  *
  * @param opts - Options object
- * @param opts.seller - The account ID which created the offer.
- * @param opts.offerId - The offer ID.
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `seller`: The account ID which created the offer.
+ *   - `offerId`: The offer ID.
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  *
  * @example
+ * ```ts
  * const op = Operation.revokeOfferSponsorship({
  *   seller: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7',
  *   offerId: '1234'
  * });
+ * ```
  */
 export function revokeOfferSponsorship(
   opts: RevokeOfferSponsorshipOpts = {} as RevokeOfferSponsorshipOpts,
@@ -166,15 +172,17 @@ export function revokeOfferSponsorship(
  * Create a "revoke sponsorship" operation for a data entry.
  *
  * @param opts - Options object
- * @param opts.account - The account ID which owns the data entry.
- * @param opts.name - The name of the data entry.
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `account`: The account ID which owns the data entry.
+ *   - `name`: The name of the data entry.
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  *
  * @example
+ * ```ts
  * const op = Operation.revokeDataSponsorship({
  *   account: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7',
  *   name: 'foo'
  * });
+ * ```
  */
 export function revokeDataSponsorship(
   opts: RevokeDataSponsorshipOpts = {} as RevokeDataSponsorshipOpts,
@@ -208,13 +216,15 @@ export function revokeDataSponsorship(
  * Create a "revoke sponsorship" operation for a claimable balance.
  *
  * @param opts - Options object
- * @param opts.balanceId - The sponsored claimable balance ID.
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `balanceId`: The sponsored claimable balance ID.
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  *
  * @example
+ * ```ts
  * const op = Operation.revokeClaimableBalanceSponsorship({
  *   balanceId: '00000000da0d57da7d4850e7fc10d2a9d0ebc731f7afb40574c03395b17d49149b91f5be',
  * });
+ * ```
  */
 export function revokeClaimableBalanceSponsorship(
   opts: RevokeClaimableBalanceSponsorshipOpts = {} as RevokeClaimableBalanceSponsorshipOpts,
@@ -243,13 +253,15 @@ export function revokeClaimableBalanceSponsorship(
  * Creates a "revoke sponsorship" operation for a liquidity pool.
  *
  * @param opts - Options object.
- * @param opts.liquidityPoolId - The sponsored liquidity pool ID in 'hex' string.
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `liquidityPoolId`: The sponsored liquidity pool ID in 'hex' string.
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  *
  * @example
+ * ```ts
  * const op = Operation.revokeLiquidityPoolSponsorship({
  *   liquidityPoolId: 'dd7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7',
  * });
+ * ```
  */
 export function revokeLiquidityPoolSponsorship(
   opts: RevokeLiquidityPoolSponsorshipOpts = {} as RevokeLiquidityPoolSponsorshipOpts,
@@ -278,21 +290,23 @@ export function revokeLiquidityPoolSponsorship(
  * Create a "revoke sponsorship" operation for a signer.
  *
  * @param opts - Options object
- * @param opts.account - The account ID where the signer sponsorship is being removed from.
- * @param opts.signer - The signer whose sponsorship is being removed. Exactly one of the following must be set:
- * @param opts.signer.ed25519PublicKey - (optional) The ed25519 public key of the signer.
- * @param opts.signer.sha256Hash - (optional) sha256 hash (Uint8Array or hex string).
- * @param opts.signer.preAuthTx - (optional) Hash (Uint8Array or hex string) of transaction.
- * @param opts.signer.ed25519SignedPayload - (optional) Signed payload signer (StrKey P... address).
- * @param opts.source - The source account for the operation. Defaults to the transaction's source account.
+ *   - `account`: The account ID where the signer sponsorship is being removed from.
+ *   - `signer`: The signer whose sponsorship is being removed. Exactly one of the following must be set:
+ *     - `ed25519PublicKey`: (optional) The ed25519 public key of the signer.
+ *     - `sha256Hash`: (optional) sha256 hash (Uint8Array or hex string).
+ *     - `preAuthTx`: (optional) Hash (Uint8Array or hex string) of transaction.
+ *     - `ed25519SignedPayload`: (optional) Signed payload signer (StrKey P... address).
+ *   - `source`: The source account for the operation. Defaults to the transaction's source account.
  *
  * @example
+ * ```ts
  * const op = Operation.revokeSignerSponsorship({
  *   account: 'GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7',
  *   signer: {
  *     ed25519PublicKey: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ'
  *   }
  * })
+ * ```
  */
 export function revokeSignerSponsorship(
   opts: RevokeSignerSponsorshipOpts = {} as RevokeSignerSponsorshipOpts,

--- a/src/base/operations/set_options.ts
+++ b/src/base/operations/set_options.ts
@@ -33,22 +33,22 @@ function weightCheckFunction(value: number, name: string): boolean {
  *
  *
  * @param opts - Options object
- * @param opts.inflationDest - Set this account ID as the account's inflation destination.
- * @param opts.clearFlags - Bitmap integer for which account flags to clear.
- * @param opts.setFlags - Bitmap integer for which account flags to set.
- * @param opts.masterWeight - The master key weight.
- * @param opts.lowThreshold - The sum weight for the low threshold.
- * @param opts.medThreshold - The sum weight for the medium threshold.
- * @param opts.highThreshold - The sum weight for the high threshold.
- * @param opts.signer - Add or remove a signer from the account. The signer is
- *                                 deleted if the weight is 0. Only one of `ed25519PublicKey`, `sha256Hash`, `preAuthTx` should be defined.
- * @param opts.signer.ed25519PublicKey - The ed25519 public key of the signer.
- * @param opts.signer.sha256Hash - sha256 hash (Uint8Array or hex string) of preimage that will unlock funds. Preimage should be used as signature of future transaction.
- * @param opts.signer.preAuthTx - Hash (Uint8Array or hex string) of transaction that will unlock funds.
- * @param opts.signer.ed25519SignedPayload - Signed payload signer (ed25519 public key + raw payload) for atomic transaction signature disclosure.
- * @param opts.signer.weight - The weight of the new signer (0 to delete or 1-255)
- * @param opts.homeDomain - sets the home domain used for reverse federation lookup.
- * @param opts.source - The source account (defaults to transaction source).
+ *   - `inflationDest`: Set this account ID as the account's inflation destination.
+ *   - `clearFlags`: Bitmap integer for which account flags to clear.
+ *   - `setFlags`: Bitmap integer for which account flags to set.
+ *   - `masterWeight`: The master key weight.
+ *   - `lowThreshold`: The sum weight for the low threshold.
+ *   - `medThreshold`: The sum weight for the medium threshold.
+ *   - `highThreshold`: The sum weight for the high threshold.
+ *   - `signer`: Add or remove a signer from the account. The signer is
+ *     deleted if the weight is 0. Only one of `ed25519PublicKey`, `sha256Hash`, `preAuthTx` should be defined.
+ *     - `ed25519PublicKey`: The ed25519 public key of the signer.
+ *     - `sha256Hash`: sha256 hash (Uint8Array or hex string) of preimage that will unlock funds. Preimage should be used as signature of future transaction.
+ *     - `preAuthTx`: Hash (Uint8Array or hex string) of transaction that will unlock funds.
+ *     - `ed25519SignedPayload`: Signed payload signer (ed25519 public key + raw payload) for atomic transaction signature disclosure.
+ *     - `weight`: The weight of the new signer (0 to delete or 1-255)
+ *   - `homeDomain`: sets the home domain used for reverse federation lookup.
+ *   - `source`: The source account (defaults to transaction source).
  * @see [Account flags](https://developers.stellar.org/docs/glossary/accounts/#flags)
  */
 export function setOptions<T extends SignerOpts = never>(

--- a/src/base/operations/set_trustline_flags.ts
+++ b/src/base/operations/set_trustline_flags.ts
@@ -32,7 +32,7 @@ import { setSourceAccount } from "../util/operations.js";
  *     - `authorizedToMaintainLiabilities`: authorize
  *       account to maintain and reduce liabilities for its credit
  *     - `clawbackEnabled`: stop claimable balances on
- *       this trustlines from having clawbacks enabled (this flag can only be set
+ *       this trustline from having clawbacks enabled (this flag can only be set
  *       to false!)
  *   - `source`: The source account for the operation.
  *     Defaults to the transaction's source account.

--- a/src/base/operations/set_trustline_flags.ts
+++ b/src/base/operations/set_trustline_flags.ts
@@ -24,18 +24,18 @@ import { setSourceAccount } from "../util/operations.js";
  *
  *
  * @param opts - Options object
- * @param opts.trustor - the account whose trustline this is
- * @param opts.asset - the asset on the trustline
- * @param opts.flags - the set of flags to modify
- * @param opts.flags.authorized - authorize account to perform
- *     transactions with its credit
- * @param opts.flags.authorizedToMaintainLiabilities - authorize
- *     account to maintain and reduce liabilities for its credit
- * @param opts.flags.clawbackEnabled - stop claimable balances on
- *     this trustlines from having clawbacks enabled (this flag can only be set
- *     to false!)
- * @param opts.source - The source account for the operation.
- *                                 Defaults to the transaction's source account.
+ *   - `trustor`: the account whose trustline this is
+ *   - `asset`: the asset on the trustline
+ *   - `flags`: the set of flags to modify
+ *     - `authorized`: authorize account to perform
+ *       transactions with its credit
+ *     - `authorizedToMaintainLiabilities`: authorize
+ *       account to maintain and reduce liabilities for its credit
+ *     - `clawbackEnabled`: stop claimable balances on
+ *       this trustlines from having clawbacks enabled (this flag can only be set
+ *       to false!)
+ *   - `source`: The source account for the operation.
+ *     Defaults to the transaction's source account.
  *
  * @see https://github.com/stellar/stellar-protocol/blob/master/core/cap-0035.md#set-trustline-flags-operation
  * @see https://developers.stellar.org/docs/start/list-of-operations/#set-options

--- a/src/base/scval.ts
+++ b/src/base/scval.ts
@@ -35,22 +35,22 @@ export interface NativeToScValOpts {
  *
  * The conversions are as follows:
  *
- *  - xdr.ScVal -> passthrough
- *  - null/undefined -> scvVoid
- *  - string -> scvString (a copy is made)
- *  - UintArray8 -> scvBytes (a copy is made)
- *  - boolean -> scvBool
+ *  - xdr.ScVal → passthrough
+ *  - null/undefined → scvVoid
+ *  - string → scvString (a copy is made)
+ *  - UintArray8 → scvBytes (a copy is made)
+ *  - boolean → scvBool
  *
- *  - number/bigint -> the smallest possible XDR integer type that will fit the
+ *  - number/bigint → the smallest possible XDR integer type that will fit the
  *    input value (if you want a specific type, use {@link ScInt})
  *
- *  - {@link Address} or {@link Contract} -> scvAddress (for contracts and
+ *  - {@link Address} or {@link Contract} → scvAddress (for contracts and
  *    public keys)
  *
- *  - Array<T> -> scvVec after attempting to convert each item of type `T` to an
+ *  - `Array<T>` → scvVec after attempting to convert each item of type `T` to an
  *    xdr.ScVal (recursively). note that all values must be the same type!
  *
- *  - object -> scvMap after attempting to convert each key and value to an
+ *  - object → scvMap after attempting to convert each key and value to an
  *    xdr.ScVal (recursively). note that there is no restriction on types
  *    matching anywhere (unlike arrays)
  *
@@ -63,8 +63,8 @@ export interface NativeToScValOpts {
  * @param val -       a native (or convertible) input value to wrap
  * @param opts - an optional set of hints around the type of
  *    conversion you'd like to see
- * @param opts.type - there is different behavior for different input
- *    types for `val`:
+ *   - `type`: there is different behavior for different input
+ *     types for `val`:
  *
  *     - when `val` is an integer-like type (i.e. number|bigint), this will be
  *       forwarded to {@link ScInt} or forced to be u32/i32.
@@ -90,7 +90,7 @@ export interface NativeToScValOpts {
  *    return an `scvSymbol`, whereas without the type it would have been an
  *    `scvString`.
  *
- * @throws {TypeError} if...
+ * @throws a `TypeError` if...
  *  - there are arrays with more than one type in them
  *  - there are values that do not have a sensible conversion (e.g. random XDR
  *    types, custom classes)
@@ -102,6 +102,7 @@ export interface NativeToScValOpts {
  * @see scValToNative
  *
  * @example
+ * ```ts
  * nativeToScVal(1000);                   // gives ScValType === scvU64
  * nativeToScVal(1000n);                  // gives ScValType === scvU64
  * nativeToScVal(1n << 100n);             // gives ScValType === scvU128
@@ -127,14 +128,16 @@ export interface NativeToScValOpts {
  * //     [ scvSymbol, scvI128 ],
  * //     [ scvString, scvArray<scvBool> ]
  * // ]
+ * ```
  *
  * @example
+ * ```ts
  * import {
  *   nativeToScVal,
  *   scValToNative,
  *   ScInt,
  *   xdr
- * } from '@stellar/stellar-base';
+ * } from '@stellar/stellar-sdk';
  *
  * let gigaMap = {
  *   bool: true,
@@ -164,6 +167,7 @@ export interface NativeToScValOpts {
  *
  * // Similarly, the inverse should work:
  * scValToNative(scv) == gigaMap;       // true
+ * ```
  */
 export function nativeToScVal(
   val: unknown,
@@ -405,15 +409,15 @@ export function nativeToScVal(
  * Given a smart contract value, attempt to convert it to a native type.
  * Possible conversions include:
  *
- *  - void -> `null`
- *  - u32, i32 -> `number`
- *  - u64, i64, u128, i128, u256, i256, timepoint, duration -> `bigint`
- *  - vec -> `Array` of any of the above (via recursion)
- *  - map -> key-value object of any of the above (via recursion)
- *  - bool -> `boolean`
- *  - bytes -> `Uint8Array`
- *  - symbol -> `string`
- *  - string -> `string` IF the underlying buffer can be decoded as ascii/utf8,
+ *  - void → `null`
+ *  - u32, i32 → `number`
+ *  - u64, i64, u128, i128, u256, i256, timepoint, duration → `bigint`
+ *  - vec → `Array` of any of the above (via recursion)
+ *  - map → key-value object of any of the above (via recursion)
+ *  - bool → `boolean`
+ *  - bytes → `Uint8Array`
+ *  - symbol → `string`
+ *  - string → `string` IF the underlying buffer can be decoded as ascii/utf8,
  *              `Uint8Array` of the raw contents in any error case
  *
  * If no viable conversion can be determined, this just "unwraps" the smart

--- a/src/base/scval.ts
+++ b/src/base/scval.ts
@@ -38,7 +38,7 @@ export interface NativeToScValOpts {
  *  - xdr.ScVal → passthrough
  *  - null/undefined → scvVoid
  *  - string → scvString (a copy is made)
- *  - UintArray8 → scvBytes (a copy is made)
+ *  - Uint8Array → scvBytes (a copy is made)
  *  - boolean → scvBool
  *
  *  - number/bigint → the smallest possible XDR integer type that will fit the

--- a/src/base/soroban.ts
+++ b/src/base/soroban.ts
@@ -10,11 +10,13 @@ export class Soroban {
    * @param amount - the token amount you want to display
    * @param decimals - specify how many decimal places a token has
    *
-   * @throws {TypeError} if the given amount has a decimal point already
+   * @throws a `TypeError` if the given amount has a decimal point already
    * @example
+   * ```ts
    * formatTokenAmount("123000", 4) === "12.3";
    * formatTokenAmount("123000", 3) === "123.0";
    * formatTokenAmount("123", 3) === "0.123";
+   * ```
    */
   static formatTokenAmount(amount: string, decimals: number): string {
     if (amount.includes(".")) {
@@ -66,9 +68,11 @@ export class Soroban {
    *    might not be present)
    *
    * @example
+   * ```ts
    * const displayValueAmount = "123.4560"
    * const parsedAmtForSmartContract = parseTokenAmount(displayValueAmount, 5);
    * parsedAmtForSmartContract === "12345600"
+   * ```
    */
   static parseTokenAmount(value: string, decimals: number): string {
     const [whole, fraction, ...rest] = value.split(".").slice();

--- a/src/base/sorobandata_builder.ts
+++ b/src/base/sorobandata_builder.ts
@@ -19,6 +19,7 @@ export type IntLike = bigint | number | string;
  * (re)building the entire data structure from scratch.
  *
  * @example
+ * ```ts
  * // You want to use an existing data blob but override specific parts.
  * const newData = new SorobanDataBuilder(existing)
  *   .setReadOnly(someLedgerKeys)
@@ -30,6 +31,7 @@ export type IntLike = bigint | number | string;
  *   .setFootprint([someLedgerKey], [])
  *   .setResourceFee("1000")
  *   .build();
+ * ```
  */
 export class SorobanDataBuilder {
   private _data: SorobanTransactionData;

--- a/src/base/transaction.ts
+++ b/src/base/transaction.ts
@@ -336,7 +336,7 @@ export class Transaction extends TransactionBase<
    *
    * @param opIndex - the index of the CreateClaimableBalance op
    *
-   * @throws {Error} for invalid `opIndex` value, if op at `opIndex` is not
+   * @throws for invalid `opIndex` value, if op at `opIndex` is not
    *    `CreateClaimableBalance`, or for general XDR un/marshalling failures
    *
    * @see https://github.com/stellar/go/blob/d712346e61e288d450b0c08038c158f8848cc3e4/txnbuild/transaction.go#L392-L435

--- a/src/base/transaction_base.ts
+++ b/src/base/transaction_base.ts
@@ -57,7 +57,7 @@ export class TransactionBase<
    * Returns a defensive copy so that external mutations cannot alter the
    * transaction that will be signed or serialized.
    *
-   * @throws {Error} if the internal transaction is not a recognized XDR type
+   * @throws if the internal transaction is not a recognized XDR type
    */
   get tx(): TTx {
     const buf = this._tx.toXdr();

--- a/src/base/transaction_builder.ts
+++ b/src/base/transaction_builder.ts
@@ -143,8 +143,8 @@ export interface TransactionBuilderOptions {
  * <p>Operations can be added to the transaction via their corresponding builder
  * methods, and each returns the TransactionBuilder object so they can be
  * chained together. After adding the desired operations, call the `build()`
- * method on the `TransactionBuilder` to return a fully constructed `{@link
- * Transaction}` that can be signed. The returned transaction will contain the
+ * method on the `TransactionBuilder` to return a fully constructed
+ * {@link Transaction} that can be signed. The returned transaction will contain the
  * sequence number of the source account and include the signature from the
  * source account.</p>
  *
@@ -299,7 +299,7 @@ export class TransactionBuilder {
    *
    * @param tx - a "template" transaction to clone exactly
    * @param opts - additional options to override the clone, e.g.
-   *    {fee: '1000'} will override the existing base fee derived from `tx` (see
+   *    `{fee: '1000'}` will override the existing base fee derived from `tx` (see
    *    the {@link TransactionBuilder} constructor for detailed options)
    *
    * @remarks
@@ -460,8 +460,8 @@ export class TransactionBuilder {
    *
    *  A call to `TransactionBuilder.setTimeout` is **required** if Transaction
    *  does not have `max_time` set. If you don't want to set timeout, use
-   *  `{@link TimeoutInfinite}`. In general you should set `{@link
-   *  TimeoutInfinite}` only in smart contracts.
+   *  {@link TimeoutInfinite}. In general you should set
+   *  {@link TimeoutInfinite} only in smart contracts.
    *
    *  Please note that Horizon may still return <code>504 Gateway Timeout</code>
    *  error, even for short timeouts. In such case you need to resubmit the same
@@ -598,7 +598,9 @@ export class TransactionBuilder {
    * If you want to prepare a transaction which will be valid only while the
    * account sequence number is
    *
-   *     minAccountSequence <= sourceAccountSequence < tx.seqNum
+   * ```
+   * minAccountSequence <= sourceAccountSequence < tx.seqNum
+   * ```
    *
    * Note that after execution the account's sequence number is always raised to
    * `tx.seqNum`. Internally this will set the `minAccountSequence`
@@ -606,8 +608,8 @@ export class TransactionBuilder {
    *
    * @param minAccountSequence - The minimum source account sequence
    *     number this transaction is valid for. If the value is `0` (the
-   *     default), the transaction is valid when `sourceAccount's sequence
-   *     number == tx.seqNum- 1`.
+   *     default), the transaction is valid when
+   *     `sourceAccount's sequence number == tx.seqNum - 1`.
    */
   setMinAccountSequence(minAccountSequence: string): TransactionBuilder {
     if (this.minAccountSequence !== null) {
@@ -730,7 +732,7 @@ export class TransactionBuilder {
    * @param sorobanData - the {@link xdr.SorobanTransactionData} as a raw xdr
    *    object or a base64 string to be decoded
    *
-   * @see {SorobanDataBuilder}
+   * @see {@link SorobanDataBuilder}
    */
   setSorobanData(
     sorobanData: SorobanTransactionData | string,
@@ -1138,7 +1140,7 @@ export class TransactionBuilder {
    *       changed to be less awkward: accept a MuxedAccount as the `feeSource`
    *       rather than a keypair or string.
    *
-   * Your fee-bump amount should be >= 10x the original fee.
+   * Your fee-bump amount should be `>= 10x` the original fee.
    * @see  https://developers.stellar.org/docs/glossary/fee-bumps/#replace-by-fee
    */
   static buildFeeBumpTransaction(

--- a/src/base/util/continued_fraction.ts
+++ b/src/base/util/continued_fraction.ts
@@ -8,7 +8,7 @@ const MAX_INT_BN = new CustomBigNumber(MAX_INT);
  * number as `[n, d]` where `n` is the numerator and `d` is the denominator.
  *
  * @param rawNumber - real number to approximate
- * @throws {Error} when the best rational approximation cannot be found
+ * @throws when the best rational approximation cannot be found
  */
 export function best_r(
   rawNumber: BigNumber | number | string,

--- a/src/contract/assembled_transaction.ts
+++ b/src/contract/assembled_transaction.ts
@@ -63,8 +63,6 @@ import {
 import { getAddressCredentials } from "../base/auth.js";
 import { base64ToUint8Array } from "uint8array-extras";
 
-/** @module contract */
-
 /**
  * The main workhorse of {@link Client}. This class is used to wrap a
  * transaction-under-construction and provide high-level interfaces to the most
@@ -1054,7 +1052,7 @@ export class AssembledTransaction<T> {
     signAuthEntry?: ClientOptions["signAuthEntry"];
 
     /**
-     * If you have a pro use-case and need to override the default `authorizeEntry` function, rather than using the one in `@stellar/stellar-base`, you can do that! Your function needs to take at least the first argument, `entry: xdr.SorobanAuthorizationEntry`, and return a `Promise<xdr.SorobanAuthorizationEntry>`.
+     * If you have a pro use-case and need to override the default `authorizeEntry` function, rather than using the one this SDK provides, you can do that! Your function needs to take at least the first argument, `entry: xdr.SorobanAuthorizationEntry`, and return a `Promise<xdr.SorobanAuthorizationEntry>`.
      *
      * Note that you if you pass this, then `signAuthEntry` will be ignored.
      */

--- a/src/contract/spec.ts
+++ b/src/contract/spec.ts
@@ -497,7 +497,7 @@ function unionToJsonSchema(udt: ScSpecUdtUnionV0): any {
  * Constructs a new ContractSpec from an array of XDR spec entries.
  *
  * @param entries - the XDR spec entries
- * @throws {Error} if entries is invalid
+ * @throws if entries is invalid
  *
  * @example
  * ```ts

--- a/src/federation/server.ts
+++ b/src/federation/server.ts
@@ -9,8 +9,6 @@ import type { Api } from "./api.js";
 import { httpClient } from "../http-client/index.js";
 import { validateDomain } from "./utils.js";
 
-/** @module Federation */
-
 /**
  * The maximum size of response from a federation server
  * @defaultValue 102400

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -1,5 +1,3 @@
-/** @module rpc */
-
 // Expose all types
 export * from "./api.js";
 

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -207,7 +207,6 @@ export class RpcServer {
   constructor(serverURL: string, opts: RpcServer.Options = {}) {
     /**
      * RPC Server URL (ex. `http://localhost:8000/soroban/rpc`).
-     * @member {URL}
      */
     this.serverURL = new URL(serverURL);
     this.httpClient = createHttpClient(opts.headers);

--- a/src/stellartoml/index.ts
+++ b/src/stellartoml/index.ts
@@ -4,8 +4,6 @@ import { httpClient } from "../http-client/index.js";
 
 import { Config } from "../config.js";
 
-/** @module StellarToml */
-
 /**
  * The maximum size of stellar.toml file, in bytes
  * @defaultValue 102400

--- a/src/xdr/util.ts
+++ b/src/xdr/util.ts
@@ -1,8 +1,8 @@
 /**
  * Assert that an XDR union value has the expected `type` discriminant, and if so narrow the type of the value to that variant.
- * @param value the XDR union value to check
- * @param type the expected type discriminant
- * @throws {TypeError} if `value.type !== type`
+ * @param value - the XDR union value to check
+ * @param type - the expected type discriminant
+ * @throws a `TypeError` if `value.type !== type`
  * @returns the same value, but with its type narrowed to the expected variant
  */
 export function expectUnionVariant<
@@ -22,8 +22,8 @@ export function expectUnionVariant<
 
 /**
  * Check if an XDR union value has a given `type` discriminant, and if so narrow
- * @param value the XDR union value to check
- * @param type the expected type discriminant
+ * @param value - the XDR union value to check
+ * @param type - the expected type discriminant
  * @returns `true` if `value.type === type`, and narrows the type of `value` to that variant; otherwise `false`
  */
 export function isUnionVariant<


### PR DESCRIPTION
> [!NOTE]
> Mostly comment and link fixes. Everything under `src/` is comments only — verified by transpiling each changed file with `removeComments` and diffing against `main` (49/49 identical), so no library behavior can have changed. The single logic change is in `scripts/build-docs.ts`, which is build-time docs tooling and is not part of the published package.

- Fixed `{@link}` resolution in the docs generator, taking resolved cross-references from **51 to 291** — TypeDoc reports a numeric reflection id, but the resolver was keyed only by symbol-name strings, so every non-backticked `{@link}` silently degraded to plain inline code; a guard now fails the build if the call-builder pass runs after the resolver exists, since that pass has its own overlapping id space
- Switched generated cross-file links to root-absolute `/reference/<slug>/#<anchor>`, matching what the authored guides have used since v16 — these 70 links are a new category for the reference docs, since the relative `.md` form the generator previously emitted was never once produced in a shipped release and breaks on the built site
- Converted 164 dotted `@param obj.field` lines into indented sub-bullets under the parent `@param` — TypeDoc matches `@param` names against real signature parameters, so every one of these descriptions was being silently dropped from the published reference
- Wrapped 19 unfenced `@example` bodies in ` ```ts ` fences — TSDoc parsed their contents as prose, so object literals, generics and `@scope`d imports inside them tripped four separate syntax rules
- Stripped JSDoc type braces from `@throws` (dropping the uninformative `{Error}`, moving `{TypeError}`/`{RangeError}` into prose to match the 47 existing bare-condition sites), replaced bare `->` with `→`, backticked `<` / `>=` comparisons, and removed the redundant `@module`/`@member` tags
- Corrected the doc comments flagged in review — three that still pointed at the deprecated `@stellar/stellar-base`, the `UintArray8` typo in the `nativeToScVal` conversion table, and a singular/plural disagreement in `setTrustLineFlags`
- Regenerated `docs/reference/*.md`, which CI verifies is in sync with the source comments