### PR TITLE
Document Deno usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Two Deno-specific things to keep in mind:
   `--allow-net` (or scope it, e.g.
   `--allow-net=horizon-testnet.stellar.org,soroban-testnet.stellar.org`).
 - **The CLI.** Run it without installing anything:
-  `deno run -A npm:@stellar/stellar-sdk generate …` (see [CLI](#cli)).
+  `deno run -A npm:@stellar/stellar-sdk` (see [CLI](#cli)).
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ npm install --save @stellar/stellar-sdk
 pnpm add @stellar/stellar-sdk
 # or
 yarn add @stellar/stellar-sdk
-# or, with Deno
+# or
 deno add npm:@stellar/stellar-sdk
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The library provides:
   - [...with React Native](#usage-with-react-native)
   - [...with Expo](#usage-with-expo-managed-workflows)
   - [...with CloudFlare Workers](#usage-with-cloudflare-workers)
+  - [...with Deno](#usage-with-deno)
 - [CLI](#cli): generate TypeScript bindings for Stellar smart contracts
 - [Migrating](#migrating): migration guides for breaking changes
 - [Developing](#developing): contribute to the project!
@@ -44,6 +45,8 @@ npm install --save @stellar/stellar-sdk
 pnpm add @stellar/stellar-sdk
 # or
 yarn add @stellar/stellar-sdk
+# or, with Deno
+deno add npm:@stellar/stellar-sdk
 ```
 
 Then, require or import it in your JavaScript code:
@@ -262,6 +265,33 @@ flag is no longer required for it. The one thing to watch for:
 - **Streaming.** Horizon's `.stream()` depends on `EventSource`; long-lived
   streaming connections don't fit the Workers request model well, so prefer
   polling (`.call()` / `.cursor()`) for Horizon data in a Worker.
+
+### Usage with Deno
+
+Deno pulls the SDK in through its npm compatibility layer. Add it to your
+`deno.json` (see [Installation](#installation)) and import the bare specifier,
+or skip that step and import the `npm:` specifier directly:
+
+```js
+import * as StellarSdk from "@stellar/stellar-sdk";
+// or, without adding it to deno.json
+import * as StellarSdk from "npm:@stellar/stellar-sdk";
+```
+
+Subpath imports work the same way, e.g.
+`import { Server } from "npm:@stellar/stellar-sdk/rpc"`.
+
+No polyfills are needed. As of v17 the SDK relies only on web APIs that Deno
+provides natively — `fetch`, `crypto.getRandomValues()`, `TextDecoder`, and
+`ReadableStream` — and it no longer uses `Buffer`.
+
+Two Deno-specific things to keep in mind:
+
+- **Permissions.** Horizon and RPC calls need network access, so run with
+  `--allow-net` (or scope it, e.g.
+  `--allow-net=horizon-testnet.stellar.org,soroban-testnet.stellar.org`).
+- **The CLI.** Run it without installing anything:
+  `deno run -A npm:@stellar/stellar-sdk generate …` (see [CLI](#cli)).
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -278,13 +278,6 @@ import * as StellarSdk from "@stellar/stellar-sdk";
 import * as StellarSdk from "npm:@stellar/stellar-sdk";
 ```
 
-Subpath imports work the same way, e.g.
-`import { Server } from "npm:@stellar/stellar-sdk/rpc"`.
-
-No polyfills are needed. As of v17 the SDK relies only on web APIs that Deno
-provides natively — `fetch`, `crypto.getRandomValues()`, `TextDecoder`, and
-`ReadableStream` — and it no longer uses `Buffer`.
-
 Two Deno-specific things to keep in mind:
 
 - **Permissions.** Horizon and RPC calls need network access, so run with

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ The library provides:
   - [...with React Native](#usage-with-react-native)
   - [...with Expo](#usage-with-expo-managed-workflows)
   - [...with CloudFlare Workers](#usage-with-cloudflare-workers)
+  - [...with Deno](#usage-with-deno)
 - [CLI](#cli): generate TypeScript bindings for Stellar smart contracts
 - [Migrating](#migrating): migration guides for breaking changes
 - [Developing](#developing): contribute to the project!
@@ -49,6 +50,8 @@ npm install --save @stellar/stellar-sdk
 pnpm add @stellar/stellar-sdk
 # or
 yarn add @stellar/stellar-sdk
+# or, with Deno
+deno add npm:@stellar/stellar-sdk
 ```
 
 Then, require or import it in your JavaScript code:
@@ -267,6 +270,33 @@ flag is no longer required for it. The one thing to watch for:
 - **Streaming.** Horizon's `.stream()` depends on `EventSource`; long-lived
   streaming connections don't fit the Workers request model well, so prefer
   polling (`.call()` / `.cursor()`) for Horizon data in a Worker.
+
+### Usage with Deno
+
+Deno pulls the SDK in through its npm compatibility layer. Add it to your
+`deno.json` (see [Installation](#installation)) and import the bare specifier,
+or skip that step and import the `npm:` specifier directly:
+
+```js
+import * as StellarSdk from "@stellar/stellar-sdk";
+// or, without adding it to deno.json
+import * as StellarSdk from "npm:@stellar/stellar-sdk";
+```
+
+Subpath imports work the same way, e.g.
+`import { Server } from "npm:@stellar/stellar-sdk/rpc"`.
+
+No polyfills are needed. As of v17 the SDK relies only on web APIs that Deno
+provides natively — `fetch`, `crypto.getRandomValues()`, `TextDecoder`, and
+`ReadableStream` — and it no longer uses `Buffer`.
+
+Two Deno-specific things to keep in mind:
+
+- **Permissions.** Horizon and RPC calls need network access, so run with
+  `--allow-net` (or scope it, e.g.
+  `--allow-net=horizon-testnet.stellar.org,soroban-testnet.stellar.org`).
+- **The CLI.** Run it without installing anything:
+  `deno run -A npm:@stellar/stellar-sdk generate …` (see [CLI](#cli)).
 
 ## CLI
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -283,13 +283,6 @@ import * as StellarSdk from "@stellar/stellar-sdk";
 import * as StellarSdk from "npm:@stellar/stellar-sdk";
 ```
 
-Subpath imports work the same way, e.g.
-`import { Server } from "npm:@stellar/stellar-sdk/rpc"`.
-
-No polyfills are needed. As of v17 the SDK relies only on web APIs that Deno
-provides natively — `fetch`, `crypto.getRandomValues()`, `TextDecoder`, and
-`ReadableStream` — and it no longer uses `Buffer`.
-
 Two Deno-specific things to keep in mind:
 
 - **Permissions.** Horizon and RPC calls need network access, so run with

--- a/docs/index.md
+++ b/docs/index.md
@@ -289,7 +289,7 @@ Two Deno-specific things to keep in mind:
   `--allow-net` (or scope it, e.g.
   `--allow-net=horizon-testnet.stellar.org,soroban-testnet.stellar.org`).
 - **The CLI.** Run it without installing anything:
-  `deno run -A npm:@stellar/stellar-sdk generate …` (see [CLI](#cli)).
+  `deno run -A npm:@stellar/stellar-sdk` (see [CLI](#cli)).
 
 ## CLI
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,7 +50,7 @@ npm install --save @stellar/stellar-sdk
 pnpm add @stellar/stellar-sdk
 # or
 yarn add @stellar/stellar-sdk
-# or, with Deno
+# or
 deno add npm:@stellar/stellar-sdk
 ```
 


### PR DESCRIPTION
### What

Add Deno to the installation options and a "Usage with Deno" section covering imports, network permissions, and running the bindings CLI.

### Why

The docs cover npm, browsers, React Native, Expo, and CloudFlare Workers, but not Deno.