### PR TITLE
fix: declare node >=22.12.0, where the cjs build can be required

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,12 @@ jobs:
   browser_test:
     runs-on: ubuntu-latest
 
+    # `playwright install-deps` is the only step here that touches apt, so a
+    # degraded Ubuntu mirror wedges it inside `apt-get update` with no output
+    # and no failure. Without this, the job would hang for GitHub's 360-minute
+    # default; healthy runs finish in under 6 minutes.
+    timeout-minutes: 15
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
     # degraded Ubuntu mirror wedges it inside `apt-get update` with no output
     # and no failure. Without this, the job would hang for GitHub's 360-minute
     # default; healthy runs finish in under 6 minutes.
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
@@ -128,4 +128,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: No-op
-        run: echo "Node 20 is no longer supported; placeholder for the required status check."
+        run:
+          echo "Node 20 is no longer supported; placeholder for the required
+          status check."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,8 +113,9 @@ jobs:
 
   # Placeholder to satisfy the `build_and_test (20)` required status check in
   # the `protect-main` ruleset. Node 20 was dropped from the test matrix
-  # (engines.node is now >=22), but the ruleset still requires that context by
-  # name, so without this every PR would stay "Expected" and block merge.
+  # (engines.node is now >=22.12.0), but the ruleset still requires that
+  # context by name, so without this every PR would stay "Expected" and block
+  # merge.
   # Remove this job once the ruleset is repointed to `build_and_test (22)`.
   build_and_test_node20_placeholder:
     name: build_and_test (20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 A breaking change will get clearly marked in this log.
 
+## Unreleased
+
+### Breaking Changes
+* `engines.node` is now `>=22.12.0`, up from `>=22.0.0`. The CommonJS build `require()`s ESM-only dependencies, and `require(esm)` is only unflagged from Node 22.12.0, so on Node 22.0–22.11 `require("@stellar/stellar-sdk")` failed with `ERR_REQUIRE_ESM` even though the declared range allowed it. Installing on one of those versions now produces an `EBADENGINE` warning instead of a package that cannot be required. Nothing changes for ESM consumers, or on Node 22.12 and later ([#1664](https://github.com/stellar/js-stellar-sdk/issues/1664)).
+
 ## [v17.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v17.0.0-rc.1...v17.0.0-rc.2)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Breaking Changes
-* `engines.node` is now `>=22.12.0`, up from `>=22.0.0`. The CommonJS build `require()`s ESM-only dependencies, and `require(esm)` is only unflagged from Node 22.12.0, so on Node 22.0–22.11 `require("@stellar/stellar-sdk")` failed with `ERR_REQUIRE_ESM` even though the declared range allowed it. Installing on one of those versions now produces an `EBADENGINE` warning instead of a package that cannot be required. Nothing changes for ESM consumers, or on Node 22.12 and later ([#1664](https://github.com/stellar/js-stellar-sdk/issues/1664)).
+* `engines.node` is now `>=22.12.0`, up from `>=22.0.0`. The CommonJS build `require()`s ESM-only dependencies, and `require(esm)` is only unflagged from Node 22.12.0, so on Node 22.0–22.11 `require("@stellar/stellar-sdk")` failed with `ERR_REQUIRE_ESM` even though the declared range allowed it. Installing on one of those versions now produces an `EBADENGINE` warning instead of a package that cannot be required. Nothing changes for ESM consumers, or on Node 22.12 and later ([#1667](https://github.com/stellar/js-stellar-sdk/pull/1667)).
 
 ## [v17.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v17.0.0-rc.1...v17.0.0-rc.2)
 

--- a/README.md
+++ b/README.md
@@ -198,10 +198,15 @@ Tell Jest to transform those packages instead of skipping them:
 // jest.config.js
 module.exports = {
   transformIgnorePatterns: [
-    "node_modules/(?!(@noble|@exodus|uint8array-extras)/)",
+    "node_modules/(?!(\\.pnpm|@noble|@exodus|uint8array-extras)/)",
   ],
 };
 ```
+
+`.pnpm` belongs in that list even though it is not a package. Under pnpm the
+real path is `node_modules/.pnpm/<pkg>@<version>/node_modules/<pkg>/…`, so
+without it the pattern matches at the first `node_modules/` segment and the
+package is skipped before the name is ever compared.
 
 If you compile tests with ts-jest or Babel, also make sure the compilation
 target is `es2020` or later — the SDK and its crypto dependencies use native

--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ You can also refer to:
 ### Usage with Jest
 
 Some of the SDK's dependencies (`@noble/hashes`, `@noble/ed25519`,
-`uint8array-extras`, `smol-toml`, `eventsource`) ship only ES modules. Node
-itself handles this (`require(esm)` is on by default from Node 22.12.0; on
-22.0–22.11 it needs `--experimental-require-module`), but Jest's default
-transform pipeline does not: tests that load the SDK fail with
+`uint8array-extras`, `@exodus/bytes`) ship only ES modules. Node itself handles
+this (`require(esm)` is unflagged from Node 22.12.0, the minimum this SDK
+supports), but Jest's default transform pipeline does not: tests that load the
+SDK fail with
 `SyntaxError: Cannot use import statement outside a module` coming from inside
 `node_modules`.
 
@@ -198,7 +198,7 @@ Tell Jest to transform those packages instead of skipping them:
 // jest.config.js
 module.exports = {
   transformIgnorePatterns: [
-    "node_modules/(?!(@noble|uint8array-extras|smol-toml|eventsource)/)",
+    "node_modules/(?!(@noble|@exodus|uint8array-extras)/)",
   ],
 };
 ```

--- a/docs/guides/00-migration.md
+++ b/docs/guides/00-migration.md
@@ -131,12 +131,11 @@ Soroban contract authorization entries.
 
 ### Installation: Node 22 is now required
 
-The minimum Node version is now `22` (up from `20`), raised again to `22.12.0`
-in 17.x.x. Installing on older Node produces an `EBADENGINE` warning. Two
-runtime globals are now assumed and are built into Node 22: `fetch` (the
-default transport) and `crypto.getRandomValues` (used by SEP-10
-`buildChallengeTx`, which dropped the `randombytes` dependency). Constrained
-runtimes such as React Native need polyfills for both.
+The minimum Node version is now `22` (up from `20`). Installing on older Node
+produces an `EBADENGINE` warning. Two runtime globals are now assumed and are
+built into Node 22: `fetch` (the default transport) and `crypto.getRandomValues`
+(used by SEP-10 `buildChallengeTx`, which dropped the `randombytes` dependency).
+Constrained runtimes such as React Native need polyfills for both.
 
 A `.nvmrc` pinned to `v22` is included:
 

--- a/docs/guides/00-migration.md
+++ b/docs/guides/00-migration.md
@@ -49,6 +49,16 @@ at all**:
 The method renames (`toXDR` → `toXdr`, `fromXDRObject` → `fromXdrObject`, and
 eleven more) ship without back-compat aliases, so those at least fail loudly.
 
+### Installation: the Node floor is now 22.12.0
+
+`engines.node` is `>=22.12.0` (16.x said `>=22.0.0`). The CommonJS build loads
+ESM-only dependencies through `require()`, which Node only supports unflagged
+from 22.12.0 — on 22.0–22.11 `require("@stellar/stellar-sdk")` fails with
+`ERR_REQUIRE_ESM`. Installing on an earlier 22.x now produces an `EBADENGINE`
+warning instead of a package that cannot be required
+([#1664](https://github.com/stellar/js-stellar-sdk/issues/1664)). ESM consumers
+were never affected. Upgrade Node, or use the ESM entry point.
+
 ### Auth: CAP-71 v2 address credentials are now the default
 
 Protocol 27 ([CAP-71](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0071.md))
@@ -121,11 +131,12 @@ Soroban contract authorization entries.
 
 ### Installation: Node 22 is now required
 
-The minimum Node version is now `22` (up from `20`). Installing on older Node
-produces an `EBADENGINE` warning. Two runtime globals are now assumed and are
-built into Node 22: `fetch` (the default transport) and `crypto.getRandomValues`
-(used by SEP-10 `buildChallengeTx`, which dropped the `randombytes` dependency).
-Constrained runtimes such as React Native need polyfills for both.
+The minimum Node version is now `22` (up from `20`), raised again to `22.12.0`
+in 17.x.x. Installing on older Node produces an `EBADENGINE` warning. Two
+runtime globals are now assumed and are built into Node 22: `fetch` (the
+default transport) and `crypto.getRandomValues` (used by SEP-10
+`buildChallengeTx`, which dropped the `randombytes` dependency). Constrained
+runtimes such as React Native need polyfills for both.
 
 A `.nvmrc` pinned to `v22` is included:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -203,10 +203,15 @@ Tell Jest to transform those packages instead of skipping them:
 // jest.config.js
 module.exports = {
   transformIgnorePatterns: [
-    "node_modules/(?!(@noble|@exodus|uint8array-extras)/)",
+    "node_modules/(?!(\\.pnpm|@noble|@exodus|uint8array-extras)/)",
   ],
 };
 ```
+
+`.pnpm` belongs in that list even though it is not a package. Under pnpm the
+real path is `node_modules/.pnpm/<pkg>@<version>/node_modules/<pkg>/…`, so
+without it the pattern matches at the first `node_modules/` segment and the
+package is skipped before the name is ever compared.
 
 If you compile tests with ts-jest or Babel, also make sure the compilation
 target is `es2020` or later — the SDK and its crypto dependencies use native

--- a/docs/index.md
+++ b/docs/index.md
@@ -190,10 +190,10 @@ You can also refer to:
 ### Usage with Jest
 
 Some of the SDK's dependencies (`@noble/hashes`, `@noble/ed25519`,
-`uint8array-extras`, `smol-toml`, `eventsource`) ship only ES modules. Node
-itself handles this (`require(esm)` is on by default from Node 22.12.0; on
-22.0–22.11 it needs `--experimental-require-module`), but Jest's default
-transform pipeline does not: tests that load the SDK fail with
+`uint8array-extras`, `@exodus/bytes`) ship only ES modules. Node itself handles
+this (`require(esm)` is unflagged from Node 22.12.0, the minimum this SDK
+supports), but Jest's default transform pipeline does not: tests that load the
+SDK fail with
 `SyntaxError: Cannot use import statement outside a module` coming from inside
 `node_modules`.
 
@@ -203,7 +203,7 @@ Tell Jest to transform those packages instead of skipping them:
 // jest.config.js
 module.exports = {
   transformIgnorePatterns: [
-    "node_modules/(?!(@noble|uint8array-extras|smol-toml|eventsource)/)",
+    "node_modules/(?!(@noble|@exodus|uint8array-extras)/)",
   ],
 };
 ```

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     ]
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "devDependencies": {
     "@astrojs/markdown-remark": "^7.2.0",


### PR DESCRIPTION
- Raised `engines.node` to `>=22.12.0` — the old `>=22.0.0` admitted Node 22.0–22.11, where `require("@stellar/stellar-sdk")` fails with `ERR_REQUIRE_ESM`, because the CJS build loads ESM-only dependencies and `require(esm)` is only unflagged from 22.12.0
- Fixed the README's Jest `transformIgnorePatterns` snippet, which skipped all four ESM-only packages under pnpm (the leading `node_modules/.pnpm/` segment matched the ignore pattern before the package name was compared), omitted `@exodus/bytes`, and listed `smol-toml` and `eventsource` as ESM-only when both resolve to a CJS build
- Documented the new floor in the v17 migration guide, cross-referenced from the v16 "Node 22 is now required" section so a v15 → v17 reader does not stop at `22`