### PR TITLE
fix(xdr): throw XdrError for malformed hex, base64, and escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 A breaking change will get clearly marked in this log.
 
+## Unreleased
+
+### Fixed
+* Malformed input to the XDR layer throws `XdrError`, matchable by class, instead of escaping as a bare `Error` (hex), a runtime-specific `DOMException` (base64), or a `SyntaxError` (a bad SEP-0051 escape in `fromJson`) ([#1642](https://github.com/stellar/js-stellar-sdk/issues/1642)).
+* Previously undocumented: v17 rejects malformed base64 outright, where v16's `Buffer.from(str, "base64")` silently dropped any character outside the alphabet ([#1642](https://github.com/stellar/js-stellar-sdk/issues/1642)).
+
 ## [v17.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v17.0.0-rc.1...v17.0.0-rc.2)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Fixed
-* Malformed input to the XDR layer throws `XdrError`, matchable by class, instead of escaping as a bare `Error` (hex), a runtime-specific `DOMException` (base64), or a `SyntaxError` (a bad SEP-0051 escape in `fromJson`) ([#1642](https://github.com/stellar/js-stellar-sdk/issues/1642)).
-* Previously undocumented: v17 rejects malformed base64 outright, where v16's `Buffer.from(str, "base64")` silently dropped any character outside the alphabet ([#1642](https://github.com/stellar/js-stellar-sdk/issues/1642)).
+* Malformed input to the XDR layer throws `XdrError`, matchable by class, instead of escaping as a bare `Error` (hex), a runtime-specific `DOMException` (base64), or a `SyntaxError` (a bad SEP-0051 escape in `fromJson`) ([#1666](https://github.com/stellar/js-stellar-sdk/pull/1666)).
+* Previously undocumented: v17 rejects malformed base64 outright, where v16's `Buffer.from(str, "base64")` silently dropped any character outside the alphabet ([#1666](https://github.com/stellar/js-stellar-sdk/pull/1666)).
 
 ## [v17.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v17.0.0-rc.1...v17.0.0-rc.2)
 

--- a/docs/XDR_MIGRATION.md
+++ b/docs/XDR_MIGRATION.md
@@ -1008,8 +1008,9 @@ In JSON output an unset optional is `null` too (§ 12).
 
 ## 15. Errors and validation
 
-Every failure in the XDR layer now throws **`XdrError`**, which the SDK exports,
-so you can finally match on the class instead of on message text:
+Every encode, decode, and validation failure in the XDR layer throws
+**`XdrError`**, which the SDK exports, so you can finally match on the class
+instead of on message text:
 
 ```ts
 import { xdr } from "@stellar/stellar-sdk";
@@ -1028,9 +1029,11 @@ Two things to know when migrating:
   the only option) with text like `"XDR Write Error: invalid i32 value"`. The
   equivalent is now `"Uint32: value 4294967296 out of range [0, 4294967295]"`.
   Any `catch` block matching on error text needs rewriting.
-- There is one exception to the rule. Invalid base64 surfaces as a
-  `DOMException: Invalid character` from the platform decoder, not an
-  `XdrError`. Catch broadly if you accept untrusted base64.
+- Only the `xdr` namespace follows this rule. SDK entry points that decode
+  base64 or hex themselves — `new Transaction(envelope)`,
+  `Operation.setOptions`'s hex signer keys — still surface the platform
+  decoder's error, which Node words `DOMException: Invalid character` and other
+  runtimes word differently.
 
 Strictness itself is mostly unchanged. v4 also rejected buffers it didn't fully
 consume (`"source buffer not entirely consumed"`), which is now

--- a/docs/XDR_MIGRATION.md
+++ b/docs/XDR_MIGRATION.md
@@ -1008,9 +1008,9 @@ In JSON output an unset optional is `null` too (§ 12).
 
 ## 15. Errors and validation
 
-Every encode, decode, and validation failure in the XDR layer throws
-**`XdrError`**, which the SDK exports, so you can finally match on the class
-instead of on message text:
+Malformed data in the XDR layer throws **`XdrError`**, which the SDK exports,
+so you can finally match on the class instead of on message text. Arguments of
+the wrong type are caller errors and throw a `TypeError`.
 
 ```ts
 import { xdr } from "@stellar/stellar-sdk";
@@ -1029,7 +1029,7 @@ Two things to know when migrating:
   the only option) with text like `"XDR Write Error: invalid i32 value"`. The
   equivalent is now `"Uint32: value 4294967296 out of range [0, 4294967295]"`.
   Any `catch` block matching on error text needs rewriting.
-- Only the `xdr` namespace follows this rule. SDK entry points that decode
+- `XdrError` covers the `xdr` namespace only. SDK entry points that decode
   base64 or hex themselves — `new Transaction(envelope)`,
   `Operation.setOptions`'s hex signer keys — still surface the platform
   decoder's error, which Node words `DOMException: Invalid character` and other

--- a/src/xdr/values/bytes-value.ts
+++ b/src/xdr/values/bytes-value.ts
@@ -1,10 +1,6 @@
-import {
-  hexToUint8Array,
-  base64ToUint8Array,
-  stringToUint8Array,
-} from "uint8array-extras";
+import { stringToUint8Array } from "uint8array-extras";
 import { XdrError } from "@stellar/js-xdr";
-import { XdrValue } from "./xdr-value.js";
+import { XdrValue, decodeBytes } from "./xdr-value.js";
 
 export type BytesEncoding = "hex" | "base64" | "ascii";
 
@@ -13,14 +9,8 @@ function decodeBytesInput(
   encoding: BytesEncoding,
 ): Uint8Array {
   if (input instanceof Uint8Array) return input;
-  switch (encoding) {
-    case "hex":
-      return hexToUint8Array(input);
-    case "base64":
-      return base64ToUint8Array(input);
-    case "ascii":
-      return stringToUint8Array(input);
-  }
+  if (encoding === "ascii") return stringToUint8Array(input);
+  return decodeBytes(input, encoding);
 }
 
 /**

--- a/src/xdr/values/xdr-string.ts
+++ b/src/xdr/values/xdr-string.ts
@@ -166,14 +166,14 @@ export class XdrString {
           case 0x78 /* `x` */:
           case 0x58 /* `X` */: {
             if (i + 3 >= escaped.length) {
-              throw new SyntaxError(
+              throw new XdrError(
                 `XdrString: truncated \\x escape at index ${i}`,
               );
             }
             const hi = hexDigit(escaped.charCodeAt(i + 2));
             const lo = hexDigit(escaped.charCodeAt(i + 3));
             if (hi < 0 || lo < 0) {
-              throw new SyntaxError(
+              throw new XdrError(
                 `XdrString: invalid \\x escape "${escaped.slice(i, i + 4)}"`,
               );
             }
@@ -182,14 +182,14 @@ export class XdrString {
             break;
           }
           default:
-            throw new SyntaxError(
+            throw new XdrError(
               `XdrString: unsupported escape \\${escaped[i + 1] ?? ""}`,
             );
         }
       } else if (ch >= 0x20 && ch <= 0x7e) {
         out.push(ch);
       } else {
-        throw new SyntaxError(
+        throw new XdrError(
           `XdrString: non-ASCII char (code 0x${ch.toString(16)}) at index ${i}`,
         );
       }

--- a/src/xdr/values/xdr-value.ts
+++ b/src/xdr/values/xdr-value.ts
@@ -352,19 +352,20 @@ export function decodeBytes(
   format: "raw" | "hex" | "base64" | undefined,
 ): Uint8Array {
   if (input instanceof Uint8Array) return input;
+  // A non-string argument is a caller mistake, not malformed data, so it stays
+  // a TypeError — the same split `Keypair.verify` uses. Checked ahead of every
+  // `format` branch so the class never depends on the other argument.
+  if (typeof input !== "string") {
+    throw new TypeError(
+      `fromXdr: expected a string or Uint8Array, got ${typeof input}`,
+    );
+  }
   if (format === undefined || format === "raw") {
     throw new XdrError(
       "fromXdr: string input requires format ('hex' | 'base64')",
     );
   }
   if (format === "hex" || format === "base64") {
-    // A non-string argument is a caller mistake, not malformed data, so it
-    // stays a TypeError — same split `Keypair.verify` uses.
-    if (typeof input !== "string") {
-      throw new TypeError(
-        `fromXdr: expected a string or Uint8Array, got ${typeof input}`,
-      );
-    }
     try {
       return format === "hex"
         ? hexToUint8Array(input)

--- a/src/xdr/values/xdr-value.ts
+++ b/src/xdr/values/xdr-value.ts
@@ -342,8 +342,9 @@ export function encodeBytes(
  *
  * @param input - the bytes or encoded string to decode
  * @param format - required when `input` is a string; ignored for `Uint8Array`
- * @throws an {@link XdrError} when a string arrives without a `"hex"` /
- *   `"base64"` format, or the format is unknown
+ * @throws an {@link XdrError} when `input` is not valid `format`, when a string
+ *   arrives without a `"hex"` / `"base64"` format, or when the format is
+ *   unknown; a `TypeError` when `input` is neither a string nor a `Uint8Array`
  * @see {@link encodeBytes} for the reverse direction
  */
 export function decodeBytes(
@@ -356,8 +357,24 @@ export function decodeBytes(
       "fromXdr: string input requires format ('hex' | 'base64')",
     );
   }
-  if (format === "hex") return hexToUint8Array(input);
-  if (format === "base64") return base64ToUint8Array(input);
+  if (format === "hex" || format === "base64") {
+    // A non-string argument is a caller mistake, not malformed data, so it
+    // stays a TypeError — same split `Keypair.verify` uses.
+    if (typeof input !== "string") {
+      throw new TypeError(
+        `fromXdr: expected a string or Uint8Array, got ${typeof input}`,
+      );
+    }
+    try {
+      return format === "hex"
+        ? hexToUint8Array(input)
+        : base64ToUint8Array(input);
+    } catch {
+      // The decoders report through the platform: a plain Error for hex, a
+      // runtime-worded DOMException for base64. Neither is matchable.
+      throw new XdrError(`invalid ${format} input`);
+    }
+  }
   // Plain-JS callers get no TS checking; treating an unknown format as
   // base64 would silently decode garbage bytes.
   throw new XdrError(`fromXdr: unknown format "${String(format)}"`);

--- a/test/unit/xdr/decode_bytes.test.ts
+++ b/test/unit/xdr/decode_bytes.test.ts
@@ -35,6 +35,14 @@ describe("decodeBytes", () => {
     expect(() => new AssetCode4(123 as never)).toThrow(TypeError);
   });
 
+  it("reports the input type before the format, whatever the format", () => {
+    expect(() => decodeBytes(123 as never, "raw")).toThrow(TypeError);
+    expect(() => decodeBytes(123 as never, undefined)).toThrow(TypeError);
+    expect(() => decodeBytes(123 as never, "bogus" as never)).toThrow(
+      TypeError,
+    );
+  });
+
   it("still decodes valid input", () => {
     const hex = "ab".repeat(32);
     expect(decodeBytes(hex, "hex")).toEqual(new Uint8Array(32).fill(0xab));

--- a/test/unit/xdr/decode_bytes.test.ts
+++ b/test/unit/xdr/decode_bytes.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  AssetCode4,
+  Hash,
+  ScVal,
+  XdrError,
+  decodeBytes,
+} from "../../../src/xdr/index.js";
+
+describe("decodeBytes", () => {
+  it("throws XdrError on malformed hex", () => {
+    expect(() => ScVal.fromXdr("zzzz", "hex")).toThrow(XdrError);
+    expect(() => ScVal.fromXdr("zzzz", "hex")).toThrow(/invalid hex input/);
+    // odd length, a different failure inside the hex decoder
+    expect(() => ScVal.fromXdr("abc", "hex")).toThrow(XdrError);
+  });
+
+  it("throws XdrError on malformed base64", () => {
+    expect(() => ScVal.fromXdr("not-valid-xdr", "base64")).toThrow(XdrError);
+    expect(() => ScVal.fromXdr("not-valid-xdr", "base64")).toThrow(
+      /invalid base64 input/,
+    );
+  });
+
+  it("throws XdrError from byte-alias constructors too", () => {
+    expect(() => new Hash("zz".repeat(32))).toThrow(XdrError);
+  });
+
+  it("keeps TypeError for a non-string input, which is caller error", () => {
+    expect(() => decodeBytes(123 as never, "hex")).toThrow(TypeError);
+    expect(() => decodeBytes(null as never, "base64")).toThrow(TypeError);
+    expect(() => new Hash(123 as never)).toThrow(TypeError);
+    // the ascii path reports the same class, from `uint8array-extras`
+    expect(() => new AssetCode4(123 as never)).toThrow(TypeError);
+  });
+
+  it("still decodes valid input", () => {
+    const hex = "ab".repeat(32);
+    expect(decodeBytes(hex, "hex")).toEqual(new Uint8Array(32).fill(0xab));
+    expect(new Hash(hex).toXdr("hex")).toBe(hex);
+    expect(ScVal.fromXdr("AAAAAxI0Vng=", "base64").toXdr("base64")).toBe(
+      "AAAAAxI0Vng=",
+    );
+    expect(new AssetCode4("USD").toXdr("hex")).toBe("55534400");
+  });
+});

--- a/test/unit/xdr/to_json.test.ts
+++ b/test/unit/xdr/to_json.test.ts
@@ -711,6 +711,13 @@ describe("walker — fromJson input validation", () => {
     expect(() => ScVal.fromJson({ bytes: "zz" })).toThrow(/hex/);
     expect(() => ScVal.fromJson({ bytes: "abc" })).toThrow(/hex/);
   });
+
+  it("rejects malformed string escapes with an XdrError, not SyntaxError", () => {
+    expect(() => ScVal.fromJson({ string: "\\q" })).toThrow(jsxdr.XdrError);
+    expect(() => ScVal.fromJson({ string: "\\xZZ" })).toThrow(jsxdr.XdrError);
+    expect(() => ScVal.fromJson({ string: "\\x4" })).toThrow(jsxdr.XdrError);
+    expect(() => ScVal.fromJson({ string: "é" })).toThrow(jsxdr.XdrError);
+  });
 });
 
 describe("walker — omitted option fields parse as null", () => {


### PR DESCRIPTION
- Fixed malformed hex and base64 decoding to throw `XdrError` — previously a bare `Error` from the decoding library (no `name` or `code` to match on) and a `DOMException` worded differently on Node, Deno, and Bun, so message-matching was the only option
- Routed byte-alias constructors through `decodeBytes` instead of calling the decoders directly, so `new xdr.Hash("zz…")` reports the same class as `fromXdr`, and the decode path now has one implementation site
- Replaced the four `SyntaxError`s in `XdrString.fromJson` with `XdrError`, matching the `i64` and hex branches of the same JSON walker — one `ScVal.fromJson` call could previously throw either class depending on which field was malformed
- Kept a `TypeError` for a non-string argument, following the split `Keypair.verify` established: caller mistake is a `TypeError`, bad data in a correctly-typed argument is an `XdrError`
- Rewrote § 15 of `XDR_MIGRATION.md`, which claimed one exception to the `XdrError` rule and quoted Node's `DOMException: Invalid character` — the class list is now accurate and the platform error is described where it still surfaces, on `new Transaction(envelope)` and `Operation.setOptions` hex signer keys