### PR TITLE
feat(xdr): add `encodeArray` / `decodeArray` for length-prefixed XDR arrays

### DIFF
--- a/docs/XDR_MIGRATION.md
+++ b/docs/XDR_MIGRATION.md
@@ -108,6 +108,21 @@ stood for rather than exporting a name for it:
 These only bite type annotations and `import type` lines. The runtime values
 were always the underlying types.
 
+The one runtime use the array typedefs had was encoding or decoding a whole
+list as a single length-prefixed blob (e.g.
+`xdr.LedgerEntryChanges.fromXDR(feeMetaXdr, "base64")` on Horizon's
+`fee_meta_xdr`). That job moved to the generic `encodeArray` / `decodeArray`
+helpers, which work with any XDR class:
+
+```js
+const changes = xdr.decodeArray(xdr.LedgerEntryChange, feeMetaXdr, "base64");
+const blob = xdr.encodeArray(xdr.LedgerEntryChange, changes, "base64");
+```
+
+This is only for the bare typedef wire format. Lists exchanged as one base64
+string per element (RPC simulation auth entries, `operation.auth`) still use
+`value.toXdr("base64")` / `Type.fromXdr(s, "base64")` per element.
+
 ---
 
 ## 2. Union types: discriminated classes, not switch/value pairs
@@ -817,6 +832,10 @@ const entries = xdr.decodeStream(xdr.ScSpecEntry, bytes);
 
 `decodeStream` decodes until the buffer is exhausted and throws if the remaining
 bytes don't form a complete value. It never returns a partial list.
+
+For a length-prefixed XDR variable-length array (the wire format of the removed
+array typedefs — a 4-byte count, then the elements), use `xdr.encodeArray` and
+`xdr.decodeArray` instead (§ 1).
 
 ### Runtime type constructors
 

--- a/src/xdr/index.ts
+++ b/src/xdr/index.ts
@@ -40,6 +40,7 @@ export {
   decodeStream,
   encodeArray,
   decodeArray,
+  type XdrArrayOptions,
   type XdrFormat,
   type JsonValue,
   type XdrValueConstructor,

--- a/src/xdr/index.ts
+++ b/src/xdr/index.ts
@@ -38,6 +38,8 @@ export {
   encodeBytes,
   decodeBytes,
   decodeStream,
+  encodeArray,
+  decodeArray,
   type XdrFormat,
   type JsonValue,
   type XdrValueConstructor,

--- a/src/xdr/values/xdr-value.ts
+++ b/src/xdr/values/xdr-value.ts
@@ -176,6 +176,24 @@ export function decodeStream<Wire, Instance extends XdrValue>(
   return out;
 }
 
+/** Options shared by {@link encodeArray} and {@link decodeArray}. */
+export interface XdrArrayOptions {
+  /**
+   * Largest element count to accept, defaulting to the XDR maximum of
+   * 2^32 - 1. Both encoding and decoding throw `XdrError` past this many
+   * elements. Pass the bound from the XDR definition, so a field declared
+   * `TimeSlicedPeerData peers<25>` decodes with `maxLength: 25`, or any cap
+   * you want to enforce, to reject an oversized array before its elements are
+   * decoded.
+   */
+  maxLength?: number;
+  /**
+   * How many nested schemas may be entered, counting the array itself as the
+   * first level.
+   */
+  maxDepth?: number;
+}
+
 /**
  * Encode a list of XDR values as a single length-prefixed XDR variable-length
  * array (`T values<>` — a 4-byte count followed by the elements). This is the
@@ -188,25 +206,33 @@ export function decodeStream<Wire, Instance extends XdrValue>(
 export function encodeArray<Wire, Instance extends XdrValue>(
   type: XdrValueConstructor<Wire, Instance>,
   values: readonly Instance[],
+  options?: XdrArrayOptions,
 ): Uint8Array;
 export function encodeArray<Wire, Instance extends XdrValue>(
   type: XdrValueConstructor<Wire, Instance>,
   values: readonly Instance[],
   format: "raw",
+  options?: XdrArrayOptions,
 ): Uint8Array;
 export function encodeArray<Wire, Instance extends XdrValue>(
   type: XdrValueConstructor<Wire, Instance>,
   values: readonly Instance[],
   format: "hex" | "base64",
+  options?: XdrArrayOptions,
 ): string;
 export function encodeArray<Wire, Instance extends XdrValue>(
   type: XdrValueConstructor<Wire, Instance>,
   values: readonly Instance[],
-  format: XdrFormat = "raw",
+  formatOrOptions?: XdrFormat | XdrArrayOptions,
+  maybeOptions?: XdrArrayOptions,
 ): Uint8Array | string {
-  const codec = array(type.schema, UNBOUNDED_MAX_LENGTH);
-  const bytes = codec.encode(values.map((v) => v.toXdrObject() as Wire));
-  return encodeBytes(bytes, format);
+  const [format, options] = splitArrayArgs(formatOrOptions, maybeOptions);
+  const codec = array(type.schema, options.maxLength ?? UNBOUNDED_MAX_LENGTH);
+  const bytes = codec.encode(
+    values.map((v) => v.toXdrObject() as Wire),
+    { maxDepth: options.maxDepth },
+  );
+  return encodeBytes(bytes, format ?? "raw");
 }
 
 /**
@@ -219,20 +245,40 @@ export function encodeArray<Wire, Instance extends XdrValue>(
 export function decodeArray<Wire, Instance extends XdrValue>(
   type: XdrValueConstructor<Wire, Instance>,
   input: Uint8Array,
+  options?: XdrArrayOptions,
 ): Instance[];
 export function decodeArray<Wire, Instance extends XdrValue>(
   type: XdrValueConstructor<Wire, Instance>,
   input: string,
   format: "hex" | "base64",
+  options?: XdrArrayOptions,
 ): Instance[];
 export function decodeArray<Wire, Instance extends XdrValue>(
   type: XdrValueConstructor<Wire, Instance>,
   input: Uint8Array | string,
-  format?: "hex" | "base64",
+  formatOrOptions?: "hex" | "base64" | XdrArrayOptions,
+  maybeOptions?: XdrArrayOptions,
 ): Instance[] {
-  const codec = array(type.schema, UNBOUNDED_MAX_LENGTH);
-  const wires = codec.decode(decodeBytes(input, format));
+  const [format, options] = splitArrayArgs(formatOrOptions, maybeOptions);
+  const codec = array(type.schema, options.maxLength ?? UNBOUNDED_MAX_LENGTH);
+  const wires = codec.decode(
+    decodeBytes(input, format as "hex" | "base64" | undefined),
+    { maxDepth: options.maxDepth },
+  );
   return wires.map((w) => type.fromXdrObject(w));
+}
+
+/**
+ * Sort out the trailing `(format?, options?)` arguments of the array helpers,
+ * where the format may be omitted and the options object take its place.
+ */
+function splitArrayArgs(
+  formatOrOptions?: XdrFormat | XdrArrayOptions,
+  maybeOptions?: XdrArrayOptions,
+): [XdrFormat | undefined, XdrArrayOptions] {
+  return typeof formatOrOptions === "string"
+    ? [formatOrOptions, maybeOptions ?? {}]
+    : [undefined, formatOrOptions ?? maybeOptions ?? {}];
 }
 
 export function encodeBytes(

--- a/src/xdr/values/xdr-value.ts
+++ b/src/xdr/values/xdr-value.ts
@@ -6,7 +6,7 @@ import {
   areUint8ArraysEqual,
 } from "uint8array-extras";
 import type { XdrType } from "@stellar/js-xdr";
-import { Reader, XdrError } from "@stellar/js-xdr";
+import { array, Reader, UNBOUNDED_MAX_LENGTH, XdrError } from "@stellar/js-xdr";
 import { walkToJson, walkFromJson } from "./to-json.js";
 
 export type XdrFormat = "raw" | "hex" | "base64";
@@ -174,6 +174,65 @@ export function decodeStream<Wire, Instance extends XdrValue>(
     out.push(type.fromXdrObject(type.schema._read(reader, path)));
   }
   return out;
+}
+
+/**
+ * Encode a list of XDR values as a single length-prefixed XDR variable-length
+ * array (`T values<>` — a 4-byte count followed by the elements). This is the
+ * wire format of the removed array typedef classes (`LedgerEntryChanges`,
+ * `SorobanAuthorizationEntries`, …); use it where a protocol expects the whole
+ * list as one blob, such as Horizon's `fee_meta_xdr`. For lists exchanged as
+ * one string per element, encode each element with `value.toXdr(format)`
+ * instead.
+ */
+export function encodeArray<Wire, Instance extends XdrValue>(
+  type: XdrValueConstructor<Wire, Instance>,
+  values: readonly Instance[],
+): Uint8Array;
+export function encodeArray<Wire, Instance extends XdrValue>(
+  type: XdrValueConstructor<Wire, Instance>,
+  values: readonly Instance[],
+  format: "raw",
+): Uint8Array;
+export function encodeArray<Wire, Instance extends XdrValue>(
+  type: XdrValueConstructor<Wire, Instance>,
+  values: readonly Instance[],
+  format: "hex" | "base64",
+): string;
+export function encodeArray<Wire, Instance extends XdrValue>(
+  type: XdrValueConstructor<Wire, Instance>,
+  values: readonly Instance[],
+  format: XdrFormat = "raw",
+): Uint8Array | string {
+  const codec = array(type.schema, UNBOUNDED_MAX_LENGTH);
+  const bytes = codec.encode(values.map((v) => v.toXdrObject() as Wire));
+  return encodeBytes(bytes, format);
+}
+
+/**
+ * Decode a single length-prefixed XDR variable-length array (`T values<>`)
+ * into a list of values — the inverse of {@link encodeArray}. Throws
+ * `XdrError` on a short buffer, trailing bytes, or a count that doesn't match
+ * the payload. For a buffer of values concatenated with no length prefix, use
+ * {@link decodeStream}.
+ */
+export function decodeArray<Wire, Instance extends XdrValue>(
+  type: XdrValueConstructor<Wire, Instance>,
+  input: Uint8Array,
+): Instance[];
+export function decodeArray<Wire, Instance extends XdrValue>(
+  type: XdrValueConstructor<Wire, Instance>,
+  input: string,
+  format: "hex" | "base64",
+): Instance[];
+export function decodeArray<Wire, Instance extends XdrValue>(
+  type: XdrValueConstructor<Wire, Instance>,
+  input: Uint8Array | string,
+  format?: "hex" | "base64",
+): Instance[] {
+  const codec = array(type.schema, UNBOUNDED_MAX_LENGTH);
+  const wires = codec.decode(decodeBytes(input, format));
+  return wires.map((w) => type.fromXdrObject(w));
 }
 
 export function encodeBytes(

--- a/test/unit/xdr/array_codec.test.ts
+++ b/test/unit/xdr/array_codec.test.ts
@@ -53,4 +53,77 @@ describe("encodeArray / decodeArray", () => {
     const padded = new Uint8Array([...bytes, 0, 0, 0, 0]);
     expect(() => decodeArray(ScVal, padded)).toThrow(XdrError);
   });
+
+  describe("maxLength", () => {
+    it("accepts a list at the limit", () => {
+      const bytes = encodeArray(ScVal, values, { maxLength: 3 });
+      const decoded = decodeArray(ScVal, bytes, { maxLength: 3 });
+      decoded.forEach((v, i) => expect(v.equals(values[i])).toBe(true));
+    });
+
+    it("rejects encoding more elements than the limit", () => {
+      expect(() => encodeArray(ScVal, values, { maxLength: 2 })).toThrow(
+        XdrError,
+      );
+      expect(() =>
+        encodeArray(ScVal, values, "base64", { maxLength: 2 }),
+      ).toThrow(XdrError);
+    });
+
+    it("rejects decoding a count past the limit", () => {
+      const bytes = encodeArray(ScVal, values);
+      expect(() => decodeArray(ScVal, bytes, { maxLength: 2 })).toThrow(
+        XdrError,
+      );
+
+      const b64 = encodeArray(ScVal, values, "base64");
+      expect(() => decodeArray(ScVal, b64, "base64", { maxLength: 2 })).toThrow(
+        XdrError,
+      );
+    });
+
+    it("rejects an inflated count before reading any element", () => {
+      // A 4-byte header claiming 2^31 elements over an otherwise empty body:
+      // the count check must fire instead of allocating for the claim.
+      const bogus = new Uint8Array([0x7f, 0xff, 0xff, 0xff]);
+      expect(() => decodeArray(ScVal, bogus, { maxLength: 16 })).toThrow(
+        XdrError,
+      );
+    });
+  });
+
+  describe("maxDepth", () => {
+    /** An `ScVal` vector nested `depth` levels deep around a u32. */
+    const nest = (depth: number): ScVal => {
+      let v: ScVal = ScVal.scvU32(1);
+      for (let i = 0; i < depth; i++) v = ScVal.scvVec([v]);
+      return v;
+    };
+
+    it("rejects encoding past the limit", () => {
+      expect(() => encodeArray(ScVal, [nest(8)], { maxDepth: 4 })).toThrow(
+        XdrError,
+      );
+    });
+
+    it("rejects decoding past the limit", () => {
+      const bytes = encodeArray(ScVal, [nest(8)]);
+      expect(() => decodeArray(ScVal, bytes, { maxDepth: 4 })).toThrow(
+        XdrError,
+      );
+      // Same bytes, same helper — only the cap makes them unacceptable.
+      expect(decodeArray(ScVal, bytes)).toHaveLength(1);
+    });
+
+    it("counts the array itself as a level", () => {
+      // Flat elements, so a cap of 1 leaves no room past the array itself.
+      // (How many levels a given element costs is a js-xdr detail — an
+      // ScVal union arm nests through option/array/lazy wrappers.)
+      const bytes = encodeArray(ScVal, values);
+      expect(() => decodeArray(ScVal, bytes, { maxDepth: 1 })).toThrow(
+        XdrError,
+      );
+      expect(decodeArray(ScVal, bytes, { maxDepth: 2 })).toHaveLength(3);
+    });
+  });
 });

--- a/test/unit/xdr/array_codec.test.ts
+++ b/test/unit/xdr/array_codec.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  decodeArray,
+  encodeArray,
+  ScVal,
+  XdrError,
+} from "../../../src/xdr/index.js";
+
+describe("encodeArray / decodeArray", () => {
+  const values = [ScVal.scvU32(1), ScVal.scvU32(2), ScVal.scvSymbol("hi")];
+
+  it("round-trips a list through raw bytes", () => {
+    const bytes = encodeArray(ScVal, values);
+    const decoded = decodeArray(ScVal, bytes);
+    expect(decoded).toHaveLength(3);
+    decoded.forEach((v, i) => expect(v.equals(values[i])).toBe(true));
+  });
+
+  it("round-trips through base64 and hex", () => {
+    const b64 = encodeArray(ScVal, values, "base64");
+    expect(typeof b64).toBe("string");
+    const fromB64 = decodeArray(ScVal, b64, "base64");
+    fromB64.forEach((v, i) => expect(v.equals(values[i])).toBe(true));
+
+    const hex = encodeArray(ScVal, values, "hex");
+    const fromHex = decodeArray(ScVal, hex, "hex");
+    fromHex.forEach((v, i) => expect(v.equals(values[i])).toBe(true));
+  });
+
+  it("emits the XDR var-array wire format: count prefix + elements", () => {
+    const bytes = encodeArray(ScVal, values);
+    expect(Array.from(bytes.subarray(0, 4))).toEqual([0, 0, 0, 3]);
+    const elements = new Uint8Array(
+      values.flatMap((v) => Array.from(v.toXdr())),
+    );
+    expect(Array.from(bytes.subarray(4))).toEqual(Array.from(elements));
+  });
+
+  it("encodes an empty list as a zero count and decodes it back", () => {
+    const bytes = encodeArray(ScVal, []);
+    expect(Array.from(bytes)).toEqual([0, 0, 0, 0]);
+    expect(decodeArray(ScVal, bytes)).toEqual([]);
+  });
+
+  it("throws when the buffer ends mid-element", () => {
+    const bytes = encodeArray(ScVal, values).slice(0, -1);
+    expect(() => decodeArray(ScVal, bytes)).toThrow(XdrError);
+  });
+
+  it("throws on trailing bytes past the declared count", () => {
+    const bytes = encodeArray(ScVal, values);
+    const padded = new Uint8Array([...bytes, 0, 0, 0, 0]);
+    expect(() => decodeArray(ScVal, padded)).toThrow(XdrError);
+  });
+});


### PR DESCRIPTION
## What

Adds two generic helpers to the XDR layer, exported from `xdr`:

- `xdr.encodeArray(Type, values, format?)` encodes a list of XDR values as a single length-prefixed variable-length array (`T values<>`: a 4-byte count followed by the elements). Returns bytes by default, or a string for `"hex"` / `"base64"`.
- `xdr.decodeArray(Type, input, format?)` is the inverse. It throws `XdrError` on a short buffer, trailing bytes, or a count that doesn't match the payload.

Both work with any XDR class. Unit tests cover round-trips and error cases, and the migration guide (`docs/XDR_MIGRATION.md`) now documents the helpers and points to them from the `decodeStream` section.

## Why

The class-XDR refactor dropped the array typedef classes (`LedgerEntryChanges`, `SorobanAuthorizationEntries`, and the rest), since they were just aliases for plain arrays. But those classes had one real runtime job: encoding or decoding a whole list as one blob, the wire format some protocols use. For example, Horizon returns `fee_meta_xdr` as a single base64 `LedgerEntryChanges` value, and after the refactor there was no way to decode it. These helpers restore that ability generically instead of reintroducing per-typedef classes:

```js
const changes = xdr.decodeArray(xdr.LedgerEntryChange, feeMetaXdr, "base64");
```

`decodeStream` doesn't cover this case: it handles concatenated values with no length prefix, while this format carries a leading count that must match the payload.