### PR TITLE
fix(createClaimableBalance): reject claimants stellar-core rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 A breaking change will get clearly marked in this log.
 
+## Unreleased
+
+### Fixed
+
+* `Operation.createClaimableBalance` rejects claimants that stellar-core would reject, instead of building an operation the network refuses. It validated three things: that `asset` is an `Asset`, that `amount` parses, and that `claimants` is a non-empty array. `CreateClaimableBalanceOpFrame::doCheckValid` checks three more, and every one of them fails the whole transaction with a single `CREATE_CLAIMABLE_BALANCE_MALFORMED` that names neither the claimant nor the predicate at fault. The builder now mirrors those checks and throws locally: a destination that appears on two claimants, a predicate nested deeper than four levels (the root predicate is depth 1), a `not` holding no predicate, an `and` or `or` holding other than exactly two predicates, and a negative `absBefore` or `relBefore`. Over-length `and`/`or` arrays and an eleventh claimant already threw an `XdrError` at encoding time from the array bounds; the new checks are the cases that encoded cleanly and only failed on the network.
+
 ## [v17.0.0-rc.2](https://github.com/stellar/js-stellar-sdk/compare/v17.0.0-rc.1...v17.0.0-rc.2)
 
 ### Breaking Changes

--- a/src/base/operations/create_claimable_balance.ts
+++ b/src/base/operations/create_claimable_balance.ts
@@ -1,6 +1,7 @@
 import {
   Asset as XdrAsset,
   Claimant,
+  ClaimPredicate,
   CreateClaimableBalanceOp,
   Int64,
   Operation,
@@ -14,6 +15,73 @@ import {
   setSourceAccount,
   toXdrAmount,
 } from "../util/operations.js";
+
+/**
+ * Deepest claim predicate stellar-core accepts. The root predicate is depth 1,
+ * so three further levels of nesting fit underneath it.
+ */
+const MAX_PREDICATE_DEPTH = 4;
+
+/**
+ * Rejects predicates that stellar-core would reject.
+ *
+ * This mirrors `validatePredicate` in `CreateClaimableBalanceOpFrame.cpp`, which
+ * bounds nesting depth, requires `and` and `or` to hold exactly two predicates,
+ * requires `not` to hold one, and forbids negative times. Every one of those
+ * failures reaches the submitter as a single `CREATE_CLAIMABLE_BALANCE_MALFORMED`
+ * with no indication of which claimant or which predicate was at fault.
+ */
+function validateClaimPredicate(
+  predicate: ClaimPredicate,
+  depth: number,
+): void {
+  if (depth > MAX_PREDICATE_DEPTH) {
+    throw new Error(
+      `claim predicate is nested deeper than ${MAX_PREDICATE_DEPTH} levels`,
+    );
+  }
+
+  switch (predicate.type) {
+    case "claimPredicateUnconditional":
+      return;
+
+    case "claimPredicateAnd":
+    case "claimPredicateOr": {
+      const children =
+        predicate.type === "claimPredicateAnd"
+          ? predicate.andPredicates
+          : predicate.orPredicates;
+
+      if (children.length !== 2) {
+        throw new Error(
+          `${predicate.type} requires exactly two predicates, got ${children.length}`,
+        );
+      }
+
+      children.forEach((child) => validateClaimPredicate(child, depth + 1));
+      return;
+    }
+
+    case "claimPredicateNot":
+      if (!predicate.notPredicate) {
+        throw new Error("claimPredicateNot requires a predicate");
+      }
+      validateClaimPredicate(predicate.notPredicate, depth + 1);
+      return;
+
+    case "claimPredicateBeforeAbsoluteTime":
+      if (predicate.absBefore < 0n) {
+        throw new Error("absBefore must not be negative");
+      }
+      return;
+
+    case "claimPredicateBeforeRelativeTime":
+      if (predicate.relBefore < 0n) {
+        throw new Error("relBefore must not be negative");
+      }
+      return;
+  }
+}
 
 /**
  * Create a new claimable balance operation.
@@ -62,6 +130,18 @@ export function createClaimableBalance(
   if (!Array.isArray(opts.claimants) || opts.claimants.length === 0) {
     throw new Error("must provide at least one claimant");
   }
+
+  const destinations = new Set<string>();
+  opts.claimants.forEach((claimant) => {
+    if (destinations.has(claimant.destination)) {
+      throw new Error(
+        `duplicate claimant destination: ${claimant.destination}`,
+      );
+    }
+    destinations.add(claimant.destination);
+
+    validateClaimPredicate(claimant.predicate, 1);
+  });
 
   const asset: XdrAsset = opts.asset.toXdrObject();
   const amount: Int64 = toXdrAmount(opts.amount);

--- a/test/unit/base/operations/create_claimable_balance.test.ts
+++ b/test/unit/base/operations/create_claimable_balance.test.ts
@@ -89,4 +89,160 @@ describe("Operation.createClaimableBalance()", () => {
     const roundtripped = xdr.Operation.fromXdr(hex, "hex");
     expect(roundtripped.body.type).toBe("createClaimableBalance");
   });
+
+  describe("rejects what stellar-core rejects", () => {
+    const other = "GDGU5OAPHNPU5UCLE5RDJHG7PXZFQYWKCFOEXSXNMR6KRQRI5T6XXCD7";
+    const first = expectDefined(claimants[0]);
+
+    const nest = (levels: number) => {
+      let predicate = Claimant.predicateUnconditional();
+      for (let i = 0; i < levels; i += 1) {
+        predicate = Claimant.predicateNot(predicate);
+      }
+      return predicate;
+    };
+
+    it("throws on a duplicate claimant destination", () => {
+      expect(() =>
+        Operation.createClaimableBalance({
+          asset,
+          amount,
+          claimants: [first, new Claimant(first.destination)],
+        }),
+      ).toThrow(/duplicate claimant destination/);
+    });
+
+    it("accepts distinct claimant destinations", () => {
+      expect(() =>
+        Operation.createClaimableBalance({
+          asset,
+          amount,
+          claimants: [first, new Claimant(other)],
+        }),
+      ).not.toThrow();
+    });
+
+    it("throws on a predicate nested more than four levels deep", () => {
+      expect(() =>
+        Operation.createClaimableBalance({
+          asset,
+          amount,
+          claimants: [new Claimant(first.destination, nest(4))],
+        }),
+      ).toThrow(/nested deeper than 4 levels/);
+    });
+
+    it("accepts a predicate nested exactly four levels deep", () => {
+      expect(() =>
+        Operation.createClaimableBalance({
+          asset,
+          amount,
+          claimants: [
+            new Claimant(
+              first.destination,
+              Claimant.predicateAnd(
+                Claimant.predicateOr(
+                  Claimant.predicateNot(Claimant.predicateUnconditional()),
+                  Claimant.predicateUnconditional(),
+                ),
+                Claimant.predicateUnconditional(),
+              ),
+            ),
+          ],
+        }),
+      ).not.toThrow();
+    });
+
+    it("throws on a negative absBefore", () => {
+      expect(() =>
+        Operation.createClaimableBalance({
+          asset,
+          amount,
+          claimants: [
+            new Claimant(
+              first.destination,
+              Claimant.predicateBeforeAbsoluteTime("-1"),
+            ),
+          ],
+        }),
+      ).toThrow(/absBefore must not be negative/);
+    });
+
+    it("throws on a negative relBefore", () => {
+      expect(() =>
+        Operation.createClaimableBalance({
+          asset,
+          amount,
+          claimants: [
+            new Claimant(
+              first.destination,
+              Claimant.predicateBeforeRelativeTime("-1"),
+            ),
+          ],
+        }),
+      ).toThrow(/relBefore must not be negative/);
+    });
+
+    it("accepts a zero absBefore", () => {
+      expect(() =>
+        Operation.createClaimableBalance({
+          asset,
+          amount,
+          claimants: [
+            new Claimant(
+              first.destination,
+              Claimant.predicateBeforeAbsoluteTime("0"),
+            ),
+          ],
+        }),
+      ).not.toThrow();
+    });
+
+    it("throws when and holds fewer than two predicates", () => {
+      expect(() =>
+        Operation.createClaimableBalance({
+          asset,
+          amount,
+          claimants: [
+            new Claimant(
+              first.destination,
+              xdr.ClaimPredicate.claimPredicateAnd([
+                Claimant.predicateUnconditional(),
+              ]),
+            ),
+          ],
+        }),
+      ).toThrow(/claimPredicateAnd requires exactly two predicates, got 1/);
+    });
+
+    it("throws when or holds fewer than two predicates", () => {
+      expect(() =>
+        Operation.createClaimableBalance({
+          asset,
+          amount,
+          claimants: [
+            new Claimant(
+              first.destination,
+              xdr.ClaimPredicate.claimPredicateOr([]),
+            ),
+          ],
+        }),
+      ).toThrow(/claimPredicateOr requires exactly two predicates, got 0/);
+    });
+
+    it("throws when not holds no predicate", () => {
+      expect(() =>
+        Operation.createClaimableBalance({
+          asset,
+          amount,
+          claimants: [
+            new Claimant(
+              first.destination,
+              xdr.ClaimPredicate.claimPredicateNot(null),
+            ),
+          ],
+        }),
+      ).toThrow(/claimPredicateNot requires a predicate/);
+    });
+  });
 });


### PR DESCRIPTION
`Operation.createClaimableBalance` validates three things: that `asset` is an `Asset`, that `amount` parses, and that `claimants` is a non-empty array. `CreateClaimableBalanceOpFrame::doCheckValid` checks three more, and every one of them fails the whole transaction with a single `CREATE_CLAIMABLE_BALANCE_MALFORMED = -1`. That result code carries `void`, so nothing on the wire says which claimant or which predicate was at fault.

This adds the missing checks to the builder so the failure surfaces at the call site with the reason attached.

### What core checks and the builder did not

From [`CreateClaimableBalanceOpFrame.cpp`](https://github.com/stellar/stellar-core/blob/master/src/transactions/CreateClaimableBalanceOpFrame.cpp):

```cpp
// check for duplicates
UnorderedSet<AccountID> dests;
for (auto const& claimant : claimants)
{
    auto const& dest = claimant.v0().destination;
    if (!dests.emplace(dest).second)
    {
        innerResult(res).code(CREATE_CLAIMABLE_BALANCE_MALFORMED);
        return false;
    }
}
```

```cpp
static bool
validatePredicate(ClaimPredicate const& pred, uint32_t depth)
{
    if (depth > 4)
    {
        return false;
    }
    ...
    case CLAIM_PREDICATE_AND:
    {
        auto const& andPredicates = pred.andPredicates();
        if (andPredicates.size() != 2)
        {
            return false;
        }
    ...
    case CLAIM_PREDICATE_NOT:
    {
        if (!pred.notPredicate())
        {
            return false;
        }
    ...
    case CLAIM_PREDICATE_BEFORE_ABSOLUTE_TIME:
        return pred.absBefore() >= 0;
    case CLAIM_PREDICATE_BEFORE_RELATIVE_TIME:
        return pred.relBefore() >= 0;
```

It is entered as `validatePredicate(claimant.v0().predicate, 1)`, so the root predicate is depth 1 and four levels are legal.

### Measured on `v17.0.0-rc.2` before this change

Each row builds an operation and encodes it with `op.toXdr("hex")`.

| Input | Today | Core |
|---|---|---|
| same destination on two claimants | encodes, 112 bytes | `MALFORMED` |
| predicate nested 5 levels | encodes, 100 bytes | `MALFORMED` |
| predicate nested 10 levels | encodes, 140 bytes | `MALFORMED` |
| `absBefore = -1` | encodes, 76 bytes | `MALFORMED` |
| `relBefore = -1` | encodes, 76 bytes | `MALFORMED` |
| `and` with 1 predicate | encodes, 76 bytes | `MALFORMED` |
| `or` with 0 predicates | encodes, 72 bytes | `MALFORMED` |
| `not` with `null` | encodes, 72 bytes | `MALFORMED` |
| `and` with 3 predicates | `XdrError: array length 3 exceeds maximum 2` | n/a |
| 11 claimants | `XdrError: array length 11 exceeds maximum 10` | n/a |

The last two rows are already caught, by the `<2>` and `<10>` array bounds in the XDR schema. The other eight encode cleanly and fail only once the transaction reaches the network. Those eight are what this PR adds.

Note that `claimants<10>` is a wire bound, not a `doCheckValid` rule; there is no separate claimant-count check in core, so nothing is added for it here.

### This is a behaviour change

The builder now throws where it previously returned an operation. Every newly rejected input is one the network refuses, so no submission that succeeds today starts failing. The three positive controls in the added tests (distinct destinations, a predicate nested exactly four levels, `absBefore = 0`) pass both before and after.

There is precedent for moving a core-side constraint to the client: `set_options.ts` throws locally for `masterWeight > 255`, which is likewise a rule core enforces. `Keypair.verify` in `v17.0.0-rc.2` moved in the same direction, from returning `false` to throwing on argument types it does not accept.

### Tests

Ten tests added to `test/unit/base/operations/create_claimable_balance.test.ts`, seven negative and three positive. On `main` without the source change, the seven negative tests fail and the three positive ones pass. With it, all seventeen tests in the file pass, and the full unit suite goes from 6627 to 6637 passing with no failures.

### Two things I would like your call on

1. `MAX_PREDICATE_DEPTH = 4` is a constant here mirroring core's literal `4`. If you would rather it lived somewhere shared, say where.
2. The depth, arity and sign checks could sit in `Claimant`'s predicate factories instead, failing at the point the predicate is built rather than when the operation is assembled. I put them in the operation builder because the duplicate-destination check has to live there anyway, and splitting the two halves seemed worse than keeping them together. Happy to move them.

### One thing I found while testing this, and could not resolve myself

`Transaction.getClaimableBalanceId()` uses this builder as a **type guard**, at `src/base/transaction.ts:362`:

```ts
try {
  Operation.createClaimableBalance(
    op as Parameters<typeof Operation.createClaimableBalance>[0],
  );
} catch (err) {
  throw new TypeError(
    `expected createClaimableBalance, got ${op.type}: ${String(err)}`,
  );
}
```

So every check added to the builder also reaches a read-only accessor. I built an envelope with two identical claimant destinations on `main`, then parsed the same bytes on each branch:

```
===== main =====
  parsed op type: createClaimableBalance
  getClaimableBalanceId OK: 000000009c4ae4f5db9e...

===== this branch =====
  parsed op type: createClaimableBalance
  getClaimableBalanceId THREW: TypeError: expected createClaimableBalance,
    got createClaimableBalance: Error: duplicate claimant destination: GCXOSFGC...
```

Reading an existing transaction is a legitimate thing to do whether or not the network accepted it, and it works today. Neither the full unit suite nor the 10 tests here catch this, because they all exercise the builder rather than the read path.

I can see three ways to resolve it and they are all your call rather than mine:

1. Loosen the guard in `getClaimableBalanceId` so it checks `op.type` instead of round-tripping through the builder.
2. Put the new validation behind an option, off by default.
3. Move the checks into `Claimant`'s factories, so they fire when a claimant is constructed rather than when the operation is assembled.

Tell me which you prefer and I will send it. If you would rather have this as an issue first, say so and I will close this and open one.

### On the CHANGELOG entry

I filed it under `### Fixed`. It could reasonably belong under `### Breaking Changes` instead, since calls that succeed today will throw. The file says a breaking change gets clearly marked, and where the line sits is your judgement rather than mine, so tell me and I will move it.

### Checks

- `tsc -p tsconfig.json --noEmit`, `eslint` and `prettier --check` all clean, run on Node 24 per the `>=22` engines field.
- `create_claimable_balance.test.ts`: 17 passed. With the source reverted to `main` and the tests kept, 7 fail and the 3 positive controls pass.
- Full `test/unit`: 6099 passed against 6089 on `main`, so exactly the 10 added tests, no regressions. The 41 pre-existing file-level failures (`ReferenceError: __PACKAGE_VERSION__ is not defined`) are identical on `main`.
- `docs_build`'s `git diff --exit-code -- docs/index.md docs/reference/` passes with no docs change needed.
