### PR TITLE
feat: accept CAP-85 external executable refs in createCustomContract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 A breaking change will get clearly marked in this log.
 
+## Unreleased
+
+### Added
+* `Operation.createCustomContract` can deploy from a [CAP-85](https://stellar.org/protocol/cap-85) external executable reference. Pass `externalRef` — either `{owner, tag}` (owner as a strkey or `Address`, tag as a string or raw bytes) or an `xdr.ContractExecutableExternalRef` pulled from an existing contract instance — instead of `wasmHash`; the two options are mutually exclusive. The owner must be a contract, since only a contract can hold the persistent tag entry that names the WASM, and a binary tag passes through undecoded.
+
 ## [v17.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v17.0.0-rc.1...v17.0.0-rc.2)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ A breaking change will get clearly marked in this log.
 
 ### Added
 * `Operation.createCustomContract` can deploy from a [CAP-85](https://stellar.org/protocol/cap-85) external executable reference. Pass `externalRef` — either `{owner, tag}` (owner as a strkey or `Address`, tag as a string or raw bytes) or an `xdr.ContractExecutableExternalRef` pulled from an existing contract instance — instead of `wasmHash`; the two options are mutually exclusive. The owner must be a contract, since only a contract can hold the persistent tag entry that names the WASM, and a binary tag passes through undecoded ([#1665](https://github.com/stellar/js-stellar-sdk/pull/1665)).
+* `contract.Client.deploy` accepts the same `externalRef` option in place of `wasmHash`. The reference is resolved on-chain (via `rpc.Server.getExternalRefWasmHash`) to fetch the contract spec for constructor arguments, while the deploy operation itself carries the external reference, so the deployed contract keeps following the tag ([#1665](https://github.com/stellar/js-stellar-sdk/pull/1665)).
 
 ## [v17.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v17.0.0-rc.1...v17.0.0-rc.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ A breaking change will get clearly marked in this log.
 
 ### Added
 * `Operation.createCustomContract` can deploy from a [CAP-85](https://stellar.org/protocol/cap-85) external executable reference. Pass `externalRef` — either `{owner, tag}` (owner as a strkey or `Address`, tag as a string or raw bytes) or an `xdr.ContractExecutableExternalRef` pulled from an existing contract instance — instead of `wasmHash`; the two options are mutually exclusive. The owner must be a contract, since only a contract can hold the persistent tag entry that names the WASM, and a binary tag passes through undecoded ([#1665](https://github.com/stellar/js-stellar-sdk/pull/1665)).
-* `contract.Client.deploy` accepts the same `externalRef` option in place of `wasmHash`. The reference is resolved on-chain (via `rpc.Server.getExternalRefWasmHash`) to fetch the contract spec for constructor arguments, while the deploy operation itself carries the external reference, so the deployed contract keeps following the tag ([#1665](https://github.com/stellar/js-stellar-sdk/pull/1665)).
+* `contract.Client.deploy` accepts the same `externalRef` option in place of `wasmHash`. The reference is resolved on-chain (via `rpc.Server.getExternalRefWasmHash`) to fetch the contract spec for constructor arguments, while the deploy operation itself carries the external reference, so the deployed contract keeps following the tag. Generated bindings (`BindingGenerator`) emit a `deploy` method with the same option, and the `ExternalExecutableRef` type is exported from the package root and from `@stellar/stellar-sdk/contract` ([#1665](https://github.com/stellar/js-stellar-sdk/pull/1665)).
 
 ## [v17.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v17.0.0-rc.1...v17.0.0-rc.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Added
-* `Operation.createCustomContract` can deploy from a [CAP-85](https://stellar.org/protocol/cap-85) external executable reference. Pass `externalRef` — either `{owner, tag}` (owner as a strkey or `Address`, tag as a string or raw bytes) or an `xdr.ContractExecutableExternalRef` pulled from an existing contract instance — instead of `wasmHash`; the two options are mutually exclusive. The owner must be a contract, since only a contract can hold the persistent tag entry that names the WASM, and a binary tag passes through undecoded.
+* `Operation.createCustomContract` can deploy from a [CAP-85](https://stellar.org/protocol/cap-85) external executable reference. Pass `externalRef` — either `{owner, tag}` (owner as a strkey or `Address`, tag as a string or raw bytes) or an `xdr.ContractExecutableExternalRef` pulled from an existing contract instance — instead of `wasmHash`; the two options are mutually exclusive. The owner must be a contract, since only a contract can hold the persistent tag entry that names the WASM, and a binary tag passes through undecoded ([#1665](https://github.com/stellar/js-stellar-sdk/pull/1665)).
 
 ## [v17.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v17.0.0-rc.1...v17.0.0-rc.2)
 

--- a/docs/reference/contracts-client.md
+++ b/docs/reference/contracts-client.md
@@ -658,7 +658,7 @@ transaction.
 ```ts
 class Client {
   constructor(spec: Spec, options: ClientOptions);
-  static deploy<T = Client>(args: Record<string, any> | null, options: MethodOptions & Omit<ClientOptions, "contractId"> & { address?: string; format?: "hex" | "base64"; salt?: Uint8Array<ArrayBufferLike>; wasmHash: string | Uint8Array<ArrayBufferLike> }): Promise<AssembledTransaction<T>>;
+  static deploy<T = Client>(args: Record<string, any> | null, options: MethodOptions & Omit<ClientOptions, "contractId"> & { salt?: Uint8Array<ArrayBufferLike> | undefined; address?: string | undefined; } & ({ wasmHash: string | Uint8Array<ArrayBufferLike>; format?: "hex" | ... 1 more ... | undefined; externalRef?: undefined; } | { ...; })): Promise<AssembledTransaction<T>>;
   static from<T = unknown>(options: ClientOptions): Promise<Client & T>;
   static fromWasm<T = unknown>(wasm: Uint8Array, options: ClientOptions): Promise<Client & T>;
   static fromWasmHash<T = unknown>(wasmHash: string | Uint8Array<ArrayBufferLike>, options: ClientOptions, format: "hex" | "base64" = "hex"): Promise<Client & T>;
@@ -670,7 +670,7 @@ class Client {
 }
 ```
 
-**Source:** [src/contract/client.ts:39](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L39)
+**Source:** [src/contract/client.ts:25](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L25)
 
 ### `new Client(spec, options)`
 
@@ -683,20 +683,20 @@ constructor(spec: Spec, options: ClientOptions);
 - **`spec`** — `Spec` (required)
 - **`options`** — `ClientOptions` (required)
 
-**Source:** [src/contract/client.ts:96](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L96)
+**Source:** [src/contract/client.ts:134](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L134)
 
 ### `Client.deploy(args, options)`
 
 ```ts
-static deploy<T = Client>(args: Record<string, any> | null, options: MethodOptions & Omit<ClientOptions, "contractId"> & { address?: string; format?: "hex" | "base64"; salt?: Uint8Array<ArrayBufferLike>; wasmHash: string | Uint8Array<ArrayBufferLike> }): Promise<AssembledTransaction<T>>;
+static deploy<T = Client>(args: Record<string, any> | null, options: MethodOptions & Omit<ClientOptions, "contractId"> & { salt?: Uint8Array<ArrayBufferLike> | undefined; address?: string | undefined; } & ({ wasmHash: string | Uint8Array<ArrayBufferLike>; format?: "hex" | ... 1 more ... | undefined; externalRef?: undefined; } | { ...; })): Promise<AssembledTransaction<T>>;
 ```
 
 **Parameters**
 
 - **`args`** — `Record<string, any> | null` (required) — Constructor/Initialization Args for the contract's `__constructor` method
-- **`options`** — `MethodOptions & Omit<ClientOptions, "contractId"> & { address?: string; format?: "hex" | "base64"; salt?: Uint8Array<ArrayBufferLike>; wasmHash: string | Uint8Array<ArrayBufferLike> }` (required) — Options for initializing a Client as well as for calling a method, with extras specific to deploying.
+- **`options`** — `MethodOptions & Omit<ClientOptions, "contractId"> & { salt?: Uint8Array<ArrayBufferLike> | undefined; address?: string | undefined; } & ({ wasmHash: string | Uint8Array<ArrayBufferLike>; format?: "hex" | ... 1 more ... | undefined; externalRef?: undefined; } | { ...; })` (required) — Options for initializing a Client as well as for calling a method, with extras specific to deploying.
 
-**Source:** [src/contract/client.ts:40](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L40)
+**Source:** [src/contract/client.ts:26](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L26)
 
 ### `Client.from(options)`
 
@@ -737,7 +737,7 @@ const client = await contract.Client.from<MyContract>(options);
 const tx = await client.increment(); // typed
 ```
 
-**Source:** [src/contract/client.ts:246](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L246)
+**Source:** [src/contract/client.ts:284](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L284)
 
 ### `Client.fromWasm(wasm, options)`
 
@@ -770,7 +770,7 @@ const client = await contract.Client.fromWasm<MyContract>(wasm, options);
 const tx = await client.increment(); // typed
 ```
 
-**Source:** [src/contract/client.ts:208](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L208)
+**Source:** [src/contract/client.ts:246](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L246)
 
 ### `Client.fromWasmHash(wasmHash, options, format)`
 
@@ -805,7 +805,7 @@ const client = await contract.Client.fromWasmHash<MyContract>(hash, options);
 const tx = await client.increment(); // typed
 ```
 
-**Source:** [src/contract/client.ts:166](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L166)
+**Source:** [src/contract/client.ts:204](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L204)
 
 ### `client.options`
 
@@ -813,7 +813,7 @@ const tx = await client.increment(); // typed
 readonly options: ClientOptions;
 ```
 
-**Source:** [src/contract/client.ts:98](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L98)
+**Source:** [src/contract/client.ts:136](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L136)
 
 ### `client.spec`
 
@@ -821,7 +821,7 @@ readonly options: ClientOptions;
 readonly spec: Spec;
 ```
 
-**Source:** [src/contract/client.ts:97](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L97)
+**Source:** [src/contract/client.ts:135](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L135)
 
 ### `client.txFromJSON`
 
@@ -835,7 +835,7 @@ txFromJSON: <T>(json: string) => AssembledTransaction<T>;
 
 - **`json`** — `string` (required)
 
-**Source:** [src/contract/client.ts:298](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L298)
+**Source:** [src/contract/client.ts:336](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L336)
 
 ### `client.txFromJson(json)`
 
@@ -847,7 +847,7 @@ txFromJson<T>(json: string): AssembledTransaction<T>;
 
 - **`json`** — `string` (required)
 
-**Source:** [src/contract/client.ts:282](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L282)
+**Source:** [src/contract/client.ts:320](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L320)
 
 ### `client.txFromXDR(xdrBase64)`
 
@@ -859,7 +859,7 @@ txFromXDR<T>(xdrBase64: string): AssembledTransaction<T>;
 
 - **`xdrBase64`** — `string` (required)
 
-**Source:** [src/contract/client.ts:300](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L300)
+**Source:** [src/contract/client.ts:338](https://github.com/stellar/js-stellar-sdk/blob/main/src/contract/client.ts#L338)
 
 ## contract.DEFAULT_TIMEOUT
 

--- a/docs/reference/core-transactions.md
+++ b/docs/reference/core-transactions.md
@@ -1137,8 +1137,13 @@ const op = Operation.createClaimableBalance({
 
 ### `Operation.createCustomContract`
 
-Returns an operation that creates a custom WASM contract and atomically
-invokes its constructor.
+Returns an operation that creates a custom contract and atomically invokes
+its constructor.
+
+The contract's executable is either the hash of uploaded WASM (`wasmHash`)
+or a CAP-85 external executable reference (`externalRef`), naming an owner
+contract and the tag under which it publishes the WASM hash. Exactly one of
+the two must be given.
 
 ```ts
 static createCustomContract: (opts: CreateCustomContractOpts) => Operation;
@@ -1147,8 +1152,10 @@ static createCustomContract: (opts: CreateCustomContractOpts) => Operation;
 **Parameters**
 
 - **`opts`** — `CreateCustomContractOpts` (required) — the set of parameters
-    - `address`: the contract uploader address
-    - `wasmHash`: the SHA-256 hash of the contract WASM you're uploading
+    - `address`: the contract deployer address
+    - `wasmHash`: the SHA-256 hash of the contract WASM you're deploying
+    - `externalRef`: an external executable reference to deploy from instead,
+      as either `{owner, tag}` or an `ContractExecutableExternalRef`
     - `constructorArgs`: the optional parameters to pass to the constructor
     - `salt`: an optional, 32-byte salt to distinguish deployment instances
     - `auth`: an optional list outlining the tree of authorizations required for the call
@@ -1156,7 +1163,8 @@ static createCustomContract: (opts: CreateCustomContractOpts) => Operation;
 
 **See also**
 
-- https://soroban.stellar.org/docs/fundamentals-and-concepts/invoking-contracts-with-transactions#function
+- - https://soroban.stellar.org/docs/fundamentals-and-concepts/invoking-contracts-with-transactions#function
+ - https://stellar.org/protocol/cap-85
 
 **Source:** [src/base/operation.ts:483](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operation.ts#L483)
 
@@ -3556,7 +3564,7 @@ new XdrLargeInt('i128', bigi); // if you do
 type AuthFlag = { readonly clawbackEnabled: 8; readonly immutable: 4; readonly required: 1; readonly revocable: 2 }
 ```
 
-**Source:** [src/base/operations/types.ts:445](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L445)
+**Source:** [src/base/operations/types.ts:485](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L485)
 
 ### AuthFlag
 
@@ -3564,7 +3572,7 @@ type AuthFlag = { readonly clawbackEnabled: 8; readonly immutable: 4; readonly r
 type AuthFlag = typeof AuthFlag[keyof typeof AuthFlag]
 ```
 
-**Source:** [src/base/operations/types.ts:445](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L445)
+**Source:** [src/base/operations/types.ts:485](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L485)
 
 ### AuthFlag.clawbackEnabled
 
@@ -3572,7 +3580,7 @@ type AuthFlag = typeof AuthFlag[keyof typeof AuthFlag]
 type clawbackEnabled = 8
 ```
 
-**Source:** [src/base/operations/types.ts:458](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L458)
+**Source:** [src/base/operations/types.ts:498](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L498)
 
 ### AuthFlag.immutable
 
@@ -3580,7 +3588,7 @@ type clawbackEnabled = 8
 type immutable = 4
 ```
 
-**Source:** [src/base/operations/types.ts:457](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L457)
+**Source:** [src/base/operations/types.ts:497](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L497)
 
 ### AuthFlag.required
 
@@ -3588,7 +3596,7 @@ type immutable = 4
 type required = 1
 ```
 
-**Source:** [src/base/operations/types.ts:455](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L455)
+**Source:** [src/base/operations/types.ts:495](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L495)
 
 ### AuthFlag.revocable
 
@@ -3596,7 +3604,7 @@ type required = 1
 type revocable = 2
 ```
 
-**Source:** [src/base/operations/types.ts:456](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L456)
+**Source:** [src/base/operations/types.ts:496](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L496)
 
 ### MemoType
 
@@ -3987,7 +3995,7 @@ type SetTrustLineFlags = SetTrustLineFlagsResult
 type OperationOptions = AccountMergeOpts | AllowTrustOpts | BeginSponsoringFutureReservesOpts | BumpSequenceOpts | ChangeTrustOpts | ClaimClaimableBalanceOpts | ClawbackClaimableBalanceOpts | ClawbackOpts | CreateAccountOpts | CreateClaimableBalanceOpts | CreateCustomContractOpts | CreatePassiveSellOfferOpts | CreateStellarAssetContractOpts | EndSponsoringFutureReservesOpts | ExtendFootprintTtlOpts | InflationOpts | InvokeContractFunctionOpts | InvokeHostFunctionOpts | LiquidityPoolDepositOpts | LiquidityPoolWithdrawOpts | ManageBuyOfferOpts | ManageDataOpts | ManageSellOfferOpts | PathPaymentStrictReceiveOpts | PathPaymentStrictSendOpts | PaymentOpts | RestoreFootprintOpts | RevokeAccountSponsorshipOpts | RevokeClaimableBalanceSponsorshipOpts | RevokeDataSponsorshipOpts | RevokeLiquidityPoolSponsorshipOpts | RevokeOfferSponsorshipOpts | RevokeSignerSponsorshipOpts | RevokeTrustlineSponsorshipOpts | SetOptionsOpts | SetTrustLineFlagsOpts | UploadContractWasmOpts
 ```
 
-**Source:** [src/base/operations/types.ts:325](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L325)
+**Source:** [src/base/operations/types.ts:365](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L365)
 
 ### OperationRecord
 
@@ -3997,7 +4005,7 @@ Union of all possible operation objects returned by Operation.fromXdrObject.
 type OperationRecord = AccountMergeResult | AllowTrustResult | BeginSponsoringFutureReservesResult | BumpSequenceResult | ChangeTrustResult | ClaimClaimableBalanceResult | ClawbackClaimableBalanceResult | ClawbackResult | CreateAccountResult | CreateClaimableBalanceResult | CreatePassiveSellOfferResult | EndSponsoringFutureReservesResult | ExtendFootprintTTLResult | InflationResult | InvokeHostFunctionResult | LiquidityPoolDepositResult | LiquidityPoolWithdrawResult | ManageBuyOfferResult | ManageDataResult | ManageSellOfferResult | PathPaymentStrictReceiveResult | PathPaymentStrictSendResult | PaymentResult | RestoreFootprintResult | RevokeAccountSponsorshipResult | RevokeClaimableBalanceSponsorshipResult | RevokeDataSponsorshipResult | RevokeLiquidityPoolSponsorshipResult | RevokeOfferSponsorshipResult | RevokeSignerSponsorshipResult | RevokeTrustlineSponsorshipResult | SetOptionsResult<SignerOpts> | SetTrustLineFlagsResult
 ```
 
-**Source:** [src/base/operations/types.ts:700](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L700)
+**Source:** [src/base/operations/types.ts:740](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L740)
 
 ### OperationType
 
@@ -4005,7 +4013,7 @@ type OperationRecord = AccountMergeResult | AllowTrustResult | BeginSponsoringFu
 type OperationType = OperationType.AccountMerge | OperationType.AllowTrust | OperationType.BeginSponsoringFutureReserves | OperationType.BumpSequence | OperationType.ChangeTrust | OperationType.ClaimClaimableBalance | OperationType.Clawback | OperationType.ClawbackClaimableBalance | OperationType.CreateAccount | OperationType.CreateClaimableBalance | OperationType.CreatePassiveSellOffer | OperationType.EndSponsoringFutureReserves | OperationType.ExtendFootprintTTL | OperationType.Inflation | OperationType.InvokeHostFunction | OperationType.LiquidityPoolDeposit | OperationType.LiquidityPoolWithdraw | OperationType.ManageBuyOffer | OperationType.ManageData | OperationType.ManageSellOffer | OperationType.PathPaymentStrictReceive | OperationType.PathPaymentStrictSend | OperationType.Payment | OperationType.RestoreFootprint | OperationType.RevokeAccountSponsorship | OperationType.RevokeClaimableBalanceSponsorship | OperationType.RevokeDataSponsorship | OperationType.RevokeLiquidityPoolSponsorship | OperationType.RevokeOfferSponsorship | OperationType.RevokeSignerSponsorship | OperationType.RevokeTrustlineSponsorship | OperationType.SetOptions | OperationType.SetTrustLineFlags
 ```
 
-**Source:** [src/base/operations/types.ts:368](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L368)
+**Source:** [src/base/operations/types.ts:408](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L408)
 
 ### OperationType.AccountMerge
 
@@ -4013,7 +4021,7 @@ type OperationType = OperationType.AccountMerge | OperationType.AllowTrust | Ope
 type AccountMerge = "accountMerge"
 ```
 
-**Source:** [src/base/operations/types.ts:379](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L379)
+**Source:** [src/base/operations/types.ts:419](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L419)
 
 ### OperationType.AllowTrust
 
@@ -4021,7 +4029,7 @@ type AccountMerge = "accountMerge"
 type AllowTrust = "allowTrust"
 ```
 
-**Source:** [src/base/operations/types.ts:378](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L378)
+**Source:** [src/base/operations/types.ts:418](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L418)
 
 ### OperationType.BeginSponsoringFutureReserves
 
@@ -4029,7 +4037,7 @@ type AllowTrust = "allowTrust"
 type BeginSponsoringFutureReserves = "beginSponsoringFutureReserves"
 ```
 
-**Source:** [src/base/operations/types.ts:385](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L385)
+**Source:** [src/base/operations/types.ts:425](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L425)
 
 ### OperationType.BumpSequence
 
@@ -4037,7 +4045,7 @@ type BeginSponsoringFutureReserves = "beginSponsoringFutureReserves"
 type BumpSequence = "bumpSequence"
 ```
 
-**Source:** [src/base/operations/types.ts:382](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L382)
+**Source:** [src/base/operations/types.ts:422](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L422)
 
 ### OperationType.ChangeTrust
 
@@ -4045,7 +4053,7 @@ type BumpSequence = "bumpSequence"
 type ChangeTrust = "changeTrust"
 ```
 
-**Source:** [src/base/operations/types.ts:377](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L377)
+**Source:** [src/base/operations/types.ts:417](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L417)
 
 ### OperationType.ClaimClaimableBalance
 
@@ -4053,7 +4061,7 @@ type ChangeTrust = "changeTrust"
 type ClaimClaimableBalance = "claimClaimableBalance"
 ```
 
-**Source:** [src/base/operations/types.ts:384](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L384)
+**Source:** [src/base/operations/types.ts:424](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L424)
 
 ### OperationType.Clawback
 
@@ -4061,7 +4069,7 @@ type ClaimClaimableBalance = "claimClaimableBalance"
 type Clawback = "clawback"
 ```
 
-**Source:** [src/base/operations/types.ts:397](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L397)
+**Source:** [src/base/operations/types.ts:437](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L437)
 
 ### OperationType.ClawbackClaimableBalance
 
@@ -4069,7 +4077,7 @@ type Clawback = "clawback"
 type ClawbackClaimableBalance = "clawbackClaimableBalance"
 ```
 
-**Source:** [src/base/operations/types.ts:398](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L398)
+**Source:** [src/base/operations/types.ts:438](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L438)
 
 ### OperationType.CreateAccount
 
@@ -4077,7 +4085,7 @@ type ClawbackClaimableBalance = "clawbackClaimableBalance"
 type CreateAccount = "createAccount"
 ```
 
-**Source:** [src/base/operations/types.ts:369](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L369)
+**Source:** [src/base/operations/types.ts:409](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L409)
 
 ### OperationType.CreateClaimableBalance
 
@@ -4085,7 +4093,7 @@ type CreateAccount = "createAccount"
 type CreateClaimableBalance = "createClaimableBalance"
 ```
 
-**Source:** [src/base/operations/types.ts:383](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L383)
+**Source:** [src/base/operations/types.ts:423](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L423)
 
 ### OperationType.CreatePassiveSellOffer
 
@@ -4093,7 +4101,7 @@ type CreateClaimableBalance = "createClaimableBalance"
 type CreatePassiveSellOffer = "createPassiveSellOffer"
 ```
 
-**Source:** [src/base/operations/types.ts:373](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L373)
+**Source:** [src/base/operations/types.ts:413](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L413)
 
 ### OperationType.EndSponsoringFutureReserves
 
@@ -4101,7 +4109,7 @@ type CreatePassiveSellOffer = "createPassiveSellOffer"
 type EndSponsoringFutureReserves = "endSponsoringFutureReserves"
 ```
 
-**Source:** [src/base/operations/types.ts:386](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L386)
+**Source:** [src/base/operations/types.ts:426](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L426)
 
 ### OperationType.ExtendFootprintTTL
 
@@ -4109,7 +4117,7 @@ type EndSponsoringFutureReserves = "endSponsoringFutureReserves"
 type ExtendFootprintTTL = "extendFootprintTtl"
 ```
 
-**Source:** [src/base/operations/types.ts:403](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L403)
+**Source:** [src/base/operations/types.ts:443](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L443)
 
 ### OperationType.Inflation
 
@@ -4117,7 +4125,7 @@ type ExtendFootprintTTL = "extendFootprintTtl"
 type Inflation = "inflation"
 ```
 
-**Source:** [src/base/operations/types.ts:380](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L380)
+**Source:** [src/base/operations/types.ts:420](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L420)
 
 ### OperationType.InvokeHostFunction
 
@@ -4125,7 +4133,7 @@ type Inflation = "inflation"
 type InvokeHostFunction = "invokeHostFunction"
 ```
 
-**Source:** [src/base/operations/types.ts:402](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L402)
+**Source:** [src/base/operations/types.ts:442](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L442)
 
 ### OperationType.LiquidityPoolDeposit
 
@@ -4133,7 +4141,7 @@ type InvokeHostFunction = "invokeHostFunction"
 type LiquidityPoolDeposit = "liquidityPoolDeposit"
 ```
 
-**Source:** [src/base/operations/types.ts:400](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L400)
+**Source:** [src/base/operations/types.ts:440](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L440)
 
 ### OperationType.LiquidityPoolWithdraw
 
@@ -4141,7 +4149,7 @@ type LiquidityPoolDeposit = "liquidityPoolDeposit"
 type LiquidityPoolWithdraw = "liquidityPoolWithdraw"
 ```
 
-**Source:** [src/base/operations/types.ts:401](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L401)
+**Source:** [src/base/operations/types.ts:441](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L441)
 
 ### OperationType.ManageBuyOffer
 
@@ -4149,7 +4157,7 @@ type LiquidityPoolWithdraw = "liquidityPoolWithdraw"
 type ManageBuyOffer = "manageBuyOffer"
 ```
 
-**Source:** [src/base/operations/types.ts:375](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L375)
+**Source:** [src/base/operations/types.ts:415](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L415)
 
 ### OperationType.ManageData
 
@@ -4157,7 +4165,7 @@ type ManageBuyOffer = "manageBuyOffer"
 type ManageData = "manageData"
 ```
 
-**Source:** [src/base/operations/types.ts:381](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L381)
+**Source:** [src/base/operations/types.ts:421](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L421)
 
 ### OperationType.ManageSellOffer
 
@@ -4165,7 +4173,7 @@ type ManageData = "manageData"
 type ManageSellOffer = "manageSellOffer"
 ```
 
-**Source:** [src/base/operations/types.ts:374](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L374)
+**Source:** [src/base/operations/types.ts:414](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L414)
 
 ### OperationType.PathPaymentStrictReceive
 
@@ -4173,7 +4181,7 @@ type ManageSellOffer = "manageSellOffer"
 type PathPaymentStrictReceive = "pathPaymentStrictReceive"
 ```
 
-**Source:** [src/base/operations/types.ts:371](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L371)
+**Source:** [src/base/operations/types.ts:411](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L411)
 
 ### OperationType.PathPaymentStrictSend
 
@@ -4181,7 +4189,7 @@ type PathPaymentStrictReceive = "pathPaymentStrictReceive"
 type PathPaymentStrictSend = "pathPaymentStrictSend"
 ```
 
-**Source:** [src/base/operations/types.ts:372](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L372)
+**Source:** [src/base/operations/types.ts:412](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L412)
 
 ### OperationType.Payment
 
@@ -4189,7 +4197,7 @@ type PathPaymentStrictSend = "pathPaymentStrictSend"
 type Payment = "payment"
 ```
 
-**Source:** [src/base/operations/types.ts:370](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L370)
+**Source:** [src/base/operations/types.ts:410](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L410)
 
 ### OperationType.RestoreFootprint
 
@@ -4197,7 +4205,7 @@ type Payment = "payment"
 type RestoreFootprint = "restoreFootprint"
 ```
 
-**Source:** [src/base/operations/types.ts:404](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L404)
+**Source:** [src/base/operations/types.ts:444](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L444)
 
 ### OperationType.RevokeAccountSponsorship
 
@@ -4205,7 +4213,7 @@ type RestoreFootprint = "restoreFootprint"
 type RevokeAccountSponsorship = "revokeAccountSponsorship"
 ```
 
-**Source:** [src/base/operations/types.ts:389](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L389)
+**Source:** [src/base/operations/types.ts:429](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L429)
 
 ### OperationType.RevokeClaimableBalanceSponsorship
 
@@ -4213,7 +4221,7 @@ type RevokeAccountSponsorship = "revokeAccountSponsorship"
 type RevokeClaimableBalanceSponsorship = "revokeClaimableBalanceSponsorship"
 ```
 
-**Source:** [src/base/operations/types.ts:393](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L393)
+**Source:** [src/base/operations/types.ts:433](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L433)
 
 ### OperationType.RevokeDataSponsorship
 
@@ -4221,7 +4229,7 @@ type RevokeClaimableBalanceSponsorship = "revokeClaimableBalanceSponsorship"
 type RevokeDataSponsorship = "revokeDataSponsorship"
 ```
 
-**Source:** [src/base/operations/types.ts:392](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L392)
+**Source:** [src/base/operations/types.ts:432](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L432)
 
 ### OperationType.RevokeLiquidityPoolSponsorship
 
@@ -4229,7 +4237,7 @@ type RevokeDataSponsorship = "revokeDataSponsorship"
 type RevokeLiquidityPoolSponsorship = "revokeLiquidityPoolSponsorship"
 ```
 
-**Source:** [src/base/operations/types.ts:395](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L395)
+**Source:** [src/base/operations/types.ts:435](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L435)
 
 ### OperationType.RevokeOfferSponsorship
 
@@ -4237,7 +4245,7 @@ type RevokeLiquidityPoolSponsorship = "revokeLiquidityPoolSponsorship"
 type RevokeOfferSponsorship = "revokeOfferSponsorship"
 ```
 
-**Source:** [src/base/operations/types.ts:391](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L391)
+**Source:** [src/base/operations/types.ts:431](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L431)
 
 ### OperationType.RevokeSignerSponsorship
 
@@ -4245,7 +4253,7 @@ type RevokeOfferSponsorship = "revokeOfferSponsorship"
 type RevokeSignerSponsorship = "revokeSignerSponsorship"
 ```
 
-**Source:** [src/base/operations/types.ts:396](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L396)
+**Source:** [src/base/operations/types.ts:436](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L436)
 
 ### OperationType.RevokeSponsorship
 
@@ -4255,7 +4263,7 @@ type RevokeSignerSponsorship = "revokeSignerSponsorship"
 type RevokeSponsorship = "revokeSponsorship"
 ```
 
-**Source:** [src/base/operations/types.ts:388](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L388)
+**Source:** [src/base/operations/types.ts:428](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L428)
 
 ### OperationType.RevokeTrustlineSponsorship
 
@@ -4263,7 +4271,7 @@ type RevokeSponsorship = "revokeSponsorship"
 type RevokeTrustlineSponsorship = "revokeTrustlineSponsorship"
 ```
 
-**Source:** [src/base/operations/types.ts:390](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L390)
+**Source:** [src/base/operations/types.ts:430](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L430)
 
 ### OperationType.SetOptions
 
@@ -4271,7 +4279,7 @@ type RevokeTrustlineSponsorship = "revokeTrustlineSponsorship"
 type SetOptions = "setOptions"
 ```
 
-**Source:** [src/base/operations/types.ts:376](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L376)
+**Source:** [src/base/operations/types.ts:416](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L416)
 
 ### OperationType.SetTrustLineFlags
 
@@ -4279,7 +4287,7 @@ type SetOptions = "setOptions"
 type SetTrustLineFlags = "setTrustLineFlags"
 ```
 
-**Source:** [src/base/operations/types.ts:399](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L399)
+**Source:** [src/base/operations/types.ts:439](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L439)
 
 ### ScIntType
 
@@ -4295,7 +4303,7 @@ type ScIntType = "duration" | "i64" | "i128" | "i256" | "timepoint" | "u64" | "u
 type Signer = Signer.Ed25519PublicKey | Signer.Ed25519SignedPayload | Signer.PreAuthTx | Signer.Sha256Hash
 ```
 
-**Source:** [src/base/operations/types.ts:476](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L476)
+**Source:** [src/base/operations/types.ts:516](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L516)
 
 ### Signer.Ed25519PublicKey
 
@@ -4306,7 +4314,7 @@ interface Ed25519PublicKey {
 }
 ```
 
-**Source:** [src/base/operations/types.ts:477](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L477)
+**Source:** [src/base/operations/types.ts:517](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L517)
 
 #### `ed25519PublicKey.ed25519PublicKey`
 
@@ -4314,7 +4322,7 @@ interface Ed25519PublicKey {
 ed25519PublicKey: string;
 ```
 
-**Source:** [src/base/operations/types.ts:478](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L478)
+**Source:** [src/base/operations/types.ts:518](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L518)
 
 #### `ed25519PublicKey.weight`
 
@@ -4322,7 +4330,7 @@ ed25519PublicKey: string;
 weight?: number;
 ```
 
-**Source:** [src/base/operations/types.ts:479](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L479)
+**Source:** [src/base/operations/types.ts:519](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L519)
 
 ### Signer.Ed25519SignedPayload
 
@@ -4333,7 +4341,7 @@ interface Ed25519SignedPayload {
 }
 ```
 
-**Source:** [src/base/operations/types.ts:489](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L489)
+**Source:** [src/base/operations/types.ts:529](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L529)
 
 #### `ed25519SignedPayload.ed25519SignedPayload`
 
@@ -4341,7 +4349,7 @@ interface Ed25519SignedPayload {
 ed25519SignedPayload: string;
 ```
 
-**Source:** [src/base/operations/types.ts:490](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L490)
+**Source:** [src/base/operations/types.ts:530](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L530)
 
 #### `ed25519SignedPayload.weight`
 
@@ -4349,7 +4357,7 @@ ed25519SignedPayload: string;
 weight?: number;
 ```
 
-**Source:** [src/base/operations/types.ts:491](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L491)
+**Source:** [src/base/operations/types.ts:531](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L531)
 
 ### Signer.PreAuthTx
 
@@ -4360,7 +4368,7 @@ interface PreAuthTx {
 }
 ```
 
-**Source:** [src/base/operations/types.ts:485](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L485)
+**Source:** [src/base/operations/types.ts:525](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L525)
 
 #### `preAuthTx.preAuthTx`
 
@@ -4368,7 +4376,7 @@ interface PreAuthTx {
 preAuthTx: Uint8Array;
 ```
 
-**Source:** [src/base/operations/types.ts:486](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L486)
+**Source:** [src/base/operations/types.ts:526](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L526)
 
 #### `preAuthTx.weight`
 
@@ -4376,7 +4384,7 @@ preAuthTx: Uint8Array;
 weight?: number;
 ```
 
-**Source:** [src/base/operations/types.ts:487](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L487)
+**Source:** [src/base/operations/types.ts:527](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L527)
 
 ### Signer.Sha256Hash
 
@@ -4387,7 +4395,7 @@ interface Sha256Hash {
 }
 ```
 
-**Source:** [src/base/operations/types.ts:481](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L481)
+**Source:** [src/base/operations/types.ts:521](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L521)
 
 #### `sha256Hash.sha256Hash`
 
@@ -4395,7 +4403,7 @@ interface Sha256Hash {
 sha256Hash: Uint8Array;
 ```
 
-**Source:** [src/base/operations/types.ts:482](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L482)
+**Source:** [src/base/operations/types.ts:522](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L522)
 
 #### `sha256Hash.weight`
 
@@ -4403,7 +4411,7 @@ sha256Hash: Uint8Array;
 weight?: number;
 ```
 
-**Source:** [src/base/operations/types.ts:483](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L483)
+**Source:** [src/base/operations/types.ts:523](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L523)
 
 ### SorobanFees
 
@@ -4526,7 +4534,7 @@ sequenceNumber(): string;
 type TrustLineFlag = TrustLineFlag.authorize | TrustLineFlag.authorizeToMaintainLiabilities | TrustLineFlag.deauthorize
 ```
 
-**Source:** [src/base/operations/types.ts:465](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L465)
+**Source:** [src/base/operations/types.ts:505](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L505)
 
 ### TrustLineFlag.authorize
 
@@ -4534,7 +4542,7 @@ type TrustLineFlag = TrustLineFlag.authorize | TrustLineFlag.authorizeToMaintain
 type authorize = 1
 ```
 
-**Source:** [src/base/operations/types.ts:467](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L467)
+**Source:** [src/base/operations/types.ts:507](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L507)
 
 ### TrustLineFlag.authorizeToMaintainLiabilities
 
@@ -4542,7 +4550,7 @@ type authorize = 1
 type authorizeToMaintainLiabilities = 2
 ```
 
-**Source:** [src/base/operations/types.ts:468](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L468)
+**Source:** [src/base/operations/types.ts:508](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L508)
 
 ### TrustLineFlag.deauthorize
 
@@ -4550,4 +4558,4 @@ type authorizeToMaintainLiabilities = 2
 type deauthorize = 0
 ```
 
-**Source:** [src/base/operations/types.ts:466](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L466)
+**Source:** [src/base/operations/types.ts:506](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L506)

--- a/docs/reference/core-transactions.md
+++ b/docs/reference/core-transactions.md
@@ -3606,6 +3606,20 @@ type revocable = 2
 
 **Source:** [src/base/operations/types.ts:496](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L496)
 
+### ExternalExecutableRef
+
+A CAP-85 external executable reference: the contract that owns the
+executable plus the owner-scoped tag naming it. The tag is an unbounded
+`SCString` and may be binary, so it is accepted as raw bytes as well as
+text. An `ContractExecutableExternalRef` (e.g. pulled from an
+existing contract instance) is accepted directly.
+
+```ts
+type ExternalExecutableRef = ContractExecutableExternalRef | { owner: Address | string; tag: string | Uint8Array }
+```
+
+**Source:** [src/base/operations/types.ts:277](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/operations/types.ts#L277)
+
 ### MemoType
 
 ```ts

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -42,6 +42,7 @@ export {
 } from "./operation.js";
 export type {
   AuthFlag,
+  ExternalExecutableRef,
   TrustLineFlag,
   OperationOptions,
   OperationType,

--- a/src/base/operations/index.ts
+++ b/src/base/operations/index.ts
@@ -41,6 +41,7 @@ export { extendFootprintTtl } from "./extend_footprint_ttl.js";
 export { restoreFootprint } from "./restore_footprint.js";
 export type {
   AuthFlag,
+  ExternalExecutableRef,
   TrustLineFlag,
   OperationOptions,
   OperationType,

--- a/src/base/operations/invoke_host_function.ts
+++ b/src/base/operations/invoke_host_function.ts
@@ -157,7 +157,7 @@ export function createCustomContract(
   if (opts.externalRef !== undefined) {
     if (opts.wasmHash !== undefined) {
       throw new TypeError(
-        `'opts.wasmHash' and 'opts.externalRef' are mutually exclusive`,
+        `Must provide only one of: 'opts.wasmHash' or 'opts.externalRef'`,
       );
     }
 

--- a/src/base/operations/invoke_host_function.ts
+++ b/src/base/operations/invoke_host_function.ts
@@ -1,5 +1,6 @@
 import {
   ContractExecutable,
+  ContractExecutableExternalRef,
   ContractIdPreimage,
   ContractIdPreimageFromAddress,
   CreateContractArgs,
@@ -126,28 +127,69 @@ export function invokeContractFunction(
 }
 
 /**
- * Returns an operation that creates a custom WASM contract and atomically
- * invokes its constructor.
+ * Returns an operation that creates a custom contract and atomically invokes
+ * its constructor.
  *
+ * The contract's executable is either the hash of uploaded WASM (`wasmHash`)
+ * or a CAP-85 external executable reference (`externalRef`), naming an owner
+ * contract and the tag under which it publishes the WASM hash. Exactly one of
+ * the two must be given.
  *
  * @param opts - the set of parameters
- *   - `address`: the contract uploader address
- *   - `wasmHash`: the SHA-256 hash of the contract WASM you're uploading
+ *   - `address`: the contract deployer address
+ *   - `wasmHash`: the SHA-256 hash of the contract WASM you're deploying
+ *   - `externalRef`: an external executable reference to deploy from instead,
+ *     as either `{owner, tag}` or an {@link ContractExecutableExternalRef}
  *   - `constructorArgs`: the optional parameters to pass to the constructor
  *   - `salt`: an optional, 32-byte salt to distinguish deployment instances
  *   - `auth`: an optional list outlining the tree of authorizations required for the call
  *   - `source`: an optional source account
  *
  * @see https://soroban.stellar.org/docs/fundamentals-and-concepts/invoking-contracts-with-transactions#function
+ * @see https://stellar.org/protocol/cap-85
  */
 export function createCustomContract(
   opts: CreateCustomContractOpts,
 ): Operation {
   const salt = Uint8Array.from(opts.salt || getSalty());
 
-  if (!opts.wasmHash || opts.wasmHash.length !== 32) {
-    throw new TypeError(
-      `expected hash(contract WASM) in 'opts.wasmHash', got ${String(opts.wasmHash)}`,
+  let executable: ContractExecutable;
+  if (opts.externalRef !== undefined) {
+    if (opts.wasmHash !== undefined) {
+      throw new TypeError(
+        `'opts.wasmHash' and 'opts.externalRef' are mutually exclusive`,
+      );
+    }
+
+    let ref = opts.externalRef;
+    if (!(ref instanceof ContractExecutableExternalRef)) {
+      const owner =
+        ref.owner instanceof Address ? ref.owner : new Address(ref.owner);
+      ref = new ContractExecutableExternalRef({
+        executableOwner: owner.toScAddress(),
+        tag: ref.tag,
+      });
+    }
+
+    // Only a contract can hold the persistent tag entry that names the WASM,
+    // so any other owner is unresolvable and the deploy would fail on-chain.
+    if (ref.executableOwner.type !== "scAddressTypeContract") {
+      throw new TypeError(
+        `expected contract address in 'opts.externalRef.owner', got ` +
+          Address.fromScAddress(ref.executableOwner).toString(),
+      );
+    }
+
+    executable = ContractExecutable.contractExecutableExternalRef(ref);
+  } else {
+    if (!opts.wasmHash || opts.wasmHash.length !== 32) {
+      throw new TypeError(
+        `expected hash(contract WASM) in 'opts.wasmHash', got ${String(opts.wasmHash)}`,
+      );
+    }
+
+    executable = ContractExecutable.contractExecutableWasm(
+      new Hash(Uint8Array.from(opts.wasmHash)),
     );
   }
 
@@ -160,9 +202,7 @@ export function createCustomContract(
   return invokeHostFunction({
     func: HostFunction.hostFunctionTypeCreateContractV2(
       new CreateContractArgsV2({
-        executable: ContractExecutable.contractExecutableWasm(
-          new Hash(Uint8Array.from(opts.wasmHash)),
-        ),
+        executable,
         contractIdPreimage: ContractIdPreimage.contractIdPreimageFromAddress(
           new ContractIdPreimageFromAddress({
             address: opts.address.toScAddress(),

--- a/src/base/operations/types.ts
+++ b/src/base/operations/types.ts
@@ -281,20 +281,36 @@ export type ExternalExecutableRef =
       tag: string | Uint8Array;
     };
 
+/**
+ * Parameters shared by every {@link Operation.createCustomContract} call,
+ * regardless of which executable the contract deploys from.
+ */
 interface CreateCustomContractBaseOpts {
+  /** the contract deployer address, which (with the salt) derives the new contract's ID */
   address: Address;
+  /** the optional parameters to pass to the constructor */
   constructorArgs?: ScVal[];
+  /** an optional, 32-byte salt to distinguish deployment instances */
   salt?: Uint8Array;
+  /** an optional list outlining the tree of authorizations required for the call */
   auth?: SorobanAuthorizationEntry[];
+  /** an optional source account */
   source?: string;
 }
 
+/**
+ * Options for {@link Operation.createCustomContract}: the shared parameters
+ * plus exactly one executable — the SHA-256 hash of uploaded contract WASM
+ * (`wasmHash`), or a CAP-85 external executable reference (`externalRef`).
+ */
 export type CreateCustomContractOpts =
   | (CreateCustomContractBaseOpts & {
+      /** the SHA-256 hash of the contract WASM you're deploying */
       wasmHash: Uint8Array;
       externalRef?: never;
     })
   | (CreateCustomContractBaseOpts & {
+      /** an external executable reference to deploy from instead of a WASM hash */
       externalRef: ExternalExecutableRef;
       wasmHash?: never;
     });

--- a/src/base/operations/types.ts
+++ b/src/base/operations/types.ts
@@ -4,6 +4,7 @@ import { Claimant } from "../claimant.js";
 import { LiquidityPoolAsset } from "../liquidity_pool_asset.js";
 import { LiquidityPoolId } from "../liquidity_pool_id.js";
 import {
+  ContractExecutableExternalRef,
   HostFunction,
   MuxedAccount,
   OperationBody,
@@ -266,14 +267,37 @@ export interface InvokeContractFunctionOpts {
   source?: string;
 }
 
-export interface CreateCustomContractOpts {
+/**
+ * A CAP-85 external executable reference: the contract that owns the
+ * executable plus the owner-scoped tag naming it. The tag is an unbounded
+ * `SCString` and may be binary, so it is accepted as raw bytes as well as
+ * text. An {@link ContractExecutableExternalRef} (e.g. pulled from an
+ * existing contract instance) is accepted directly.
+ */
+export type ExternalExecutableRef =
+  | ContractExecutableExternalRef
+  | {
+      owner: Address | string;
+      tag: string | Uint8Array;
+    };
+
+interface CreateCustomContractBaseOpts {
   address: Address;
-  wasmHash: Uint8Array;
   constructorArgs?: ScVal[];
   salt?: Uint8Array;
   auth?: SorobanAuthorizationEntry[];
   source?: string;
 }
+
+export type CreateCustomContractOpts =
+  | (CreateCustomContractBaseOpts & {
+      wasmHash: Uint8Array;
+      externalRef?: never;
+    })
+  | (CreateCustomContractBaseOpts & {
+      externalRef: ExternalExecutableRef;
+      wasmHash?: never;
+    });
 
 export interface CreateStellarAssetContractOpts {
   asset: Asset | string;

--- a/src/bindings/client.ts
+++ b/src/bindings/client.ts
@@ -141,6 +141,7 @@ ${eventMethods}
         "Client as ContractClient",
         "ClientOptions as ContractClientOptions",
         "MethodOptions",
+        "ExternalExecutableRef",
       ],
     });
   }
@@ -405,7 +406,7 @@ ${eventMethods}
     }
 
     params.push(
-      'options: MethodOptions & Omit<ContractClientOptions, \'contractId\'> & { wasmHash: Uint8Array | string; salt?: Uint8Array; format?: "hex" | "base64"; address?: string; }',
+      `options: MethodOptions & Omit<ContractClientOptions, 'contractId'> & { salt?: Uint8Array; address?: string; } & ({ wasmHash: Uint8Array | string; format?: "hex" | "base64"; externalRef?: never; } | { externalRef: ExternalExecutableRef; wasmHash?: never; format?: never; })`,
     );
 
     return params.join(", ");

--- a/src/contract/client.ts
+++ b/src/contract/client.ts
@@ -1,28 +1,14 @@
 import { Operation, Address } from "../base/index.js";
+import type { ExternalExecutableRef } from "../base/operations/types.js";
 import { Spec } from "./spec.js";
 import { Server } from "../rpc/index.js";
 import { AssembledTransaction } from "./assembled_transaction.js";
 import type { ClientOptions, MethodOptions } from "./types.js";
 import { sanitizeIdentifier } from "../bindings/utils.js";
-import { ScVal } from "../xdr/index.js";
+import { ContractExecutableExternalRef, ScVal } from "../xdr/index.js";
 import { base64ToUint8Array, hexToUint8Array } from "uint8array-extras";
 
 const CONSTRUCTOR_FUNC = "__constructor";
-
-async function specFromWasmHash(
-  wasmHash: Uint8Array | string,
-  options: Server.Options & { rpcUrl: string },
-  format: "hex" | "base64" = "hex",
-): Promise<Spec> {
-  if (!options || !options.rpcUrl) {
-    throw new TypeError("options must contain rpcUrl");
-  }
-  const { rpcUrl, allowHttp, headers } = options;
-  const serverOpts: Server.Options = { allowHttp, headers };
-  const server = new Server(rpcUrl, serverOpts);
-  const wasm = await server.getContractWasmByHash(wasmHash, format);
-  return Spec.fromWasm(wasm);
-}
 
 /**
  * Generate a class from the contract spec that where each contract method
@@ -43,18 +29,35 @@ export class Client {
     /** Options for initializing a Client as well as for calling a method, with extras specific to deploying. */
     options: MethodOptions &
       Omit<ClientOptions, "contractId"> & {
-        /** The hash of the Wasm blob, which must already be installed on-chain. */
-        wasmHash: Uint8Array | string;
         /** Salt used to generate the contract's ID. Passed through to {@link Operation.createCustomContract}. Default: random. */
         salt?: Uint8Array;
-        /** The format used to decode `wasmHash`, if it's provided as a string. */
-        format?: "hex" | "base64";
         /** The address to use to deploy the custom contract */
         address?: string;
-      },
+      } & (
+        | {
+            /** The hash of the Wasm blob, which must already be installed on-chain. */
+            wasmHash: Uint8Array | string;
+            /** The format used to decode `wasmHash`, if it's provided as a string. */
+            format?: "hex" | "base64";
+            externalRef?: never;
+          }
+        | {
+            /**
+             * A CAP-85 external executable reference to deploy from instead of
+             * a Wasm hash: the owner contract plus the tag under which it
+             * publishes the Wasm hash. Passed through to
+             * {@link Operation.createCustomContract}; the reference is also
+             * resolved on-chain here to fetch the contract's spec.
+             */
+            externalRef: ExternalExecutableRef;
+            wasmHash?: never;
+            format?: never;
+          }
+      ),
   ): Promise<AssembledTransaction<T>> {
     const {
       wasmHash,
+      externalRef,
       salt,
       format,
       fee,
@@ -62,16 +65,51 @@ export class Client {
       simulate,
       ...clientOptions
     } = options;
-    const spec = await specFromWasmHash(wasmHash, clientOptions, format);
 
-    const operation = Operation.createCustomContract({
-      address: new Address(options.address || options.publicKey!),
-      wasmHash:
+    if (!clientOptions.rpcUrl) {
+      throw new TypeError("options must contain rpcUrl");
+    }
+    const { rpcUrl, allowHttp, headers } = clientOptions;
+    const server =
+      clientOptions.server ?? new Server(rpcUrl, { allowHttp, headers });
+
+    // The operation deploys either from a Wasm hash or from an external ref,
+    // but the constructor's spec always has to be read from actual Wasm: an
+    // external ref is resolved to the Wasm hash it currently names.
+    let executableOpts:
+      | { wasmHash: Uint8Array }
+      | { externalRef: ContractExecutableExternalRef };
+    let specWasmHash: Uint8Array;
+    if (externalRef !== undefined) {
+      const ref =
+        externalRef instanceof ContractExecutableExternalRef
+          ? externalRef
+          : new ContractExecutableExternalRef({
+              executableOwner: (externalRef.owner instanceof Address
+                ? externalRef.owner
+                : new Address(externalRef.owner)
+              ).toScAddress(),
+              tag: externalRef.tag,
+            });
+      specWasmHash = await server.getExternalRefWasmHash(ref);
+      executableOpts = { externalRef: ref };
+    } else {
+      specWasmHash =
         typeof wasmHash === "string"
           ? (format ?? "hex") === "base64"
             ? base64ToUint8Array(wasmHash)
             : hexToUint8Array(wasmHash)
-          : wasmHash,
+          : wasmHash!;
+      executableOpts = { wasmHash: specWasmHash };
+    }
+
+    const spec = Spec.fromWasm(
+      await server.getContractWasmByHash(specWasmHash),
+    );
+
+    const operation = Operation.createCustomContract({
+      address: new Address(options.address || options.publicKey!),
+      ...executableOpts,
       salt,
       constructorArgs: args
         ? spec.funcArgsToScVals(CONSTRUCTOR_FUNC, args)

--- a/src/contract/index.ts
+++ b/src/contract/index.ts
@@ -1,4 +1,7 @@
 export * from "./assembled_transaction.js";
+// Re-exported for generated bindings, whose `deploy` method references it and
+// which already import from `@stellar/stellar-sdk/contract`.
+export type { ExternalExecutableRef } from "../base/operations/types.js";
 export * from "./basic_node_signer.js";
 export * from "./client.js";
 export type { ParsedEvent } from "./event_spec.js";

--- a/test/e2e/src/__snapshots__/bindings.test.ts.snap
+++ b/test/e2e/src/__snapshots__/bindings.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Bindings Snapshot Test > generates bindings that match snapshot for custom-types contract > custom-types-client.ts 1`] = `
 "import {RoyalCard, SimpleEnum, Test, ComplexEnum, TupleStruct, RecursiveEnum, ContractEvent} from './types.js';
-import {Result, Spec, AssembledTransaction, Client as ContractClient, ClientOptions as ContractClientOptions, MethodOptions} from '@stellar/stellar-sdk/contract';
+import {Result, Spec, AssembledTransaction, Client as ContractClient, ClientOptions as ContractClientOptions, MethodOptions, ExternalExecutableRef} from '@stellar/stellar-sdk/contract';
 import {xdr, Address} from '@stellar/stellar-sdk';
 
 export interface Client {
@@ -62,7 +62,7 @@ export class Client extends ContractClient {
     );
   }
 
-   static deploy<T = Client>(options: MethodOptions & Omit<ContractClientOptions, 'contractId'> & { wasmHash: Uint8Array | string; salt?: Uint8Array; format?: "hex" | "base64"; address?: string; }): Promise<AssembledTransaction<T>> {
+   static deploy<T = Client>(options: MethodOptions & Omit<ContractClientOptions, 'contractId'> & { salt?: Uint8Array; address?: string; } & ({ wasmHash: Uint8Array | string; format?: "hex" | "base64"; externalRef?: never; } | { externalRef: ExternalExecutableRef; wasmHash?: never; format?: never; })): Promise<AssembledTransaction<T>> {
     return ContractClient.deploy(null, options);
   }
   public readonly fromJson = {

--- a/test/unit/base/operations/invoke_host_function.test.ts
+++ b/test/unit/base/operations/invoke_host_function.test.ts
@@ -91,6 +91,107 @@ describe("Operation", () => {
         expect(expectDefined(decodedOp.auth)).toHaveLength(0);
       });
 
+      describe("lets you create contracts from an external executable ref", () => {
+        const ownerId =
+          "CCJZ5DGASBWQXR5MPFCJXMBI333XE5U3FSJTNQU7RIKE3P5GN2K2WYD5";
+
+        const cases: [string, Address | string, string | Uint8Array][] = [
+          ["a strkey owner and text tag", ownerId, "my-executable"],
+          [
+            "an Address owner and text tag",
+            new Address(ownerId),
+            "my-executable",
+          ],
+          [
+            "a binary tag",
+            ownerId,
+            Uint8Array.from([0xc0, 0xff, 0xee, 0x00, 0x01]),
+          ],
+        ];
+
+        cases.forEach(([label, owner, tag]) => {
+          it(`with ${label}`, () => {
+            const h = hash("random stuff");
+            const op = Operation.createCustomContract({
+              address: c.address(),
+              externalRef: { owner, tag },
+              salt: h,
+            });
+            expect(op.body.type).toBe("invokeHostFunction");
+
+            // round trip back
+            const hex = op.toXdr("hex");
+            const xdrOp = xdr.Operation.fromXdr(hex, "hex");
+            const decodedOp = expectOperationType(
+              Operation.fromXdrObject(xdrOp),
+              "invokeHostFunction",
+            );
+            const ref = expectVariant(
+              expectVariant(decodedOp.func, "hostFunctionTypeCreateContractV2")
+                .createContractV2.executable,
+              "contractExecutableExternalRef",
+            ).externalRef;
+
+            expect(Address.fromScAddress(ref.executableOwner).toString()).toBe(
+              ownerId,
+            );
+            if (typeof tag === "string") {
+              expect(ref.tag.toStringStrict()).toBe(tag);
+            } else {
+              expect(Array.from(ref.tag.bytes)).toEqual(Array.from(tag));
+            }
+          });
+        });
+
+        it("accepts a ContractExecutableExternalRef directly", () => {
+          const ref = new xdr.ContractExecutableExternalRef({
+            executableOwner: new Address(ownerId).toScAddress(),
+            tag: "my-executable",
+          });
+          const op = Operation.createCustomContract({
+            address: c.address(),
+            externalRef: ref,
+            salt: hash("random stuff"),
+          });
+
+          const decodedOp = expectOperationType(
+            Operation.fromXdrObject(xdr.Operation.fromXdr(op.toXdr())),
+            "invokeHostFunction",
+          );
+          const decodedRef = expectVariant(
+            expectVariant(decodedOp.func, "hostFunctionTypeCreateContractV2")
+              .createContractV2.executable,
+            "contractExecutableExternalRef",
+          ).externalRef;
+          expect(decodedRef.tag.toStringStrict()).toBe("my-executable");
+        });
+
+        it("throws when both wasmHash and externalRef are given", () => {
+          expect(() =>
+            Operation.createCustomContract({
+              address: c.address(),
+              wasmHash: hash("random stuff"),
+              externalRef: { owner: ownerId, tag: "my-executable" },
+            } as unknown as Parameters<
+              typeof Operation.createCustomContract
+            >[0]),
+          ).toThrow(/mutually exclusive/);
+        });
+
+        it("throws when the owner is not a contract", () => {
+          expect(() =>
+            Operation.createCustomContract({
+              address: c.address(),
+              externalRef: {
+                owner:
+                  "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ",
+                tag: "my-executable",
+              },
+            }),
+          ).toThrow(/expected contract address/);
+        });
+      });
+
       describe("lets you wrap tokens", () => {
         [
           "USD:GCP2QKBFLLEEWYVKAIXIJIJNCZ6XEBIE4PCDB6BF3GUB6FGE2RQ3HDVP",

--- a/test/unit/base/operations/invoke_host_function.test.ts
+++ b/test/unit/base/operations/invoke_host_function.test.ts
@@ -175,7 +175,7 @@ describe("Operation", () => {
             } as unknown as Parameters<
               typeof Operation.createCustomContract
             >[0]),
-          ).toThrow(/mutually exclusive/);
+          ).toThrow(/Must provide only one of/);
         });
 
         it("throws when the owner is not a contract", () => {

--- a/test/unit/contract/client_deploy.test.ts
+++ b/test/unit/contract/client_deploy.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, beforeEach, expect, vi } from "vitest";
+import * as StellarSdk from "../../../src/index.js";
+
+import { serverUrl } from "../../constants.js";
+import { wasmWithSpec } from "./support/wasm.js";
+import { expectOperationType } from "../base/support/operation.js";
+import { expectVariant } from "../base/support/xdr.js";
+
+const { xdr, hash, Contract, rpc, Address } = StellarSdk;
+const { Client } = StellarSdk.contract;
+const { Server } = rpc;
+
+const networkPassphrase = "Test SDF Network ; September 2015";
+
+describe("contract.Client.deploy", () => {
+  let server: any;
+  let mockPost: any;
+
+  // `Client.deploy` reuses a pre-built `Server` given via `options.server`, so
+  // spying on that instance's http client lets the real code path run against
+  // controlled JSON-RPC responses without mocking a module.
+  beforeEach(() => {
+    server = new Server(serverUrl);
+    mockPost = vi.spyOn(server.httpClient, "post").mockImplementation(() => {
+      throw new Error("unexpected RPC call");
+    });
+  });
+
+  const deployer = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGSNFHEYVXM3XOJMDS674JZ";
+
+  // A synthetic wasm exposing a single `hello` function, so `Spec.fromWasm`
+  // can parse it. The wasm hash is arbitrary for the mock; it only has to
+  // match between the tag entry / deploy options and the code entry.
+  const wasmBuffer = wasmWithSpec([
+    xdr.ScSpecEntry.scSpecEntryFunctionV0(
+      new xdr.ScSpecFunctionV0({
+        doc: "",
+        name: "hello",
+        inputs: [],
+        outputs: [],
+      }),
+    ),
+  ]);
+  const wasmHash = hash(wasmBuffer);
+
+  const wasmLedgerKey = xdr.LedgerKey.contractCode(
+    new xdr.LedgerKeyContractCode({ hash: wasmHash }),
+  );
+  const wasmLedgerCode = xdr.LedgerEntryData.contractCode(
+    new xdr.ContractCodeEntry({
+      ext: xdr.ContractCodeEntryExt.fromXdr(
+        "AAAAAQAAAAAAAAAAAAAVqAAAAJwAAAADAAAAAwAAABgAAAABAAAAAQAAABEAAAAgAAABpA==",
+        "base64",
+      ),
+      hash: wasmHash,
+      code: wasmBuffer,
+    }),
+  );
+
+  // Builds the JSON-RPC response shape returned by `getLedgerEntries` for a
+  // single ledger entry, matching what the RPC server produces.
+  function ledgerEntriesResponse(
+    val: StellarSdk.xdr.LedgerEntryData,
+    key: StellarSdk.xdr.LedgerKey,
+  ) {
+    return {
+      data: {
+        result: {
+          latestLedger: 18039,
+          entries: [
+            {
+              liveUntilLedgerSeq: 1000,
+              lastModifiedLedgerSeq: 1,
+              xdr: val.toXdr("base64"),
+              key: key.toXdr("base64"),
+            },
+          ],
+        },
+      },
+    };
+  }
+
+  // With `simulate: false` the deploy stops after assembling the transaction,
+  // so the operation it built can be inspected off the raw builder.
+  function builtDeployOp(tx: StellarSdk.contract.AssembledTransaction<any>) {
+    const op = expectOperationType(
+      tx.raw!.build().operations[0]!,
+      "invokeHostFunction",
+    );
+    return expectVariant(op.func, "hostFunctionTypeCreateContractV2")
+      .createContractV2;
+  }
+
+  describe("from a wasm hash (baseline)", () => {
+    it("fetches the spec and builds a wasm-hash deploy op", async () => {
+      mockPost.mockResolvedValueOnce(
+        ledgerEntriesResponse(wasmLedgerCode, wasmLedgerKey),
+      );
+
+      const tx = await Client.deploy(null, {
+        wasmHash,
+        address: deployer,
+        networkPassphrase,
+        rpcUrl: serverUrl,
+        server,
+        simulate: false,
+      });
+
+      // Only the wasm fetch: no account fetch (no publicKey), no simulation.
+      expect(mockPost).toHaveBeenCalledTimes(1);
+
+      const args = builtDeployOp(tx);
+      const executable = expectVariant(
+        args.executable,
+        "contractExecutableWasm",
+      );
+      expect(Array.from(executable.value.toBytes())).toEqual(
+        Array.from(wasmHash),
+      );
+      expect(args.constructorArgs).toHaveLength(0);
+    });
+  });
+
+  describe("from a CAP-85 external executable ref", () => {
+    const ownerId = "CCJZ5DGASBWQXR5MPFCJXMBI333XE5U3FSJTNQU7RIKE3P5GN2K2WYD5";
+    const owner = new Contract(ownerId);
+    const tag = "my-executable";
+
+    // The owner contract's persistent tag entry, whose value is the wasm hash
+    // the ref currently names. Resolving it is how deploy finds the spec.
+    const tagEntryKey = xdr.LedgerKey.contractData(
+      new xdr.LedgerKeyContractData({
+        contract: owner.address().toScAddress(),
+        key: xdr.ScVal.scvExecutableTag(tag),
+        durability: xdr.ContractDataDurability.persistent,
+      }),
+    );
+    const tagEntryVal = xdr.LedgerEntryData.contractData(
+      new xdr.ContractDataEntry({
+        ext: xdr.ExtensionPoint.v0(),
+        contract: owner.address().toScAddress(),
+        durability: xdr.ContractDataDurability.persistent,
+        key: xdr.ScVal.scvExecutableTag(tag),
+        val: xdr.ScVal.scvBytes(wasmHash),
+      }),
+    );
+
+    it("resolves the ref for the spec and builds an external-ref deploy op", async () => {
+      mockPost
+        .mockResolvedValueOnce(ledgerEntriesResponse(tagEntryVal, tagEntryKey))
+        .mockResolvedValueOnce(
+          ledgerEntriesResponse(wasmLedgerCode, wasmLedgerKey),
+        );
+
+      const tx = await Client.deploy(null, {
+        externalRef: { owner: ownerId, tag },
+        address: deployer,
+        networkPassphrase,
+        rpcUrl: serverUrl,
+        server,
+        simulate: false,
+      });
+
+      // The tag-entry lookup, then the wasm fetch.
+      expect(mockPost).toHaveBeenCalledTimes(2);
+
+      const args = builtDeployOp(tx);
+      const ref = expectVariant(
+        args.executable,
+        "contractExecutableExternalRef",
+      ).externalRef;
+      expect(Address.fromScAddress(ref.executableOwner).toString()).toBe(
+        ownerId,
+      );
+      expect(ref.tag.toStringStrict()).toBe(tag);
+      expect(args.constructorArgs).toHaveLength(0);
+
+      const preimage = expectVariant(
+        args.contractIdPreimage,
+        "contractIdPreimageFromAddress",
+      );
+      expect(Address.fromScAddress(preimage.value.address).toString()).toBe(
+        deployer,
+      );
+    });
+
+    it("accepts a ContractExecutableExternalRef directly", async () => {
+      mockPost
+        .mockResolvedValueOnce(ledgerEntriesResponse(tagEntryVal, tagEntryKey))
+        .mockResolvedValueOnce(
+          ledgerEntriesResponse(wasmLedgerCode, wasmLedgerKey),
+        );
+
+      const tx = await Client.deploy(null, {
+        externalRef: new xdr.ContractExecutableExternalRef({
+          executableOwner: owner.address().toScAddress(),
+          tag,
+        }),
+        address: deployer,
+        networkPassphrase,
+        rpcUrl: serverUrl,
+        server,
+        simulate: false,
+      });
+
+      const ref = expectVariant(
+        builtDeployOp(tx).executable,
+        "contractExecutableExternalRef",
+      ).externalRef;
+      expect(ref.tag.toStringStrict()).toBe(tag);
+    });
+
+    it("rejects when the owner is not a contract", async () => {
+      await expect(
+        Client.deploy(null, {
+          externalRef: { owner: deployer, tag },
+          address: deployer,
+          networkPassphrase,
+          rpcUrl: serverUrl,
+          server,
+          simulate: false,
+        }),
+      ).rejects.toMatchObject({ code: 400 });
+    });
+  });
+});

--- a/test/unit/contract/client_from.test.ts
+++ b/test/unit/contract/client_from.test.ts
@@ -1,53 +1,14 @@
 import { describe, it, beforeEach, expect, vi } from "vitest";
-import { concatUint8Arrays, stringToUint8Array } from "uint8array-extras";
 import * as StellarSdk from "../../../src/index.js";
 
 import { serverUrl } from "../../constants.js";
+import { wasmWithSpec } from "./support/wasm.js";
 
 const { xdr, hash, Contract, rpc } = StellarSdk;
 const { Client } = StellarSdk.contract;
 const { Server } = rpc;
 
 const networkPassphrase = "Test SDF Network ; September 2015";
-
-// LEB128 unsigned varint, as used for WASM section lengths.
-function leb128(value: number): Uint8Array {
-  const bytes: number[] = [];
-  let n = value;
-  do {
-    let byte = n & 0x7f;
-    n >>>= 7;
-    if (n !== 0) byte |= 0x80;
-    bytes.push(byte);
-  } while (n !== 0);
-  return Uint8Array.from(bytes);
-}
-
-// Builds a minimal valid WASM binary whose only content is a `contractspecv0`
-// custom section carrying the given spec entries. This is browser-safe (pure
-// Uint8Array ops, no filesystem) and is enough for `Spec.fromWasm` to parse,
-// which only scans for that custom section.
-function wasmWithSpec(entries: StellarSdk.xdr.ScSpecEntry[]): Uint8Array {
-  const name = stringToUint8Array("contractspecv0");
-  const payload = concatUint8Arrays(entries.map((e) => e.toXdr()));
-  const sectionBody = concatUint8Arrays([leb128(name.length), name, payload]);
-  const customSection = concatUint8Arrays([
-    Uint8Array.of(0x00), // custom section id
-    leb128(sectionBody.length),
-    sectionBody,
-  ]);
-  const header = Uint8Array.of(
-    0x00,
-    0x61,
-    0x73,
-    0x6d, // "\0asm" magic
-    0x01,
-    0x00,
-    0x00,
-    0x00, // version 1
-  );
-  return concatUint8Arrays([header, customSection]);
-}
 
 describe("contract.Client.from", () => {
   let server: any;

--- a/test/unit/contract/support/wasm.ts
+++ b/test/unit/contract/support/wasm.ts
@@ -1,0 +1,43 @@
+import { concatUint8Arrays, stringToUint8Array } from "uint8array-extras";
+import * as StellarSdk from "../../../../src/index.js";
+
+// LEB128 unsigned varint, as used for WASM section lengths.
+function leb128(value: number): Uint8Array {
+  const bytes: number[] = [];
+  let n = value;
+  do {
+    let byte = n & 0x7f;
+    n >>>= 7;
+    if (n !== 0) byte |= 0x80;
+    bytes.push(byte);
+  } while (n !== 0);
+  return Uint8Array.from(bytes);
+}
+
+// Builds a minimal valid WASM binary whose only content is a `contractspecv0`
+// custom section carrying the given spec entries. This is browser-safe (pure
+// Uint8Array ops, no filesystem) and is enough for `Spec.fromWasm` to parse,
+// which only scans for that custom section.
+export function wasmWithSpec(
+  entries: StellarSdk.xdr.ScSpecEntry[],
+): Uint8Array {
+  const name = stringToUint8Array("contractspecv0");
+  const payload = concatUint8Arrays(entries.map((e) => e.toXdr()));
+  const sectionBody = concatUint8Arrays([leb128(name.length), name, payload]);
+  const customSection = concatUint8Arrays([
+    Uint8Array.of(0x00), // custom section id
+    leb128(sectionBody.length),
+    sectionBody,
+  ]);
+  const header = Uint8Array.of(
+    0x00,
+    0x61,
+    0x73,
+    0x6d, // "\0asm" magic
+    0x01,
+    0x00,
+    0x00,
+    0x00, // version 1
+  );
+  return concatUint8Arrays([header, customSection]);
+}


### PR DESCRIPTION
## What

`Operation.createCustomContract` now deploys from a CAP-85 external executable reference as an alternative to a WASM hash. `CreateCustomContractOpts` becomes a two-arm union: pass either `wasmHash` or `externalRef`, where the reference is a plain `{owner, tag}` (strkey or `Address` owner, string or binary tag) or an `xdr.ContractExecutableExternalRef` taken from an existing instance. Passing both throws, a non-contract owner is rejected early since only a contract can hold the persistent tag entry naming the WASM, and binary tags pass through undecoded.

`contract.Client.deploy` accepts the same `externalRef` option in place of `wasmHash`. The reference is resolved on-chain (via `rpc.Server.getExternalRefWasmHash`) to read the constructor spec, while the operation itself carries the reference, so the deployed contract keeps following the tag. Generated bindings (`BindingGenerator`) emit a `deploy` method with the same option, and the `ExternalExecutableRef` type is exported from the package root and `@stellar/stellar-sdk/contract`.

## Why

v17 already reads external refs everywhere (`buildInvocationTree`, `getExternalRefWasmHash`, `contract.Client.from`), but writing one still meant assembling the `HostFunction` XDR by hand. This closes that gap so the deploy side is as ergonomic as the WASM path, from the low-level operation up through `Client.deploy` and generated bindings. Verified end to end against futurenet (protocol 28): an owner contract published a tag entry and this option deployed and ran a contract through the reference.
