### PR TITLE
Default simulation and authorizeInvocation to CAP-71 v2 address credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ A breaking change will get clearly marked in this log.
 * CAP-71 `SOROBAN_CREDENTIALS_ADDRESS_V2` credentials are now the default, on both ends of the auth flow. `rpc.Server.simulateTransaction`'s `useUpgradedAuth` and `authorizeInvocation`'s `authV2` both default to `true`, so simulation asks RPC to record v2 entries and `authorizeInvocation` builds them. Pass `false` to either one for the legacy `SOROBAN_CREDENTIALS_ADDRESS` format. Both flags are transitional and become no-ops when v2 is mandatory in protocol 28. Two consequences: code that reads the credential arm by hand must handle `addressV2` and not just `address` (or use `inspectAuthEntry`), and a hand-rolled signer that hardcodes the legacy `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION` preimage now produces signatures the network rejects, so use `buildAuthorizationEntryPreimage` or `authorizeEntry`, which pick the address-bound payload off the entry. SDK-driven signing (`contract.Client`, `authorizeEntry`, `signAuthEntries`) needs no change ([#1562](https://github.com/stellar/js-stellar-sdk/issues/1562)).
 * `simulateTransaction` now always sends `useUpgradedAuth` in the JSON-RPC request. It previously omitted the field when the flag was unset ([#1562](https://github.com/stellar/js-stellar-sdk/issues/1562)).
 
+### Added
+* `rpc.Server.prepareTransaction` takes an optional `useUpgradedAuth` parameter, since its internal simulation now requests v2 credentials by default. Pass `false` for the legacy v1 format ([#1562](https://github.com/stellar/js-stellar-sdk/issues/1562)).
+
 ### Fixed
 * `equals()` on XDR values is now callable from TypeScript on union types like `xdr.ScVal`, `xdr.TransactionEnvelope`, and `xdr.Memo` — which is what the SDK's accessors return ([#1630](https://github.com/stellar/js-stellar-sdk/issues/1630)). The parameter was typed as polymorphic `this`, which reduces to `never` on a union, so every call failed with TS2345 even though the runtime worked. The parameter is now `XdrValue`, so comparing two different XDR types compiles and returns `false`.
 
@@ -17,7 +20,6 @@ A breaking change will get clearly marked in this log.
   -if (kp.verifyMessage(untrustedInput, signature)) { grant(); }
   +if (typeof untrustedInput === "string" && kp.verifyMessage(untrustedInput, signature)) { grant(); }
   ```
-
 
 ## [v17.0.0-rc.1](https://github.com/stellar/js-stellar-sdk/compare/v16.2.0...v17.0.0-rc.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Breaking Changes
+* CAP-71 `SOROBAN_CREDENTIALS_ADDRESS_V2` credentials are now the default, on both ends of the auth flow. `rpc.Server.simulateTransaction`'s `useUpgradedAuth` and `authorizeInvocation`'s `authV2` both default to `true`, so simulation asks RPC to record v2 entries and `authorizeInvocation` builds them. Pass `false` to either one for the legacy `SOROBAN_CREDENTIALS_ADDRESS` format. Both flags are transitional and become no-ops when v2 is mandatory in protocol 28. Two consequences: code that reads the credential arm by hand must handle `addressV2` and not just `address` (or use `inspectAuthEntry`), and a hand-rolled signer that hardcodes the legacy `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION` preimage now produces signatures the network rejects, so use `buildAuthorizationEntryPreimage` or `authorizeEntry`, which pick the address-bound payload off the entry. SDK-driven signing (`contract.Client`, `authorizeEntry`, `signAuthEntries`) needs no change ([#1562](https://github.com/stellar/js-stellar-sdk/issues/1562)).
+* `simulateTransaction` now always sends `useUpgradedAuth` in the JSON-RPC request. It previously omitted the field when the flag was unset ([#1562](https://github.com/stellar/js-stellar-sdk/issues/1562)).
+
 ### Fixed
 * `equals()` on XDR values is now callable from TypeScript on union types like `xdr.ScVal`, `xdr.TransactionEnvelope`, and `xdr.Memo` — which is what the SDK's accessors return ([#1630](https://github.com/stellar/js-stellar-sdk/issues/1630)). The parameter was typed as polymorphic `this`, which reduces to `never` on a union, so every call failed with TS2345 even though the runtime worked. The parameter is now `XdrValue`, so comparing two different XDR types compiles and returns `false`.
 
@@ -13,6 +17,7 @@ A breaking change will get clearly marked in this log.
   -if (kp.verifyMessage(untrustedInput, signature)) { grant(); }
   +if (typeof untrustedInput === "string" && kp.verifyMessage(untrustedInput, signature)) { grant(); }
   ```
+
 
 ## [v17.0.0-rc.1](https://github.com/stellar/js-stellar-sdk/compare/v16.2.0...v17.0.0-rc.1)
 

--- a/docs/guides/00-migration.md
+++ b/docs/guides/00-migration.md
@@ -49,6 +49,59 @@ at all**:
 The method renames (`toXDR` → `toXdr`, `fromXDRObject` → `fromXdrObject`, and
 eleven more) ship without back-compat aliases, so those at least fail loudly.
 
+### Auth: CAP-71 v2 address credentials are now the default
+
+Protocol 27 ([CAP-71](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0071.md))
+added the address-bound `SOROBAN_CREDENTIALS_ADDRESS_V2` credential, which 16.x
+kept behind opt-in flags. Both flags now default to v2:
+
+- [`rpc.Server.simulateTransaction`](/reference/network-rpc/#serversimulatetransactiontx-addlresources-authmode-useupgradedauth)
+  asks RPC to record `ADDRESS_V2` entries. Its `useUpgradedAuth` flag defaults
+  to `true`, and is now always sent on the wire (it used to be omitted when
+  unset). The same default reaches everything built on it, including
+  `contract.AssembledTransaction.simulate()` and the `useUpgradedAuth` method
+  option.
+- [`authorizeInvocation`](/reference/core-soroban-primitives/#authorizeinvocation)
+  builds `ADDRESS_V2` credentials. Its `authV2` flag defaults to `true`.
+
+Pass `false` to either one for the legacy `ADDRESS` format:
+
+```ts
+await server.simulateTransaction(tx, undefined, undefined, false);
+await assembled.simulate({ useUpgradedAuth: false });
+await authorizeInvocation({ ...params, authV2: false });
+```
+
+Both flags are transitional and become no-ops once v2 is mandatory in protocol
+28, so don't rely on `false` to keep the v1 format long-term. `useUpgradedAuth`
+only affects the recording auth modes.
+
+Reading entries is where this surfaces. Code that picks the credential arm by
+hand must handle `addressV2`, not just `address`:
+
+```ts ins={4-6}
+const creds = entry.credentials;
+if (creds.type === "sorobanCredentialsAddress") {
+  const { nonce, signatureExpirationLedger } = creds.address;
+} else if (creds.type === "sorobanCredentialsAddressV2") {
+  // now the default arm, from simulation and from authorizeInvocation
+  const { nonce, signatureExpirationLedger } = creds.addressV2;
+}
+```
+
+Or let
+[`inspectAuthEntry`](/reference/core-soroban-primitives/#inspectauthentry)
+normalize the arms for you.
+
+Signing needs no change if you use the SDK for it. `contract.Client`,
+`authorizeEntry`, `signAuthEntries`, and `buildAuthorizationEntryPreimage` all
+sign whichever credential the entry carries, and pick the address-bound payload
+for `ADDRESS_V2`. A hand-rolled signer that hardcodes the legacy
+`ENVELOPE_TYPE_SOROBAN_AUTHORIZATION` preimage now produces signatures the
+network rejects. See
+[Protocol 27 Soroban auth](/guides/00-protocol-27-soroban-auth/) for the
+address-bound payload.
+
 ## 16.x.x Breaking changes
 
 The 16.x.x release is a major modernization. `@stellar/stellar-base` is folded
@@ -441,12 +494,13 @@ adds two address-bound Soroban credential types, `AddressV2` and
 `AddressWithDelegates`. This only affects code that signs Soroban authorization
 entries or inspects their credential arms.
 
-By default the SDK still uses the legacy `ADDRESS` credential: simulation
-returns `ADDRESS` entries and `authorizeInvocation` builds them. `ADDRESS_V2`
-is only valid on networks that have upgraded to protocol 27, so it is **opt-in** until
- protocol 28 makes it mandatory (at which point the default flips). Opt in with
-the `authV2` flag on `authorizeInvocation`'s params, once your target network
-supports it.
+In 16.x the SDK used the legacy `ADDRESS` credential everywhere by default:
+simulation returned `ADDRESS` entries and `authorizeInvocation` built them.
+`ADDRESS_V2` had not activated yet, so it was **opt-in**, via `useUpgradedAuth`
+on simulation and `authV2` on `authorizeInvocation`. Both now default to v2 in
+17.x, see
+[Auth: CAP-71 v2 address credentials are now the default](#auth-cap-71-v2-address-credentials-are-now-the-default).
+The rest of this section describes the 16.x defaults.
 
 SDK-driven signing ([`contract.Client`](/reference/contracts-client/#contractclient),
 [`basicNodeSigner`](/reference/contracts-client/#contractbasicnodesigner),
@@ -462,9 +516,10 @@ For the full walkthrough of signing Soroban authorization entries, see
 ### Auth: `authorizeInvocation` takes a params object
 
 [`authorizeInvocation`](/reference/core-soroban-primitives/#authorizeinvocation) now
-takes a single params object instead of positional arguments. It still builds a
-legacy `SOROBAN_CREDENTIALS_ADDRESS` entry by default, so keep reading the result
-with `.address()`.
+takes a single params object instead of positional arguments. In 16.x it still
+built a legacy `SOROBAN_CREDENTIALS_ADDRESS` entry by default, so keep reading
+the result with `.address()`. (In 17.x that default is `ADDRESS_V2`; see
+[above](#auth-cap-71-v2-address-credentials-are-now-the-default).)
 
 ```ts del={1-4} ins={5-7}
 const entry = await authorizeInvocation(
@@ -477,7 +532,7 @@ const addr = entry.credentials().address()
 ```
 
 To build a CAP-71 `ADDRESS_V2` entry instead, pass `authV2: true` and read the
-result with `.addressV2()`. Only do this on networks that have upgraded to protocol 27.
+result with `.addressV2()`.
 
 ```ts ins={6}
 const entry = await authorizeInvocation({

--- a/docs/guides/00-migration.md
+++ b/docs/guides/00-migration.md
@@ -68,6 +68,7 @@ Pass `false` to either one for the legacy `ADDRESS` format:
 
 ```ts
 await server.simulateTransaction(tx, undefined, undefined, false);
+await server.prepareTransaction(tx, false);
 await assembled.simulate({ useUpgradedAuth: false });
 await authorizeInvocation({ ...params, authV2: false });
 ```

--- a/docs/guides/00-protocol-27-soroban-auth.md
+++ b/docs/guides/00-protocol-27-soroban-auth.md
@@ -28,9 +28,9 @@ and two new credential types that use it: `SOROBAN_CREDENTIALS_ADDRESS_V2`
 `SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES` (an account plus a tree of delegate
 signers, all signing that same shared, address-bound payload). The old
 `SOROBAN_CREDENTIALS_ADDRESS` type and its non-address-bound payload still exist
-for backwards compatibility, and remain what `authorizeInvocation()` builds by
-default; opt new entries into `ADDRESS_V2` once CAP-71 is active on your target
-network.
+for backwards compatibility, but `ADDRESS_V2` is what simulation returns and
+what `authorizeInvocation()` builds by default. Opt back out with
+`authV2: false` (or `useUpgradedAuth: false`) if you need the legacy shape.
 
 ## The four credential types
 
@@ -38,7 +38,7 @@ network.
 |------|-------|-------------------|-------|
 | `SOROBAN_CREDENTIALS_SOURCE_ACCOUNT` | 0 | — (covered by tx envelope) | unchanged |
 | `SOROBAN_CREDENTIALS_ADDRESS` | 1 | `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION` (legacy, **not** address-bound) | still valid; pre-P27 behavior |
-| `SOROBAN_CREDENTIALS_ADDRESS_V2` | 2 | `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS` (**address-bound**) | opt-in via `authorizeInvocation({ authV2: true })` |
+| `SOROBAN_CREDENTIALS_ADDRESS_V2` | 2 | `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS` (**address-bound**) | the default from simulation and `authorizeInvocation()` |
 | `SOROBAN_CREDENTIALS_ADDRESS_WITH_DELEGATES` | 3 | `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION_WITH_ADDRESS` (bound to the **top-level** address) | account + delegate tree |
 
 `ADDRESS_V2` carries exactly the same fields as `ADDRESS`
@@ -223,43 +223,37 @@ unwrapped it the `.address()`, `.nonce()`, `.signatureExpirationLedger()`, and
 
 ## `authorizeInvocation()` and `ADDRESS_V2`
 
-By default, `authorizeInvocation()` still builds legacy
-`SOROBAN_CREDENTIALS_ADDRESS` entries — the same shape as before P27. `ADDRESS_V2`
-credentials are only valid on networks that have activated CAP-71, so V2 is
-**opt-in** via the `authV2` flag and stays off until you enable it. (The default
-flips to `true` once V2 becomes mandatory.)
+`authorizeInvocation()` builds `SOROBAN_CREDENTIALS_ADDRESS_V2` entries by
+default. Set `authV2: false` for the legacy `SOROBAN_CREDENTIALS_ADDRESS` shape.
 
-Pass `authV2: true` to build `SOROBAN_CREDENTIALS_ADDRESS_V2`. The signing is
-transparent either way — you still pass a `Keypair` or a `SigningCallback` — but
-the credential arm, and therefore the accessor you read it back with, follows
-the flag:
+The signing is transparent either way (you still pass a `Keypair` or a
+`SigningCallback`), but the credential arm, and therefore the accessor you read
+it back with, follows the flag:
 
 ```js
-// Default: legacy ADDRESS — read the result with `.address()`
-const legacy = await authorizeInvocation({
+// Default: ADDRESS_V2 — read the result with `.addressV2()`
+const v2 = await authorizeInvocation({
   signer,
   validUntilLedgerSeq,
   invocation,
   networkPassphrase,
   publicKey, // required when `signer` is a callback
 });
-const addr = legacy.credentials().address();
+const v2addr = v2.credentials().addressV2();
 
-// Opt in to ADDRESS_V2 — read the result with `.addressV2()`
-const v2 = await authorizeInvocation({
+// Opt out to legacy ADDRESS — read the result with `.address()`
+const legacy = await authorizeInvocation({
   signer,
   validUntilLedgerSeq,
   invocation,
   networkPassphrase,
   publicKey,
-  authV2: true, // ← build ADDRESS_V2 (CAP-71-active networks only)
+  authV2: false, // ← legacy credential shape
 });
-const v2addr = v2.credentials().addressV2();
+const addr = legacy.credentials().address();
 ```
 
-When you enable `authV2`, **the resulting entries are only valid on protocol
-27+.** If you assert on the credential type, or target a pre-P27 network, account
-for the new type.
+If you assert on the credential type anywhere, account for the new default.
 
 `authorizeEntry()` already handles all three credential types and selects the
 correct payload internally, so existing `authorizeEntry()` call sites keep
@@ -331,10 +325,13 @@ hand.
       `envelopeTypeSorobanAuthorizationWithAddress` and include `address`) for
       `ADDRESS_V2` entries.
 - [ ] Update reads of `credentials().address()` to handle the `addressV2()` and
-      `addressWithDelegates()` arms.
-- [ ] `authorizeInvocation()` still returns legacy `ADDRESS` (read with
-      `.address()`) by default. Only pass `authV2: true` — and read the result
-      with `.addressV2()` — when targeting a CAP-71-active (protocol 27+) network.
+      `addressWithDelegates()` arms. As of 17.x, `simulateTransaction` requests
+      `ADDRESS_V2` by default (`useUpgradedAuth` defaults to `true`), so the
+      entries simulation hands back are the v2 arm wherever the host can emit
+      them.
+- [ ] `authorizeInvocation()` returns `ADDRESS_V2` (read with `.addressV2()`)
+      by default. Pass `authV2: false`, and read the result with `.address()`,
+      only if you need the legacy shape.
 - [ ] For delegated auth, use `buildWithDelegatesEntry()` +
       `authorizeEntry(..., forAddress)` rather than building the wrapper XDR by
       hand.

--- a/docs/guides/07-contract-auth.md
+++ b/docs/guides/07-contract-auth.md
@@ -33,26 +33,25 @@ It is **not** for:
   [`basicNodeSigner`](/reference/contracts-client/#contractbasicnodesigner), or
   [`authorizeEntry`](/reference/core-soroban-primitives/#authorizeentry)).
   **Bump to the Protocol 27 SDK and change nothing.** Those paths build the
-  correct payload for whichever credential they are handed, so they sign `ADDRESS`
-  today and `AddressV2` after the flip with no code change.
+  correct payload for whichever credential they are handed, so they sign
+  `AddressV2` (now the default from simulation) and legacy `ADDRESS` alike with
+  no code change.
 - **Apps that build entries from scratch with
   [`authorizeInvocation`](/reference/core-soroban-primitives/#authorizeinvocation).**
-  This is the exception: it *constructs* the credential rather than being handed
-  one, so it does not auto-flip. It builds legacy `ADDRESS` by default and emits
-  `AddressV2` only when you pass `authV2: true` (valid on Protocol 27+ networks).
-  See the [Protocol 27 auth guide](/guides/00-protocol-27-soroban-auth/) for the
-  opt-in flag.
+  This one *constructs* the credential rather than being handed one, and it now
+  builds `AddressV2` by default. Pass `authV2: false` for the legacy `ADDRESS`
+  shape. See the [Protocol 27 auth guide](/guides/00-protocol-27-soroban-auth/).
 
 > **What Protocol 27 changes.** Protocol 27 introduces `AddressV2`, an
 > address-bound Soroban authorization credential
 > ([CAP-0071-02](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0071-02.md)).
-> Once Protocol 27 is live on a network (testnet first), Stellar Core accepts
-> `AddressV2`. But RPC simulation still hands you the legacy `ADDRESS` credential
-> by default; that default flips to `AddressV2` at Protocol 28 (see the
+> Stellar Core accepts `AddressV2` on a network running Protocol 27, and the SDK
+> now asks for it by default: simulation requests it via `useUpgradedAuth`, and
+> `authorizeInvocation` builds it (see the
 > [Protocol 27 upgrade guide](https://stellar.org/blog/foundation-news/stellar-zipper-protocol-27-upgrade-guide)).
 > The signing path here builds the correct payload from whichever credential an
-> entry carries, so the same code is right on today's `ADDRESS` and on `AddressV2`
-> after the flip, with no change from you.
+> entry carries, so the same code is right on `AddressV2` and on legacy
+> `ADDRESS`, with no change from you.
 
 ## Two signatures, not one
 

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -872,7 +872,7 @@ _before_ transaction signing.
 const DEFAULT_TIMEOUT: number
 ```
 
-**Source:** [src/contract/types.ts:311](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L311)
+**Source:** [src/contract/types.ts:310](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L310)
 
 ## contract.KeypairSigner
 
@@ -962,7 +962,7 @@ An impossible account on the Stellar network
 const NULL_ACCOUNT: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
 ```
 
-**Source:** [src/contract/types.ts:317](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L317)
+**Source:** [src/contract/types.ts:316](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L316)
 
 ## contract.SentTransaction
 
@@ -1640,7 +1640,7 @@ basicNodeSigner(keypair: Keypair, networkPassphrase: string): { signAuthEntry: S
 type AssembledTransactionOptions<T = string> = MethodOptions & ClientOptions & { address?: string; args?: any[]; method: string; parseResultXdr: (xdr: ScVal) => T; submit?: boolean; submitUrl?: string }
 ```
 
-**Source:** [src/contract/types.ts:279](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L279)
+**Source:** [src/contract/types.ts:278](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/types.ts#L278)
 
 ### contract.ClientOptions
 

--- a/docs/reference/core-soroban-primitives.md
+++ b/docs/reference/core-soroban-primitives.md
@@ -723,7 +723,7 @@ authorizeInvocation(params: AuthorizeInvocationParams): Promise<SorobanAuthoriza
 
 - **`params`** — `AuthorizeInvocationParams` (required)
 
-**Source:** [src/base/auth.ts:411](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L411)
+**Source:** [src/base/auth.ts:409](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L409)
 
 ## buildAuthorizationEntryPreimage
 
@@ -758,7 +758,7 @@ buildAuthorizationEntryPreimage(entry: SorobanAuthorizationEntry, validUntilLedg
 - `Error` if `entry` carries source-account or otherwise non-address
    credentials
 
-**Source:** [src/base/auth.ts:477](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L477)
+**Source:** [src/base/auth.ts:475](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L475)
 
 ## buildInvocationTree
 
@@ -847,7 +847,7 @@ buildWithDelegatesEntry(params: BuildWithDelegatesParams): SorobanAuthorizationE
 - `Error` if `entry` is not an `ADDRESS`/`ADDRESS_V2` entry, or if any
    delegates array contains a duplicate address.
 
-**Source:** [src/base/auth.ts:584](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L584)
+**Source:** [src/base/auth.ts:582](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L582)
 
 ## checkAuthEntryReadiness
 
@@ -889,7 +889,7 @@ a [`AuthEntryReadiness`](#authentryreadiness): `ready`, `expired`, and which
    sequence (non-integer, negative, or above 2^32 - 1), which would make the
    expiration comparison unreliable
 
-**Source:** [src/base/auth.ts:1039](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L1039)
+**Source:** [src/base/auth.ts:1037](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L1037)
 
 ## humanizeEvents
 
@@ -952,7 +952,7 @@ if (!info.signed && info.address !== null) {
 
 - checkAuthEntryReadiness
 
-**Source:** [src/base/auth.ts:919](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L919)
+**Source:** [src/base/auth.ts:917](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L917)
 
 ## nativeToScVal
 
@@ -1189,7 +1189,7 @@ The credential arm of a `xdr.SorobanAuthorizationEntry`.
 type AuthEntryCredentialType = "sourceAccount" | "address" | "addressV2" | "addressWithDelegates"
 ```
 
-**Source:** [src/base/auth.ts:799](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L799)
+**Source:** [src/base/auth.ts:797](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L797)
 
 ### AuthEntryInfo
 
@@ -1208,7 +1208,7 @@ interface AuthEntryInfo {
 }
 ```
 
-**Source:** [src/base/auth.ts:849](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L849)
+**Source:** [src/base/auth.ts:847](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L847)
 
 #### `authEntryInfo.address`
 
@@ -1218,7 +1218,7 @@ the authorizing address, or `null` for source-account credentials.
 address: string | null;
 ```
 
-**Source:** [src/base/auth.ts:852](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L852)
+**Source:** [src/base/auth.ts:850](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L850)
 
 #### `authEntryInfo.credentialType`
 
@@ -1226,7 +1226,7 @@ address: string | null;
 credentialType: AuthEntryCredentialType;
 ```
 
-**Source:** [src/base/auth.ts:850](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L850)
+**Source:** [src/base/auth.ts:848](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L848)
 
 #### `authEntryInfo.invocation`
 
@@ -1236,7 +1236,7 @@ the invocation tree this entry authorizes.
 invocation: SorobanAuthorizedInvocation;
 ```
 
-**Source:** [src/base/auth.ts:878](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L878)
+**Source:** [src/base/auth.ts:876](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L876)
 
 #### `authEntryInfo.nonce`
 
@@ -1246,7 +1246,7 @@ the credential nonce, or `null` for source-account credentials.
 nonce: bigint | null;
 ```
 
-**Source:** [src/base/auth.ts:854](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L854)
+**Source:** [src/base/auth.ts:852](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L852)
 
 #### `authEntryInfo.signatureExpirationLedger`
 
@@ -1258,7 +1258,7 @@ carry a placeholder (often `0`) until [`authorizeEntry`](#authorizeentry) sets i
 signatureExpirationLedger: number | null;
 ```
 
-**Source:** [src/base/auth.ts:860](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L860)
+**Source:** [src/base/auth.ts:858](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L858)
 
 #### `authEntryInfo.signed`
 
@@ -1274,7 +1274,7 @@ support that.
 signed: boolean;
 ```
 
-**Source:** [src/base/auth.ts:876](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L876)
+**Source:** [src/base/auth.ts:874](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L874)
 
 #### `authEntryInfo.signers`
 
@@ -1286,7 +1286,7 @@ source-account credentials.
 signers: AuthEntrySigner[];
 ```
 
-**Source:** [src/base/auth.ts:866](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L866)
+**Source:** [src/base/auth.ts:864](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L864)
 
 ### AuthEntryReadiness
 
@@ -1300,7 +1300,7 @@ interface AuthEntryReadiness {
 }
 ```
 
-**Source:** [src/base/auth.ts:882](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L882)
+**Source:** [src/base/auth.ts:880](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L880)
 
 #### `authEntryReadiness.expired`
 
@@ -1311,7 +1311,7 @@ exclusive). Always `false` for source-account credentials.
 expired: boolean;
 ```
 
-**Source:** [src/base/auth.ts:889](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L889)
+**Source:** [src/base/auth.ts:887](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L887)
 
 #### `authEntryReadiness.ready`
 
@@ -1321,7 +1321,7 @@ expired: boolean;
 ready: boolean;
 ```
 
-**Source:** [src/base/auth.ts:884](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L884)
+**Source:** [src/base/auth.ts:882](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L882)
 
 #### `authEntryReadiness.unsignedBy`
 
@@ -1331,7 +1331,7 @@ addresses of signer nodes that carry no signature payload.
 unsignedBy: string[];
 ```
 
-**Source:** [src/base/auth.ts:891](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L891)
+**Source:** [src/base/auth.ts:889](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L889)
 
 ### AuthEntrySignature
 
@@ -1345,7 +1345,7 @@ interface AuthEntrySignature {
 }
 ```
 
-**Source:** [src/base/auth.ts:809](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L809)
+**Source:** [src/base/auth.ts:807](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L807)
 
 #### `authEntrySignature.publicKey`
 
@@ -1355,7 +1355,7 @@ the signer's public key, as a `G…` strkey.
 publicKey: string;
 ```
 
-**Source:** [src/base/auth.ts:811](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L811)
+**Source:** [src/base/auth.ts:809](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L809)
 
 #### `authEntrySignature.signature`
 
@@ -1365,7 +1365,7 @@ the raw 64-byte ed25519 signature.
 signature: Uint8Array;
 ```
 
-**Source:** [src/base/auth.ts:813](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L813)
+**Source:** [src/base/auth.ts:811](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L811)
 
 ### AuthEntrySigner
 
@@ -1382,7 +1382,7 @@ interface AuthEntrySigner {
 }
 ```
 
-**Source:** [src/base/auth.ts:821](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L821)
+**Source:** [src/base/auth.ts:819](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L819)
 
 #### `authEntrySigner.address`
 
@@ -1392,7 +1392,7 @@ the node's address (`G…` account or `C…` contract).
 address: string;
 ```
 
-**Source:** [src/base/auth.ts:823](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L823)
+**Source:** [src/base/auth.ts:821](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L821)
 
 #### `authEntrySigner.rawSignature`
 
@@ -1402,7 +1402,7 @@ the raw signature value, whatever its shape.
 rawSignature: ScVal;
 ```
 
-**Source:** [src/base/auth.ts:842](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L842)
+**Source:** [src/base/auth.ts:840](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L840)
 
 #### `authEntrySigner.signatures`
 
@@ -1418,7 +1418,7 @@ node is unsigned.
 signatures: AuthEntrySignature[] | null;
 ```
 
-**Source:** [src/base/auth.ts:840](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L840)
+**Source:** [src/base/auth.ts:838](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L838)
 
 #### `authEntrySigner.signed`
 
@@ -1431,7 +1431,7 @@ contract's `__check_auth` cannot be verified client-side.
 signed: boolean;
 ```
 
-**Source:** [src/base/auth.ts:830](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L830)
+**Source:** [src/base/auth.ts:828](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L828)
 
 ### AuthorizeInvocationParams
 
@@ -1467,15 +1467,13 @@ interface AuthorizeInvocationParams {
 
 Build `SOROBAN_CREDENTIALS_ADDRESS_V2` (CAP-71) credentials instead of the
 legacy `SOROBAN_CREDENTIALS_ADDRESS`. V2 credentials bind the address into
-the signed payload but are only valid on networks that have activated
-CAP-71, so leave this off until the activation vote passes for your target
-network. The default flips to `true` once V2 becomes mandatory.
+the signed payload.
 
 ```ts
 authV2?: boolean;
 ```
 
-**Source:** [src/base/auth.ts:408](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L408)
+**Source:** [src/base/auth.ts:406](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L406)
 
 #### `authorizeInvocationParams.invocation`
 
@@ -1530,7 +1528,7 @@ interface BuildWithDelegatesParams {
 }
 ```
 
-**Source:** [src/base/auth.ts:542](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L542)
+**Source:** [src/base/auth.ts:540](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L540)
 
 #### `buildWithDelegatesParams.delegates`
 
@@ -1540,7 +1538,7 @@ the delegate signers to attach.
 delegates: DelegateSignature[];
 ```
 
-**Source:** [src/base/auth.ts:552](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L552)
+**Source:** [src/base/auth.ts:550](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L550)
 
 #### `buildWithDelegatesParams.entry`
 
@@ -1552,7 +1550,7 @@ simulation — whose address credentials should be wrapped.
 entry: SorobanAuthorizationEntry;
 ```
 
-**Source:** [src/base/auth.ts:548](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L548)
+**Source:** [src/base/auth.ts:546](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L546)
 
 #### `buildWithDelegatesParams.signature`
 
@@ -1563,7 +1561,7 @@ for accounts that authorize purely via delegated signers (CAP-71-01).
 signature?: ScVal;
 ```
 
-**Source:** [src/base/auth.ts:557](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L557)
+**Source:** [src/base/auth.ts:555](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L555)
 
 #### `buildWithDelegatesParams.validUntilLedgerSeq`
 
@@ -1573,7 +1571,7 @@ the expiration ledger sequence stored on the top-level credentials.
 validUntilLedgerSeq: number;
 ```
 
-**Source:** [src/base/auth.ts:550](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L550)
+**Source:** [src/base/auth.ts:548](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L548)
 
 ### CreateInvocation
 
@@ -1645,7 +1643,7 @@ interface DelegateSignature {
 }
 ```
 
-**Source:** [src/base/auth.ts:528](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L528)
+**Source:** [src/base/auth.ts:526](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L526)
 
 #### `delegateSignature.address`
 
@@ -1655,7 +1653,7 @@ the delegate's address (`G…` account or `C…` contract).
 address: string;
 ```
 
-**Source:** [src/base/auth.ts:530](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L530)
+**Source:** [src/base/auth.ts:528](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L528)
 
 #### `delegateSignature.nestedDelegates`
 
@@ -1665,7 +1663,7 @@ signers this delegate in turn delegates to (recursive).
 nestedDelegates?: DelegateSignature[];
 ```
 
-**Source:** [src/base/auth.ts:538](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L538)
+**Source:** [src/base/auth.ts:536](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L536)
 
 #### `delegateSignature.signature`
 
@@ -1677,7 +1675,7 @@ as `forAddress`) or by editing the entry directly.
 signature?: ScVal;
 ```
 
-**Source:** [src/base/auth.ts:536](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L536)
+**Source:** [src/base/auth.ts:534](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L534)
 
 ### ExecuteInvocation
 

--- a/docs/reference/core-soroban-primitives.md
+++ b/docs/reference/core-soroban-primitives.md
@@ -711,7 +711,7 @@ function multiPartyAuth(
 
 - authorizeInvocation
 
-**Source:** [src/base/auth.ts:196](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L196)
+**Source:** [src/base/auth.ts:198](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L198)
 
 ## authorizeInvocation
 
@@ -723,7 +723,7 @@ authorizeInvocation(params: AuthorizeInvocationParams): Promise<SorobanAuthoriza
 
 - **`params`** — `AuthorizeInvocationParams` (required)
 
-**Source:** [src/base/auth.ts:409](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L409)
+**Source:** [src/base/auth.ts:411](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L411)
 
 ## buildAuthorizationEntryPreimage
 
@@ -758,7 +758,7 @@ buildAuthorizationEntryPreimage(entry: SorobanAuthorizationEntry, validUntilLedg
 - `Error` if `entry` carries source-account or otherwise non-address
    credentials
 
-**Source:** [src/base/auth.ts:475](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L475)
+**Source:** [src/base/auth.ts:477](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L477)
 
 ## buildInvocationTree
 
@@ -847,7 +847,7 @@ buildWithDelegatesEntry(params: BuildWithDelegatesParams): SorobanAuthorizationE
 - `Error` if `entry` is not an `ADDRESS`/`ADDRESS_V2` entry, or if any
    delegates array contains a duplicate address.
 
-**Source:** [src/base/auth.ts:582](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L582)
+**Source:** [src/base/auth.ts:584](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L584)
 
 ## checkAuthEntryReadiness
 
@@ -889,7 +889,7 @@ a [`AuthEntryReadiness`](#authentryreadiness): `ready`, `expired`, and which
    sequence (non-integer, negative, or above 2^32 - 1), which would make the
    expiration comparison unreliable
 
-**Source:** [src/base/auth.ts:1037](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L1037)
+**Source:** [src/base/auth.ts:1039](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L1039)
 
 ## humanizeEvents
 
@@ -952,7 +952,7 @@ if (!info.signed && info.address !== null) {
 
 - checkAuthEntryReadiness
 
-**Source:** [src/base/auth.ts:917](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L917)
+**Source:** [src/base/auth.ts:919](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L919)
 
 ## nativeToScVal
 
@@ -1189,7 +1189,7 @@ The credential arm of a `xdr.SorobanAuthorizationEntry`.
 type AuthEntryCredentialType = "sourceAccount" | "address" | "addressV2" | "addressWithDelegates"
 ```
 
-**Source:** [src/base/auth.ts:797](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L797)
+**Source:** [src/base/auth.ts:799](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L799)
 
 ### AuthEntryInfo
 
@@ -1208,7 +1208,7 @@ interface AuthEntryInfo {
 }
 ```
 
-**Source:** [src/base/auth.ts:847](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L847)
+**Source:** [src/base/auth.ts:849](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L849)
 
 #### `authEntryInfo.address`
 
@@ -1218,7 +1218,7 @@ the authorizing address, or `null` for source-account credentials.
 address: string | null;
 ```
 
-**Source:** [src/base/auth.ts:850](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L850)
+**Source:** [src/base/auth.ts:852](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L852)
 
 #### `authEntryInfo.credentialType`
 
@@ -1226,7 +1226,7 @@ address: string | null;
 credentialType: AuthEntryCredentialType;
 ```
 
-**Source:** [src/base/auth.ts:848](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L848)
+**Source:** [src/base/auth.ts:850](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L850)
 
 #### `authEntryInfo.invocation`
 
@@ -1236,7 +1236,7 @@ the invocation tree this entry authorizes.
 invocation: SorobanAuthorizedInvocation;
 ```
 
-**Source:** [src/base/auth.ts:876](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L876)
+**Source:** [src/base/auth.ts:878](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L878)
 
 #### `authEntryInfo.nonce`
 
@@ -1246,7 +1246,7 @@ the credential nonce, or `null` for source-account credentials.
 nonce: bigint | null;
 ```
 
-**Source:** [src/base/auth.ts:852](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L852)
+**Source:** [src/base/auth.ts:854](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L854)
 
 #### `authEntryInfo.signatureExpirationLedger`
 
@@ -1258,7 +1258,7 @@ carry a placeholder (often `0`) until [`authorizeEntry`](#authorizeentry) sets i
 signatureExpirationLedger: number | null;
 ```
 
-**Source:** [src/base/auth.ts:858](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L858)
+**Source:** [src/base/auth.ts:860](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L860)
 
 #### `authEntryInfo.signed`
 
@@ -1274,7 +1274,7 @@ support that.
 signed: boolean;
 ```
 
-**Source:** [src/base/auth.ts:874](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L874)
+**Source:** [src/base/auth.ts:876](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L876)
 
 #### `authEntryInfo.signers`
 
@@ -1286,7 +1286,7 @@ source-account credentials.
 signers: AuthEntrySigner[];
 ```
 
-**Source:** [src/base/auth.ts:864](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L864)
+**Source:** [src/base/auth.ts:866](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L866)
 
 ### AuthEntryReadiness
 
@@ -1300,7 +1300,7 @@ interface AuthEntryReadiness {
 }
 ```
 
-**Source:** [src/base/auth.ts:880](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L880)
+**Source:** [src/base/auth.ts:882](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L882)
 
 #### `authEntryReadiness.expired`
 
@@ -1311,7 +1311,7 @@ exclusive). Always `false` for source-account credentials.
 expired: boolean;
 ```
 
-**Source:** [src/base/auth.ts:887](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L887)
+**Source:** [src/base/auth.ts:889](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L889)
 
 #### `authEntryReadiness.ready`
 
@@ -1321,7 +1321,7 @@ expired: boolean;
 ready: boolean;
 ```
 
-**Source:** [src/base/auth.ts:882](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L882)
+**Source:** [src/base/auth.ts:884](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L884)
 
 #### `authEntryReadiness.unsignedBy`
 
@@ -1331,7 +1331,7 @@ addresses of signer nodes that carry no signature payload.
 unsignedBy: string[];
 ```
 
-**Source:** [src/base/auth.ts:889](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L889)
+**Source:** [src/base/auth.ts:891](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L891)
 
 ### AuthEntrySignature
 
@@ -1345,7 +1345,7 @@ interface AuthEntrySignature {
 }
 ```
 
-**Source:** [src/base/auth.ts:807](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L807)
+**Source:** [src/base/auth.ts:809](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L809)
 
 #### `authEntrySignature.publicKey`
 
@@ -1355,7 +1355,7 @@ the signer's public key, as a `G…` strkey.
 publicKey: string;
 ```
 
-**Source:** [src/base/auth.ts:809](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L809)
+**Source:** [src/base/auth.ts:811](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L811)
 
 #### `authEntrySignature.signature`
 
@@ -1365,7 +1365,7 @@ the raw 64-byte ed25519 signature.
 signature: Uint8Array;
 ```
 
-**Source:** [src/base/auth.ts:811](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L811)
+**Source:** [src/base/auth.ts:813](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L813)
 
 ### AuthEntrySigner
 
@@ -1382,7 +1382,7 @@ interface AuthEntrySigner {
 }
 ```
 
-**Source:** [src/base/auth.ts:819](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L819)
+**Source:** [src/base/auth.ts:821](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L821)
 
 #### `authEntrySigner.address`
 
@@ -1392,7 +1392,7 @@ the node's address (`G…` account or `C…` contract).
 address: string;
 ```
 
-**Source:** [src/base/auth.ts:821](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L821)
+**Source:** [src/base/auth.ts:823](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L823)
 
 #### `authEntrySigner.rawSignature`
 
@@ -1402,7 +1402,7 @@ the raw signature value, whatever its shape.
 rawSignature: ScVal;
 ```
 
-**Source:** [src/base/auth.ts:840](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L840)
+**Source:** [src/base/auth.ts:842](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L842)
 
 #### `authEntrySigner.signatures`
 
@@ -1418,7 +1418,7 @@ node is unsigned.
 signatures: AuthEntrySignature[] | null;
 ```
 
-**Source:** [src/base/auth.ts:838](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L838)
+**Source:** [src/base/auth.ts:840](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L840)
 
 #### `authEntrySigner.signed`
 
@@ -1431,7 +1431,7 @@ contract's `__check_auth` cannot be verified client-side.
 signed: boolean;
 ```
 
-**Source:** [src/base/auth.ts:828](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L828)
+**Source:** [src/base/auth.ts:830](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L830)
 
 ### AuthorizeInvocationParams
 
@@ -1461,7 +1461,7 @@ interface AuthorizeInvocationParams {
 
 - authorizeEntry
 
-**Source:** [src/base/auth.ts:394](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L394)
+**Source:** [src/base/auth.ts:396](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L396)
 
 #### `authorizeInvocationParams.authV2`
 
@@ -1473,7 +1473,7 @@ the signed payload.
 authV2?: boolean;
 ```
 
-**Source:** [src/base/auth.ts:406](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L406)
+**Source:** [src/base/auth.ts:408](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L408)
 
 #### `authorizeInvocationParams.invocation`
 
@@ -1481,7 +1481,7 @@ authV2?: boolean;
 invocation: SorobanAuthorizedInvocation;
 ```
 
-**Source:** [src/base/auth.ts:397](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L397)
+**Source:** [src/base/auth.ts:399](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L399)
 
 #### `authorizeInvocationParams.networkPassphrase`
 
@@ -1489,7 +1489,7 @@ invocation: SorobanAuthorizedInvocation;
 networkPassphrase: string;
 ```
 
-**Source:** [src/base/auth.ts:398](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L398)
+**Source:** [src/base/auth.ts:400](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L400)
 
 #### `authorizeInvocationParams.publicKey`
 
@@ -1497,7 +1497,7 @@ networkPassphrase: string;
 publicKey?: string;
 ```
 
-**Source:** [src/base/auth.ts:399](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L399)
+**Source:** [src/base/auth.ts:401](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L401)
 
 #### `authorizeInvocationParams.signer`
 
@@ -1505,7 +1505,7 @@ publicKey?: string;
 signer: Keypair | SigningCallback;
 ```
 
-**Source:** [src/base/auth.ts:395](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L395)
+**Source:** [src/base/auth.ts:397](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L397)
 
 #### `authorizeInvocationParams.validUntilLedgerSeq`
 
@@ -1513,7 +1513,7 @@ signer: Keypair | SigningCallback;
 validUntilLedgerSeq: number;
 ```
 
-**Source:** [src/base/auth.ts:396](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L396)
+**Source:** [src/base/auth.ts:398](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L398)
 
 ### BuildWithDelegatesParams
 
@@ -1528,7 +1528,7 @@ interface BuildWithDelegatesParams {
 }
 ```
 
-**Source:** [src/base/auth.ts:540](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L540)
+**Source:** [src/base/auth.ts:542](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L542)
 
 #### `buildWithDelegatesParams.delegates`
 
@@ -1538,7 +1538,7 @@ the delegate signers to attach.
 delegates: DelegateSignature[];
 ```
 
-**Source:** [src/base/auth.ts:550](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L550)
+**Source:** [src/base/auth.ts:552](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L552)
 
 #### `buildWithDelegatesParams.entry`
 
@@ -1550,7 +1550,7 @@ simulation — whose address credentials should be wrapped.
 entry: SorobanAuthorizationEntry;
 ```
 
-**Source:** [src/base/auth.ts:546](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L546)
+**Source:** [src/base/auth.ts:548](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L548)
 
 #### `buildWithDelegatesParams.signature`
 
@@ -1561,7 +1561,7 @@ for accounts that authorize purely via delegated signers (CAP-71-01).
 signature?: ScVal;
 ```
 
-**Source:** [src/base/auth.ts:555](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L555)
+**Source:** [src/base/auth.ts:557](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L557)
 
 #### `buildWithDelegatesParams.validUntilLedgerSeq`
 
@@ -1571,7 +1571,7 @@ the expiration ledger sequence stored on the top-level credentials.
 validUntilLedgerSeq: number;
 ```
 
-**Source:** [src/base/auth.ts:548](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L548)
+**Source:** [src/base/auth.ts:550](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L550)
 
 ### CreateInvocation
 
@@ -1643,7 +1643,7 @@ interface DelegateSignature {
 }
 ```
 
-**Source:** [src/base/auth.ts:526](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L526)
+**Source:** [src/base/auth.ts:528](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L528)
 
 #### `delegateSignature.address`
 
@@ -1653,7 +1653,7 @@ the delegate's address (`G…` account or `C…` contract).
 address: string;
 ```
 
-**Source:** [src/base/auth.ts:528](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L528)
+**Source:** [src/base/auth.ts:530](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L530)
 
 #### `delegateSignature.nestedDelegates`
 
@@ -1663,7 +1663,7 @@ signers this delegate in turn delegates to (recursive).
 nestedDelegates?: DelegateSignature[];
 ```
 
-**Source:** [src/base/auth.ts:536](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L536)
+**Source:** [src/base/auth.ts:538](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L538)
 
 #### `delegateSignature.signature`
 
@@ -1675,7 +1675,7 @@ as `forAddress`) or by editing the entry directly.
 signature?: ScVal;
 ```
 
-**Source:** [src/base/auth.ts:534](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L534)
+**Source:** [src/base/auth.ts:536](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L536)
 
 ### ExecuteInvocation
 
@@ -1878,7 +1878,7 @@ necessary to authorize an invocation tree.
 type SigningCallback = (preimage: HashIdPreimage, payload: Uint8Array) => Promise<Uint8Array | { publicKey: string; signature: Uint8Array } | { address?: string; signatureScVal: ScVal }>
 ```
 
-**Source:** [src/base/auth.ts:58](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L58)
+**Source:** [src/base/auth.ts:60](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/auth.ts#L60)
 
 ### WasmCreateDetails
 

--- a/docs/reference/network-rpc.md
+++ b/docs/reference/network-rpc.md
@@ -237,7 +237,7 @@ _getLedgers(request: GetLedgersRequest): Promise<RawGetLedgersResponse>;
 
 - **`request`** — `GetLedgersRequest` (required)
 
-**Source:** [src/rpc/server.ts:1929](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1929)
+**Source:** [src/rpc/server.ts:1930](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1930)
 
 ### `server._getTransaction(hash)`
 
@@ -273,7 +273,7 @@ _sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<RawSend
 
 - **`transaction`** — `Transaction | FeeBumpTransaction` (required)
 
-**Source:** [src/rpc/server.ts:1568](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1568)
+**Source:** [src/rpc/server.ts:1569](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1569)
 
 ### `server._simulateTransaction(transaction, addlResources, authMode, useUpgradedAuth)`
 
@@ -288,7 +288,7 @@ _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResource
 - **`authMode`** — `SimulationAuthMode` (optional)
 - **`useUpgradedAuth`** — `boolean` (optional)
 
-**Source:** [src/rpc/server.ts:1413](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1413)
+**Source:** [src/rpc/server.ts:1414](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1414)
 
 ### `server.fundAddress(address, friendbotUrl)`
 
@@ -341,7 +341,7 @@ console.log("Contract funded! Hash:", tx.txHash);
 
 - `Friendbot docs`
 
-**Source:** [src/rpc/server.ts:1688](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1688)
+**Source:** [src/rpc/server.ts:1689](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1689)
 
 ### `server.getAccount(address)`
 
@@ -821,7 +821,7 @@ the fee stats
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getFeeStats
 
-**Source:** [src/rpc/server.ts:1734](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1734)
+**Source:** [src/rpc/server.ts:1735](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1735)
 
 ### `server.getHealth()`
 
@@ -1007,7 +1007,7 @@ const nextPage = await server.getLedgers({
 
 - `getLedgers docs`
 
-**Source:** [src/rpc/server.ts:1913](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1913)
+**Source:** [src/rpc/server.ts:1914](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1914)
 
 ### `server.getNetwork()`
 
@@ -1095,7 +1095,7 @@ console.log(
 - - getLedgerEntries
  - https://developers.stellar.org/docs/tokens/stellar-asset-contract
 
-**Source:** [src/rpc/server.ts:1798](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1798)
+**Source:** [src/rpc/server.ts:1799](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1799)
 
 ### `server.getTransaction(hash)`
 
@@ -1226,7 +1226,7 @@ the version info
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getVersionInfo
 
-**Source:** [src/rpc/server.ts:1748](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1748)
+**Source:** [src/rpc/server.ts:1749](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1749)
 
 ### `server.pollTransaction(hash, opts)`
 
@@ -1355,7 +1355,7 @@ server.sendTransaction(transaction).then(result => {
 - - module:rpc.assembleTransaction
  - `simulateTransaction docs`
 
-**Source:** [src/rpc/server.ts:1507](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1507)
+**Source:** [src/rpc/server.ts:1508](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1508)
 
 ### `server.queryContract(contractId, method, args, networkPassphrase)`
 
@@ -1463,7 +1463,7 @@ server
 - - `Friendbot docs`
  - [`Friendbot.Api.Response`](/reference/network-friendbot/#friendbotapiresponse)
 
-**Source:** [src/rpc/server.ts:1613](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1613)
+**Source:** [src/rpc/server.ts:1614](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1614)
 
 ### `server.sendTransaction(transaction)`
 
@@ -1524,7 +1524,7 @@ server.sendTransaction(transaction).then((result) => {
 - - `transaction docs`
  - `sendTransaction docs`
 
-**Source:** [src/rpc/server.ts:1562](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1562)
+**Source:** [src/rpc/server.ts:1563](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1563)
 
 ### `server.simulateTransaction(tx, addlResources, authMode, useUpgradedAuth)`
 
@@ -1549,15 +1549,14 @@ simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: Resour
      auth mode to use for simulation: `enforce` for enforcement mode,
      `record` for recording mode, or `record_allow_nonroot` for recording
      mode that allows non-root authorization
-- **`useUpgradedAuth`** — `boolean` (optional) — (optional) opt simulation into recording
-     v2 address credentials (CAP-71) instead of the legacy v1 address
-     credentials. Best-effort: it only affects the recording auth modes and
-     is silently ignored on protocol versions whose host cannot emit v2
-     credentials.
+- **`useUpgradedAuth`** — `boolean` (optional) — (optional) whether simulation records v2 address
+     credentials (CAP-71) instead of the legacy v1 address credentials.
+     Defaults to `true`; pass `false` to ask for the legacy v1 format.
+     It only affects the recording auth modes.
   
      **Deprecated**: this flag is transitional. Once the network returns v2
      credentials by default (protocol 28), it becomes a no-op — do not rely
-     on omitting it to keep receiving the legacy v1 format.
+     on passing `false` to keep receiving the legacy v1 format.
 
 **Returns**
 
@@ -1599,7 +1598,7 @@ server.simulateTransaction(transaction).then((sim) => {
  - module:rpc.Server#prepareTransaction
  - module:rpc.assembleTransaction
 
-**Source:** [src/rpc/server.ts:1399](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1399)
+**Source:** [src/rpc/server.ts:1400](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1400)
 
 ## rpc.assembleTransaction
 

--- a/docs/reference/network-rpc.md
+++ b/docs/reference/network-rpc.md
@@ -110,7 +110,7 @@ class Server {
   _getTransaction(hash: string): Promise<RawGetTransactionResponse>;
   _getTransactions(request: GetTransactionsRequest): Promise<RawGetTransactionsResponse>;
   _sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<RawSendTransactionResponse>;
-  _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, useUpgradedAuth?: boolean): Promise<RawSimulateTransactionResponse>;
+  _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, useUpgradedAuth: boolean = true): Promise<RawSimulateTransactionResponse>;
   fundAddress(address: string, friendbotUrl?: string): Promise<GetSuccessfulTransactionResponse>;
   getAccount(address: string): Promise<Account>;
   getAccountEntry(address: string): Promise<AccountEntry>;
@@ -136,11 +136,11 @@ class Server {
   getTrustline(account: string, asset: Asset): Promise<TrustLineEntry>;
   getVersionInfo(): Promise<GetVersionInfoResponse>;
   pollTransaction(hash: string, opts?: PollingOptions): Promise<GetTransactionResponse>;
-  prepareTransaction(tx: Transaction | FeeBumpTransaction): Promise<Transaction>;
+  prepareTransaction(tx: Transaction | FeeBumpTransaction, useUpgradedAuth: boolean = true): Promise<Transaction>;
   queryContract<T = any>(contractId: string, method: string, args: Record<string, unknown> = {}, networkPassphrase?: string): Promise<{ isReadCall: boolean; result: T }>;
   requestAirdrop(address: string | Pick<Account, "accountId">, friendbotUrl?: string): Promise<Account>;
   sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<SendTransactionResponse>;
-  simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, useUpgradedAuth?: boolean): Promise<SimulateTransactionResponse>;
+  simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, useUpgradedAuth: boolean = true): Promise<SimulateTransactionResponse>;
 }
 ```
 
@@ -237,7 +237,7 @@ _getLedgers(request: GetLedgersRequest): Promise<RawGetLedgersResponse>;
 
 - **`request`** — `GetLedgersRequest` (required)
 
-**Source:** [src/rpc/server.ts:1930](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1930)
+**Source:** [src/rpc/server.ts:1944](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1944)
 
 ### `server._getTransaction(hash)`
 
@@ -273,12 +273,12 @@ _sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<RawSend
 
 - **`transaction`** — `Transaction | FeeBumpTransaction` (required)
 
-**Source:** [src/rpc/server.ts:1569](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1569)
+**Source:** [src/rpc/server.ts:1583](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1583)
 
 ### `server._simulateTransaction(transaction, addlResources, authMode, useUpgradedAuth)`
 
 ```ts
-_simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, useUpgradedAuth?: boolean): Promise<RawSimulateTransactionResponse>;
+_simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, useUpgradedAuth: boolean = true): Promise<RawSimulateTransactionResponse>;
 ```
 
 **Parameters**
@@ -286,9 +286,9 @@ _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResource
 - **`transaction`** — `Transaction | FeeBumpTransaction` (required)
 - **`addlResources`** — `ResourceLeeway` (optional)
 - **`authMode`** — `SimulationAuthMode` (optional)
-- **`useUpgradedAuth`** — `boolean` (optional)
+- **`useUpgradedAuth`** — `boolean` (optional) (default: `true`)
 
-**Source:** [src/rpc/server.ts:1414](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1414)
+**Source:** [src/rpc/server.ts:1412](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1412)
 
 ### `server.fundAddress(address, friendbotUrl)`
 
@@ -341,7 +341,7 @@ console.log("Contract funded! Hash:", tx.txHash);
 
 - `Friendbot docs`
 
-**Source:** [src/rpc/server.ts:1689](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1689)
+**Source:** [src/rpc/server.ts:1703](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1703)
 
 ### `server.getAccount(address)`
 
@@ -821,7 +821,7 @@ the fee stats
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getFeeStats
 
-**Source:** [src/rpc/server.ts:1735](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1735)
+**Source:** [src/rpc/server.ts:1749](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1749)
 
 ### `server.getHealth()`
 
@@ -1007,7 +1007,7 @@ const nextPage = await server.getLedgers({
 
 - `getLedgers docs`
 
-**Source:** [src/rpc/server.ts:1914](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1914)
+**Source:** [src/rpc/server.ts:1928](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1928)
 
 ### `server.getNetwork()`
 
@@ -1095,7 +1095,7 @@ console.log(
 - - getLedgerEntries
  - https://developers.stellar.org/docs/tokens/stellar-asset-contract
 
-**Source:** [src/rpc/server.ts:1799](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1799)
+**Source:** [src/rpc/server.ts:1813](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1813)
 
 ### `server.getTransaction(hash)`
 
@@ -1226,7 +1226,7 @@ the version info
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getVersionInfo
 
-**Source:** [src/rpc/server.ts:1749](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1749)
+**Source:** [src/rpc/server.ts:1763](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1763)
 
 ### `server.pollTransaction(hash, opts)`
 
@@ -1268,7 +1268,7 @@ const txStatus = await server.pollTransaction(h, {
 
 **Source:** [src/rpc/server.ts:1069](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1069)
 
-### `server.prepareTransaction(tx)`
+### `server.prepareTransaction(tx, useUpgradedAuth)`
 
 Submit a trial contract invocation, first run a simulation of the contract
 invocation as defined on the incoming transaction, and apply the results to
@@ -1288,7 +1288,7 @@ transaction in detail first, then re-assemble it manually or via
 [`rpc.assembleTransaction`](#rpcassembletransaction).
 
 ```ts
-prepareTransaction(tx: Transaction | FeeBumpTransaction): Promise<Transaction>;
+prepareTransaction(tx: Transaction | FeeBumpTransaction, useUpgradedAuth: boolean = true): Promise<Transaction>;
 ```
 
 **Parameters**
@@ -1303,6 +1303,14 @@ prepareTransaction(tx: Transaction | FeeBumpTransaction): Promise<Transaction>;
      from the simulation. In other words, if you include auth entries, you
      don't care about the auth returned from the simulation. Other fields
      (footprint, etc.) will be filled as normal.
+- **`useUpgradedAuth`** — `boolean` (optional) (default: `true`) — (optional) whether the underlying simulation
+     records v2 address credentials (CAP-71) instead of the legacy v1
+     address credentials. Defaults to `true`; pass `false` to ask for the
+     legacy v1 format. It only affects the recording auth modes.
+  
+     **Deprecated**: this flag is transitional. Once the RPC server returns v2
+     credentials by default (protocol 28), it becomes a no-op — do not rely
+     on passing `false` to keep receiving the legacy v1 format.
 
 **Returns**
 
@@ -1355,7 +1363,7 @@ server.sendTransaction(transaction).then(result => {
 - - module:rpc.assembleTransaction
  - `simulateTransaction docs`
 
-**Source:** [src/rpc/server.ts:1508](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1508)
+**Source:** [src/rpc/server.ts:1514](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1514)
 
 ### `server.queryContract(contractId, method, args, networkPassphrase)`
 
@@ -1463,7 +1471,7 @@ server
 - - `Friendbot docs`
  - [`Friendbot.Api.Response`](/reference/network-friendbot/#friendbotapiresponse)
 
-**Source:** [src/rpc/server.ts:1614](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1614)
+**Source:** [src/rpc/server.ts:1628](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1628)
 
 ### `server.sendTransaction(transaction)`
 
@@ -1524,7 +1532,7 @@ server.sendTransaction(transaction).then((result) => {
 - - `transaction docs`
  - `sendTransaction docs`
 
-**Source:** [src/rpc/server.ts:1563](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1563)
+**Source:** [src/rpc/server.ts:1577](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1577)
 
 ### `server.simulateTransaction(tx, addlResources, authMode, useUpgradedAuth)`
 
@@ -1532,7 +1540,7 @@ Submit a trial contract invocation to get back return values, expected
 ledger footprint, expected authorizations, and expected costs.
 
 ```ts
-simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, useUpgradedAuth?: boolean): Promise<SimulateTransactionResponse>;
+simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: ResourceLeeway, authMode?: SimulationAuthMode, useUpgradedAuth: boolean = true): Promise<SimulateTransactionResponse>;
 ```
 
 **Parameters**
@@ -1549,7 +1557,7 @@ simulateTransaction(tx: Transaction | FeeBumpTransaction, addlResources?: Resour
      auth mode to use for simulation: `enforce` for enforcement mode,
      `record` for recording mode, or `record_allow_nonroot` for recording
      mode that allows non-root authorization
-- **`useUpgradedAuth`** — `boolean` (optional) — (optional) whether simulation records v2 address
+- **`useUpgradedAuth`** — `boolean` (optional) (default: `true`) — (optional) whether simulation records v2 address
      credentials (CAP-71) instead of the legacy v1 address credentials.
      Defaults to `true`; pass `false` to ask for the legacy v1 format.
      It only affects the recording auth modes.
@@ -1598,7 +1606,7 @@ server.simulateTransaction(transaction).then((sim) => {
  - module:rpc.Server#prepareTransaction
  - module:rpc.assembleTransaction
 
-**Source:** [src/rpc/server.ts:1400](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1400)
+**Source:** [src/rpc/server.ts:1398](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1398)
 
 ## rpc.assembleTransaction
 
@@ -1627,7 +1635,7 @@ a new, cloned transaction with the proper auth and resource (fee, footprint) sim
 **See also**
 
 - - [`rpc.Server.simulateTransaction`](#serversimulatetransactiontx-addlresources-authmode-useupgradedauth)
- - [`rpc.Server.prepareTransaction`](#serverpreparetransactiontx)
+ - [`rpc.Server.prepareTransaction`](#serverpreparetransactiontx-useupgradedauth)
 
 **Source:** [src/rpc/transaction.ts:45](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/transaction.ts#L45)
 

--- a/src/base/auth.ts
+++ b/src/base/auth.ts
@@ -40,8 +40,10 @@ import { nativeToScVal } from "./scval.js";
  *
  *  - the signature of the payload as a naked `Uint8Array`, implying it is
  *    signed by the key corresponding to the public key in the entry you pass to
- *    {@link authorizeEntry} (decipherable from its
- *    `credentials.address.address`),
+ *    {@link authorizeEntry} (decipherable from the entry's address
+ *    credentials — `credentials.address.address` on the legacy arm or
+ *    `credentials.addressV2.address` on the CAP-71 V2 arm, which is the
+ *    default; {@link inspectAuthEntry} handles both),
  *  - an object with the `signature` alongside an explicit `publicKey` string
  *    identifying the Ed25519 signer, or
  *  - an object with a `signatureScVal`: an arbitrary, caller-built

--- a/src/base/auth.ts
+++ b/src/base/auth.ts
@@ -386,8 +386,8 @@ export async function authorizeEntry(
  *    {@link Keypair} to `signer`, this can be omitted, as it just uses
  *    {@link Keypair.publicKey})
  *   - `authV2`: build `SOROBAN_CREDENTIALS_ADDRESS_V2` (CAP-71) credentials
- *    rather than the legacy `SOROBAN_CREDENTIALS_ADDRESS`. Defaults to `false`;
- *    only enable it for networks that have activated CAP-71.
+ *    rather than the legacy `SOROBAN_CREDENTIALS_ADDRESS`. Defaults to `true`;
+ *    pass `false` for the legacy format.
  *
  * @see authorizeEntry
  */
@@ -400,10 +400,8 @@ export interface AuthorizeInvocationParams {
   /**
    * Build `SOROBAN_CREDENTIALS_ADDRESS_V2` (CAP-71) credentials instead of the
    * legacy `SOROBAN_CREDENTIALS_ADDRESS`. V2 credentials bind the address into
-   * the signed payload but are only valid on networks that have activated
-   * CAP-71, so leave this off until the activation vote passes for your target
-   * network. The default flips to `true` once V2 becomes mandatory.
-   * @defaultValue false
+   * the signed payload.
+   * @defaultValue true
    */
   authV2?: boolean;
 }
@@ -417,7 +415,7 @@ export function authorizeInvocation(
     invocation,
     networkPassphrase,
     publicKey = "",
-    authV2 = false,
+    authV2 = true,
   } = params;
   // We use keypairs as a source of randomness for the nonce to avoid mucking
   // with any crypto dependencies. Note that this just has to be random and

--- a/src/contract/types.ts
+++ b/src/contract/types.ts
@@ -233,15 +233,14 @@ export type MethodOptions = {
   restore?: boolean;
 
   /**
-   * If true, simulation records v2 address credentials (CAP-71) instead of
-   * the legacy v1 address credentials. Best-effort: it only affects the
-   * recording auth modes and is silently ignored on protocol versions whose
-   * host cannot emit v2 credentials.
+   * Whether simulation records v2 address credentials (CAP-71) instead of the
+   * legacy v1 address credentials. Set it to false to ask for the legacy v1
+   * format. It only affects the recording auth modes.
    *
    * @deprecated This flag is transitional. Once the network returns v2
    * credentials by default (protocol 28), it becomes a no-op — do not rely on
-   * omitting it to keep receiving the legacy v1 format.
-   * @defaultValue false
+   * passing false to keep receiving the legacy v1 format.
+   * @defaultValue true
    */
   useUpgradedAuth?: boolean;
 

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -1460,6 +1460,14 @@ export class RpcServer {
    *    from the simulation. In other words, if you include auth entries, you
    *    don't care about the auth returned from the simulation. Other fields
    *    (footprint, etc.) will be filled as normal.
+   * @param useUpgradedAuth - (optional) whether the underlying simulation
+   *    records v2 address credentials (CAP-71) instead of the legacy v1
+   *    address credentials. Defaults to `true`; pass `false` to ask for the
+   *    legacy v1 format. It only affects the recording auth modes.
+   *
+   *    **Deprecated**: this flag is transitional. Once the RPC server returns v2
+   *    credentials by default (protocol 28), it becomes a no-op — do not rely
+   *    on passing `false` to keep receiving the legacy v1 format.
    * @returns A copy of the
    *    transaction with the expected authorizations (in the case of
    *    invocation), resources, and ledger footprints added. The transaction fee
@@ -1503,8 +1511,16 @@ export class RpcServer {
    * });
    * ```
    */
-  public async prepareTransaction(tx: Transaction | FeeBumpTransaction) {
-    const simResponse = await this.simulateTransaction(tx);
+  public async prepareTransaction(
+    tx: Transaction | FeeBumpTransaction,
+    useUpgradedAuth: boolean = true,
+  ) {
+    const simResponse = await this.simulateTransaction(
+      tx,
+      undefined,
+      undefined,
+      useUpgradedAuth,
+    );
     if (Api.isSimulationError(simResponse)) {
       throw new Error(simResponse.error);
     }

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -1356,8 +1356,6 @@ export class RpcServer {
    *    credentials by default (protocol 28), it becomes a no-op — do not rely
    *    on passing `false` to keep receiving the legacy v1 format.
    *
-   * @defaultValue true
-   *
    * @returns An object with the
    *    cost, footprint, result/auth requirements (if applicable), and error of
    *    the transaction
@@ -1401,7 +1399,7 @@ export class RpcServer {
     tx: Transaction | FeeBumpTransaction,
     addlResources?: RpcServer.ResourceLeeway,
     authMode?: Api.SimulationAuthMode,
-    useUpgradedAuth?: boolean,
+    useUpgradedAuth: boolean = true,
   ): Promise<Api.SimulateTransactionResponse> {
     return this._simulateTransaction(
       tx,
@@ -1415,7 +1413,7 @@ export class RpcServer {
     transaction: Transaction | FeeBumpTransaction,
     addlResources?: RpcServer.ResourceLeeway,
     authMode?: Api.SimulationAuthMode,
-    useUpgradedAuth?: boolean,
+    useUpgradedAuth: boolean = true,
   ): Promise<Api.RawSimulateTransactionResponse> {
     return jsonrpc.postObject(
       this.httpClient,
@@ -1424,7 +1422,7 @@ export class RpcServer {
       {
         transaction: transaction.toXdr(),
         authMode,
-        useUpgradedAuth: useUpgradedAuth ?? true,
+        useUpgradedAuth,
         ...(addlResources !== undefined && {
           resourceConfig: {
             instructionLeeway: addlResources.cpuInstructions,

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -1347,15 +1347,16 @@ export class RpcServer {
    *    auth mode to use for simulation: `enforce` for enforcement mode,
    *    `record` for recording mode, or `record_allow_nonroot` for recording
    *    mode that allows non-root authorization
-   * @param useUpgradedAuth - (optional) opt simulation into recording
-   *    v2 address credentials (CAP-71) instead of the legacy v1 address
-   *    credentials. Best-effort: it only affects the recording auth modes and
-   *    is silently ignored on protocol versions whose host cannot emit v2
-   *    credentials.
+   * @param useUpgradedAuth - (optional) whether simulation records v2 address
+   *    credentials (CAP-71) instead of the legacy v1 address credentials.
+   *    Defaults to `true`; pass `false` to ask for the legacy v1 format.
+   *    It only affects the recording auth modes.
    *
    *    **Deprecated**: this flag is transitional. Once the network returns v2
    *    credentials by default (protocol 28), it becomes a no-op — do not rely
-   *    on omitting it to keep receiving the legacy v1 format.
+   *    on passing `false` to keep receiving the legacy v1 format.
+   *
+   * @defaultValue true
    *
    * @returns An object with the
    *    cost, footprint, result/auth requirements (if applicable), and error of
@@ -1423,7 +1424,7 @@ export class RpcServer {
       {
         transaction: transaction.toXdr(),
         authMode,
-        ...(useUpgradedAuth !== undefined && { useUpgradedAuth }),
+        useUpgradedAuth: useUpgradedAuth ?? true,
         ...(addlResources !== undefined && {
           resourceConfig: {
             instructionLeeway: addlResources.cpuInstructions,

--- a/test/e2e/src/use-upgraded-auth.test.ts
+++ b/test/e2e/src/use-upgraded-auth.test.ts
@@ -3,10 +3,11 @@ import { inspectAuthEntry } from "../../../lib/esm/index.js";
 import { clientFor, generateFundedKeypair } from "./util.js";
 
 // TEMP (CAP-71 transition): verifies that the RPC honors the deprecated
-// `useUpgradedAuth` simulation flag and records v2 address credentials.
-// Requires an RPC built with stellar/stellar-rpc#783 on protocol >= 27; on
-// older hosts the flag is silently ignored and the v2 assertions fail.
-// Delete this file once protocol 28 activates and v2 becomes the default.
+// `useUpgradedAuth` simulation flag, which the SDK now sends as `true` by
+// default so simulation records v2 address credentials. Requires an RPC built
+// with stellar/stellar-rpc#783 on protocol >= 27; on older hosts the flag is
+// silently ignored and the v2 assertions fail. Delete this file once protocol
+// 28 activates and the flag becomes a no-op.
 
 let context: { client: any; userSigner: any; contractSigner: any };
 
@@ -37,28 +38,28 @@ describe("useUpgradedAuth simulation flag (temp, CAP-71)", () => {
       methodOptions,
     );
 
-  it("records legacy v1 address credentials by default", async () => {
+  it("records v2 address credentials by default", async () => {
     const tx = await hello();
+    const types = credentialTypes(tx);
+    expect(types.length).toBeGreaterThan(0);
+    expect(types).toEqual(types.map(() => "addressV2"));
+  });
+
+  it("records legacy v1 address credentials when disabled as a method option", async () => {
+    const tx = await hello({ useUpgradedAuth: false });
     const types = credentialTypes(tx);
     expect(types.length).toBeGreaterThan(0);
     expect(types).toEqual(types.map(() => "address"));
   });
 
-  it("records v2 address credentials when set as a method option", async () => {
-    const tx = await hello({ useUpgradedAuth: true });
-    const types = credentialTypes(tx);
-    expect(types.length).toBeGreaterThan(0);
-    expect(types).toEqual(types.map(() => "addressV2"));
-  });
-
-  it("records v2 address credentials when set per simulate() call", async () => {
+  it("records legacy v1 address credentials when disabled per simulate() call", async () => {
     // skip the automatic simulation: once a simulation's auth entries are
     // assembled onto the transaction, a re-simulation runs in enforce mode,
     // where the flag has no effect
     const tx = await hello({ simulate: false });
-    await tx.simulate({ useUpgradedAuth: true });
+    await tx.simulate({ useUpgradedAuth: false });
     const types = credentialTypes(tx);
     expect(types.length).toBeGreaterThan(0);
-    expect(types).toEqual(types.map(() => "addressV2"));
+    expect(types).toEqual(types.map(() => "address"));
   });
 });

--- a/test/unit/base/auth.test.ts
+++ b/test/unit/base/auth.test.ts
@@ -683,28 +683,45 @@ describe("building authorization entries", () => {
   });
 
   describe("authorizeInvocation", () => {
-    it("can build from scratch with a Keypair", async () => {
+    // authorizeInvocation defaults to CAP-71 SOROBAN_CREDENTIALS_ADDRESS_V2
+    // entries; the legacy arm is opt-in via `authV2: false`.
+    it.each([
+      [
+        "SOROBAN_CREDENTIALS_ADDRESS_V2 by default",
+        {},
+        "sorobanCredentialsAddressV2",
+      ],
+      [
+        "SOROBAN_CREDENTIALS_ADDRESS_V2 when authV2 is true",
+        { authV2: true },
+        "sorobanCredentialsAddressV2",
+      ],
+      [
+        "legacy SOROBAN_CREDENTIALS_ADDRESS when authV2 is false",
+        { authV2: false },
+        "sorobanCredentialsAddress",
+      ],
+    ] as const)("builds %s", async (_desc, opts, expectedArm) => {
       const signedEntry = await authorizeInvocation({
         signer: kp,
         validUntilLedgerSeq: 10,
         invocation: authEntry.rootInvocation,
         networkPassphrase: Networks.TESTNET,
+        ...opts,
       });
 
       expect(signedEntry.rootInvocation.toXdr()).toEqual(
         authEntry.rootInvocation.toXdr(),
       );
 
-      // authorizeInvocation defaults to CAP-71 SOROBAN_CREDENTIALS_ADDRESS_V2
-      // entries; the legacy arm is opt-in via `authV2: false`.
-      expect(signedEntry.credentials.type).toBe("sorobanCredentialsAddressV2");
-      const signedAddr = (
-        signedEntry.credentials as xdr.SorobanCredentialsAddressV2
-      ).value;
-      expect(signedAddr.signatureExpirationLedger).toBe(10);
-
-      const addrStr = Address.fromScAddress(signedAddr.address).toString();
-      expect(addrStr).toBe(kp.publicKey());
+      const credentials = expectUnionVariant(
+        signedEntry.credentials,
+        expectedArm,
+      );
+      expect(credentials.value.signatureExpirationLedger).toBe(10);
+      expect(Address.fromScAddress(credentials.value.address).toString()).toBe(
+        kp.publicKey(),
+      );
     });
 
     it("can build from scratch with explicit publicKey", async () => {
@@ -722,52 +739,14 @@ describe("building authorization entries", () => {
         publicKey: kp.publicKey(),
       });
 
-      expect(signedEntry.credentials.type).toBe("sorobanCredentialsAddressV2");
-      const signedAddr = (
-        signedEntry.credentials as xdr.SorobanCredentialsAddressV2
-      ).value;
-      expect(signedAddr.signatureExpirationLedger).toBe(10);
-
-      const addrStr = Address.fromScAddress(signedAddr.address).toString();
-      expect(addrStr).toBe(kp.publicKey());
-    });
-
-    it("builds legacy SOROBAN_CREDENTIALS_ADDRESS entries when authV2 is false", async () => {
-      const signedEntry = await authorizeInvocation({
-        signer: kp,
-        validUntilLedgerSeq: 10,
-        invocation: authEntry.rootInvocation,
-        networkPassphrase: Networks.TESTNET,
-        authV2: false,
-      });
-
-      expect(signedEntry.credentials.type).toBe("sorobanCredentialsAddress");
-      const signedAddr = (
-        signedEntry.credentials as xdr.SorobanCredentialsAddress
-      ).value;
-      expect(signedAddr.signatureExpirationLedger).toBe(10);
-
-      const addrStr = Address.fromScAddress(signedAddr.address).toString();
-      expect(addrStr).toBe(kp.publicKey());
-    });
-
-    it("builds SOROBAN_CREDENTIALS_ADDRESS_V2 entries when authV2 is set", async () => {
-      const signedEntry = await authorizeInvocation({
-        signer: kp,
-        validUntilLedgerSeq: 10,
-        invocation: authEntry.rootInvocation,
-        networkPassphrase: Networks.TESTNET,
-        authV2: true,
-      });
-
-      expect(signedEntry.credentials.type).toBe("sorobanCredentialsAddressV2");
-      const signedAddr = (
-        signedEntry.credentials as xdr.SorobanCredentialsAddressV2
-      ).value;
-      expect(signedAddr.signatureExpirationLedger).toBe(10);
-
-      const addrStr = Address.fromScAddress(signedAddr.address).toString();
-      expect(addrStr).toBe(kp.publicKey());
+      const credentials = expectUnionVariant(
+        signedEntry.credentials,
+        "sorobanCredentialsAddressV2",
+      );
+      expect(credentials.value.signatureExpirationLedger).toBe(10);
+      expect(Address.fromScAddress(credentials.value.address).toString()).toBe(
+        kp.publicKey(),
+      );
     });
 
     it("throws when signer has no publicKey method and none provided", () => {

--- a/test/unit/base/auth.test.ts
+++ b/test/unit/base/auth.test.ts
@@ -695,11 +695,11 @@ describe("building authorization entries", () => {
         authEntry.rootInvocation.toXdr(),
       );
 
-      // authorizeInvocation defaults to legacy SOROBAN_CREDENTIALS_ADDRESS
-      // entries (CAP-71 V2 is opt-in via `authV2`).
-      expect(signedEntry.credentials.type).toBe("sorobanCredentialsAddress");
+      // authorizeInvocation defaults to CAP-71 SOROBAN_CREDENTIALS_ADDRESS_V2
+      // entries; the legacy arm is opt-in via `authV2: false`.
+      expect(signedEntry.credentials.type).toBe("sorobanCredentialsAddressV2");
       const signedAddr = (
-        signedEntry.credentials as xdr.SorobanCredentialsAddress
+        signedEntry.credentials as xdr.SorobanCredentialsAddressV2
       ).value;
       expect(signedAddr.signatureExpirationLedger).toBe(10);
 
@@ -720,6 +720,25 @@ describe("building authorization entries", () => {
         invocation: authEntry.rootInvocation,
         networkPassphrase: Networks.TESTNET,
         publicKey: kp.publicKey(),
+      });
+
+      expect(signedEntry.credentials.type).toBe("sorobanCredentialsAddressV2");
+      const signedAddr = (
+        signedEntry.credentials as xdr.SorobanCredentialsAddressV2
+      ).value;
+      expect(signedAddr.signatureExpirationLedger).toBe(10);
+
+      const addrStr = Address.fromScAddress(signedAddr.address).toString();
+      expect(addrStr).toBe(kp.publicKey());
+    });
+
+    it("builds legacy SOROBAN_CREDENTIALS_ADDRESS entries when authV2 is false", async () => {
+      const signedEntry = await authorizeInvocation({
+        signer: kp,
+        validUntilLedgerSeq: 10,
+        invocation: authEntry.rootInvocation,
+        networkPassphrase: Networks.TESTNET,
+        authV2: false,
       });
 
       expect(signedEntry.credentials.type).toBe("sorobanCredentialsAddress");
@@ -796,9 +815,9 @@ describe("building authorization entries", () => {
       });
       const credentials = expectUnionVariant(
         entry.credentials,
-        "sorobanCredentialsAddress",
+        "sorobanCredentialsAddressV2",
       );
-      expect(credentials.address.nonce).toBe(4294967296n); // 2^32
+      expect(credentials.addressV2.nonce).toBe(4294967296n); // 2^32
     });
 
     it("all-0xFF bytes produce nonce -1 (signed Int64 all-bits-set)", async () => {
@@ -811,9 +830,9 @@ describe("building authorization entries", () => {
       });
       const credentials = expectUnionVariant(
         entry.credentials,
-        "sorobanCredentialsAddress",
+        "sorobanCredentialsAddressV2",
       );
-      expect(credentials.address.nonce).toBe(-1n);
+      expect(credentials.addressV2.nonce).toBe(-1n);
     });
 
     it("high bit set produces Int64 minimum value", async () => {
@@ -826,9 +845,9 @@ describe("building authorization entries", () => {
       });
       const credentials = expectUnionVariant(
         entry.credentials,
-        "sorobanCredentialsAddress",
+        "sorobanCredentialsAddressV2",
       );
-      expect(credentials.address.nonce).toBe(-9223372036854775808n); // -(2^63), Int64 minimum
+      expect(credentials.addressV2.nonce).toBe(-9223372036854775808n); // -(2^63), Int64 minimum
     });
 
     it("all-zero bytes produce nonce 0", async () => {
@@ -841,9 +860,9 @@ describe("building authorization entries", () => {
       });
       const credentials = expectUnionVariant(
         entry.credentials,
-        "sorobanCredentialsAddress",
+        "sorobanCredentialsAddressV2",
       );
-      expect(credentials.address.nonce).toBe(0n);
+      expect(credentials.addressV2.nonce).toBe(0n);
     });
 
     it("throws if fewer than 8 bytes are available", () => {

--- a/test/unit/server/soroban/simulate_transaction.test.ts
+++ b/test/unit/server/soroban/simulate_transaction.test.ts
@@ -142,6 +142,7 @@ function buildAuthEntry(address: any) {
     validUntilLedgerSeq: 1,
     invocation: root,
     networkPassphrase,
+    authV2: false, // this fixture asserts on the legacy ADDRESS arm
   }).then((entry) => {
     // Fields are readonly in the new XDR layer — reconstruct the entry with a
     // deterministic nonce, then re-authorize to overwrite the signature.
@@ -432,6 +433,32 @@ describe("Server#simulateTransaction", () => {
       params: {
         transaction: blob,
         authMode: undefined,
+        useUpgradedAuth: true,
+      },
+    });
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it("simulates a transaction with useUpgradedAuth disabled", async () => {
+    const mockResponse = { data: { id: 1, result: simulationResponse } };
+    mockPost.mockResolvedValue(mockResponse);
+
+    const response = await server.simulateTransaction(
+      transaction,
+      undefined,
+      undefined,
+      false,
+    );
+    const expected = cloneSimulation(parsedSimulationResponse);
+    assert.deepEqual(response, expected);
+    expect(mockPost).toHaveBeenCalledWith(serverUrl, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "simulateTransaction",
+      params: {
+        transaction: blob,
+        authMode: undefined,
+        useUpgradedAuth: false,
       },
     });
     expect(mockPost).toHaveBeenCalledTimes(1);
@@ -478,6 +505,7 @@ describe("Server#simulateTransaction", () => {
         transaction: blob,
         resourceConfig: { instructionLeeway: 100 },
         authMode: undefined,
+        useUpgradedAuth: true,
       },
     });
   });


### PR DESCRIPTION
## What

CAP-71 `SOROBAN_CREDENTIALS_ADDRESS_V2` credentials become the default on both ends of the Soroban auth flow, now that the network runs protocol 27. `rpc.Server.simulateTransaction`'s `useUpgradedAuth` and `authorizeInvocation`'s `authV2` both default to `true`, so simulation asks RPC to record v2 entries and `authorizeInvocation` builds them. Pass `false` to either one for the legacy `SOROBAN_CREDENTIALS_ADDRESS` format. Both flags stay transitional and become no-ops when v2 is mandatory in protocol 28.

`simulateTransaction` also now always sends `useUpgradedAuth` in the JSON-RPC request, where it previously omitted the field when the flag was unset. The `useUpgradedAuth` default reaches everything built on simulation, including `contract.AssembledTransaction.simulate()` and the `useUpgradedAuth` method option.

Two things break for callers. Code that reads the credential arm by hand has to handle `addressV2` and not just `address`, or switch to `inspectAuthEntry`, which normalizes the arms. And a hand-rolled signer that hardcodes the legacy `ENVELOPE_TYPE_SOROBAN_AUTHORIZATION` preimage now produces signatures the network rejects, so it should use `buildAuthorizationEntryPreimage` or `authorizeEntry`, both of which pick the address-bound payload off the entry itself. SDK-driven signing (`contract.Client`, `authorizeEntry`, `signAuthEntries`) needs no change: it signs whichever credential the entry carries.

Tests cover both defaults and both opt-outs. The simulation fixture in `simulate_transaction.test.ts` pins `authV2: false`, since it rebuilds and asserts on the legacy arm. The changelog entry goes under a new `## Unreleased` heading rather than the published `v17.0.0-rc.1` section, and the migration guide, the Protocol 27 auth guide, and the contract-auth guide are updated to describe v2 as the default instead of opt-in.
