### PR TITLE
fix(memo): widen Memo.id to accept bigint for uint64 values

### DIFF
--- a/docs/reference/core-transactions.md
+++ b/docs/reference/core-transactions.md
@@ -441,7 +441,7 @@ class Memo<T extends MemoType = MemoType> {
   constructor(type: "none", value?: null);
   static fromXdrObject(object: Memo): Memo;
   static hash(hash: string | Uint8Array<ArrayBufferLike>): Memo<"hash">;
-  static id(id: string): Memo<"id">;
+  static id(id: string | bigint): Memo<"id">;
   static none(): Memo<"none">;
   static return(hash: string | Uint8Array<ArrayBufferLike>): Memo<"return">;
   static text(text: string | Uint8Array<ArrayBufferLike>): Memo<"text">;
@@ -455,7 +455,7 @@ class Memo<T extends MemoType = MemoType> {
 
 - [Transactions concept](https://developers.stellar.org/docs/glossary/transactions/)
 
-**Source:** [src/base/memo.ts:63](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L63)
+**Source:** [src/base/memo.ts:59](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L59)
 
 ### `new Memo(type, value)`
 
@@ -468,7 +468,7 @@ constructor(type: "none", value?: null);
 - **`type`** — `"none"` (required)
 - **`value`** — `null` (optional)
 
-**Source:** [src/base/memo.ts:67](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L67)
+**Source:** [src/base/memo.ts:63](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L63)
 
 ### `Memo.fromXdrObject(object)`
 
@@ -482,7 +482,7 @@ static fromXdrObject(object: Memo): Memo;
 
 - **`object`** — `Memo` (required) — XDR memo object
 
-**Source:** [src/base/memo.ts:303](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L303)
+**Source:** [src/base/memo.ts:312](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L312)
 
 ### `Memo.hash(hash)`
 
@@ -496,21 +496,21 @@ static hash(hash: string | Uint8Array<ArrayBufferLike>): Memo<"hash">;
 
 - **`hash`** — `string | Uint8Array<ArrayBufferLike>` (required) — 32 byte hash or hex encoded string
 
-**Source:** [src/base/memo.ts:262](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L262)
+**Source:** [src/base/memo.ts:271](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L271)
 
 ### `Memo.id(id)`
 
 Creates and returns a `MemoID` memo.
 
 ```ts
-static id(id: string): Memo<"id">;
+static id(id: string | bigint): Memo<"id">;
 ```
 
 **Parameters**
 
-- **`id`** — `string` (required) — 64-bit number represented as a string
+- **`id`** — `string | bigint` (required) — 64-bit number represented as a string
 
-**Source:** [src/base/memo.ts:253](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L253)
+**Source:** [src/base/memo.ts:262](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L262)
 
 ### `Memo.none()`
 
@@ -520,7 +520,7 @@ Returns an empty memo (`MemoNone`).
 static none(): Memo<"none">;
 ```
 
-**Source:** [src/base/memo.ts:233](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L233)
+**Source:** [src/base/memo.ts:242](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L242)
 
 ### `Memo.return(hash)`
 
@@ -534,7 +534,7 @@ static return(hash: string | Uint8Array<ArrayBufferLike>): Memo<"return">;
 
 - **`hash`** — `string | Uint8Array<ArrayBufferLike>` (required) — 32 byte hash or hex encoded string
 
-**Source:** [src/base/memo.ts:271](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L271)
+**Source:** [src/base/memo.ts:280](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L280)
 
 ### `Memo.text(text)`
 
@@ -550,7 +550,7 @@ static text(text: string | Uint8Array<ArrayBufferLike>): Memo<"text">;
     pass a `Uint8Array` for byte-exact content. A plain `number[]` is not
     accepted (16.2.0 and earlier took one); wrap it: `new Uint8Array(arr)`.
 
-**Source:** [src/base/memo.ts:244](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L244)
+**Source:** [src/base/memo.ts:253](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L253)
 
 ### `memo.type`
 
@@ -560,7 +560,7 @@ Contains memo type: `MemoNone`, `MemoID`, `MemoText`, `MemoHash` or `MemoReturn`
 type: T;
 ```
 
-**Source:** [src/base/memo.ts:107](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L107)
+**Source:** [src/base/memo.ts:104](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L104)
 
 ### `memo.value`
 
@@ -574,7 +574,7 @@ Contains memo value:
 value: MemoTypeToValue<T>;
 ```
 
-**Source:** [src/base/memo.ts:122](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L122)
+**Source:** [src/base/memo.ts:119](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L119)
 
 ### `memo.toXdrObject()`
 
@@ -584,7 +584,7 @@ Returns XDR memo object.
 toXdrObject(): Memo;
 ```
 
-**Source:** [src/base/memo.ts:278](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L278)
+**Source:** [src/base/memo.ts:287](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L287)
 
 ## MemoHash
 
@@ -3692,7 +3692,7 @@ type MemoTypeText = typeof MemoText
 type MemoValue = string | null | Uint8Array
 ```
 
-**Source:** [src/base/memo.ts:47](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L47)
+**Source:** [src/base/memo.ts:43](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/memo.ts#L43)
 
 ### Networks
 

--- a/src/base/memo.ts
+++ b/src/base/memo.ts
@@ -38,11 +38,7 @@ export namespace MemoType {
   export type Return = MemoTypeReturn;
 }
 export type MemoType =
-  | MemoTypeHash
-  | MemoTypeID
-  | MemoTypeNone
-  | MemoTypeReturn
-  | MemoTypeText;
+  MemoTypeHash | MemoTypeID | MemoTypeNone | MemoTypeReturn | MemoTypeText;
 
 export type MemoValue = string | null | Uint8Array;
 
@@ -66,6 +62,7 @@ export class Memo<T extends MemoType = MemoType> {
 
   constructor(type: MemoType.None, value?: null);
   constructor(type: MemoType.Hash | MemoType.Return, value: Uint8Array);
+  constructor(type: MemoType.ID, value: string | bigint);
   constructor(
     type: MemoType.Hash | MemoType.ID | MemoType.Return | MemoType.Text,
     value: string,
@@ -75,22 +72,22 @@ export class Memo<T extends MemoType = MemoType> {
    * @param type - `MemoNone`, `MemoID`, `MemoText`, `MemoHash` or `MemoReturn`
    * @param value - `string` for `MemoID`, `MemoText`, `Uint8Array` or hex string for `MemoHash` or `MemoReturn`
    */
-  constructor(type: T, value: MemoValue = null) {
+  constructor(type: T, value: MemoValue | bigint = null) {
     this._type = type;
-    this._value = value;
+    this._value = typeof value === "bigint" ? value.toString() : value;
 
     switch (this._type) {
       case MemoNone:
         break;
       case MemoID:
-        Memo._validateIdValue(value as string);
+        Memo._validateIdValue(value as string | bigint);
         break;
       case MemoText:
-        Memo._validateTextValue(value);
+        Memo._validateTextValue(value as MemoValue);
         break;
       case MemoHash:
       case MemoReturn:
-        Memo._validateHashValue(value);
+        Memo._validateHashValue(value as MemoValue);
         // We want MemoHash and MemoReturn to have Uint8Array as a value
         if (typeof value === "string") {
           this._value = hexToUint8Array(value);
@@ -140,23 +137,35 @@ export class Memo<T extends MemoType = MemoType> {
     throw new Error("Memo is immutable");
   }
 
-  private static _validateIdValue(value: string): void {
-    const error = new Error(`Expects a uint64 as a string. Got ${value}`);
+  private static _validateIdValue(value: string | bigint): void {
+    const originalType = typeof value;
+    const error = new Error(
+      originalType === "bigint"
+        ? `Expects a uint64 as a string or bigint. Got ${value} (bigint) out of uint64 range.`
+        : `Expects a uint64 as a string or bigint. Got ${value}${
+            originalType !== "string" ? ` (${originalType})` : ""
+          }.`,
+    );
 
-    if (typeof value !== "string") {
+    if (originalType !== "string" && originalType !== "bigint") {
       throw error;
     }
+
+    const stringValue =
+      originalType === "bigint"
+        ? (value as bigint).toString()
+        : (value as string);
 
     // Only plain decimal digit strings are accepted. Scientific notation
     // ("1e18") and trailing-zero decimals ("1.0") pass BigNumber validation
     // but crash in BigInt() during XDR serialization.
-    if (!/^[0-9]+$/.test(value)) {
+    if (!/^[0-9]+$/.test(stringValue)) {
       throw error;
     }
 
     let number: BigNumber;
     try {
-      number = new CustomBigNumber(value);
+      number = new CustomBigNumber(stringValue);
     } catch {
       throw error;
     }
@@ -250,7 +259,7 @@ export class Memo<T extends MemoType = MemoType> {
    *
    * @param id - 64-bit number represented as a string
    */
-  static id(id: string): Memo<MemoTypeID> {
+  static id(id: string | bigint): Memo<MemoTypeID> {
     return new Memo(MemoID, id);
   }
 

--- a/test/unit/base/memo.test.ts
+++ b/test/unit/base/memo.test.ts
@@ -212,6 +212,48 @@ describe("Memo", () => {
       expect(() => Memo.id("1e18")).toThrow(/Expects a uint64/);
     });
 
+    it("accepts a bigint and normalizes it to a string internally", () => {
+      const memo = Memo.id(90210n);
+      expect(memo.type).toBe(MemoID);
+      expect(memo.value).toBe("90210");
+      expect(typeof memo.value).toBe("string");
+    });
+
+    it("accepts 0n", () => {
+      expect(() => Memo.id(0n)).not.toThrow();
+      expect(Memo.id(0n).value).toBe("0");
+    });
+
+    it("accepts the uint64 max as a bigint", () => {
+      const max = 18446744073709551615n;
+      expect(() => Memo.id(max)).not.toThrow();
+      expect(Memo.id(max).value).toBe("18446744073709551615");
+    });
+
+    it("throws when a bigint exceeds the uint64 max", () => {
+      expect(() => Memo.id(18446744073709551616n)).toThrow(/Expects a uint64/);
+    });
+
+    it("throws for a negative bigint", () => {
+      expect(() => Memo.id(-1n)).toThrow(/Expects a uint64/);
+    });
+
+    it("distinguishes a bigint input from a string/number input in the error message", () => {
+      expect(() => Memo.id(18446744073709551616n)).toThrow(/bigint/);
+    });
+
+    it("converts a bigint to/from xdr object", () => {
+      const memo = Memo.id(90210n);
+      const xdrMemo = memo.toXdrObject();
+      expect(xdrMemo.type).toBe("memoId");
+      if (xdrMemo.type !== "memoId") throw new Error("expected memoId");
+      expect(xdrMemo.id.toString()).toBe("90210");
+
+      const baseMemo = Memo.fromXdrObject(xdrMemo);
+      expect(baseMemo.type).toBe(MemoID);
+      expect(baseMemo.value).toBe("90210");
+    });
+
     it("rejects trailing-zero decimal strings that BigInt cannot parse", () => {
       // "1.0" passes BigNumber.isInteger() but BigInt("1.0") throws.
       expect(() => Memo.id("1.0")).toThrow(/Expects a uint64/);


### PR DESCRIPTION
## Summary

Fixes #1647

`Memo.id` was typed as `(id: string)` and rejected `bigint` at runtime, even though `bigint` is the only native JS type that represents a `uint64` exactly (`number` correctly loses precision above `2^53`, but `bigint` doesn't, and it was being rejected too). This widens the signature to accept `string | bigint`.

## Changes

- Widened `Memo.id()` and the `Memo` constructor's `MemoID` overload to accept `string | bigint`.
- `bigint` input is normalized to a `string` internally before validation and storage, so `.value`, `toXdrObject()`, and `fromXdrObject()` are all unaffected, a `Memo` constructed from a `bigint` behaves identically to one constructed from the equivalent string.
- Improved the validation error message to distinguish a `bigint` input from a `string`/`number` input, since previously both reported as `Got 90210` regardless of type.

## Testing

- Added test coverage for: a valid `bigint`, `0n`, the `uint64` max (`18446744073709551615n`) as a `bigint`, one over max, a negative `bigint`, the updated error message wording, and a full XDR round-trip via a `bigint`-constructed memo.
- `npm run build`, `tsc --noEmit -p .`, and the full `memo.test.ts` suite all pass.
- Regenerated `docs/reference/core-transactions.md` to reflect the updated `Memo.id` signature (verified via the repo's pre-push doc-freshness check).

## Reproduction (before fix)

```ts
Memo.id(90210n); // threw: "Expects a uint64 as a string. Got 90210"
```

After this change, `Memo.id(90210n)` succeeds and behaves the same as `Memo.id("90210")`.