### PR TITLE
fix(rpc): match the detail Friendbot actually returns for a funded account

### DIFF
--- a/docs/reference/network-rpc.md
+++ b/docs/reference/network-rpc.md
@@ -161,7 +161,7 @@ constructor(serverURL: string, opts: Options = {});
 - **`serverURL`** — `string` (required)
 - **`opts`** — `Options` (optional) (default: `{}`)
 
-**Source:** [src/rpc/server.ts:207](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L207)
+**Source:** [src/rpc/server.ts:232](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L232)
 
 ### `server.httpClient`
 
@@ -185,7 +185,7 @@ server.httpClient.interceptors.request.use((config) => {
 });
 ```
 
-**Source:** [src/rpc/server.ts:206](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L206)
+**Source:** [src/rpc/server.ts:231](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L231)
 
 ### `server.serverURL`
 
@@ -193,7 +193,7 @@ server.httpClient.interceptors.request.use((config) => {
 readonly serverURL: URL;
 ```
 
-**Source:** [src/rpc/server.ts:189](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L189)
+**Source:** [src/rpc/server.ts:214](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L214)
 
 ### `server._getEvents(request)`
 
@@ -205,7 +205,7 @@ _getEvents(request: GetEventsRequest): Promise<RawGetEventsResponse>;
 
 - **`request`** — `GetEventsRequest` (required)
 
-**Source:** [src/rpc/server.ts:1255](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1255)
+**Source:** [src/rpc/server.ts:1280](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1280)
 
 ### `server._getLatestLedger()`
 
@@ -213,7 +213,7 @@ _getEvents(request: GetEventsRequest): Promise<RawGetEventsResponse>;
 _getLatestLedger(): Promise<RawGetLatestLedgerResponse>;
 ```
 
-**Source:** [src/rpc/server.ts:1326](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1326)
+**Source:** [src/rpc/server.ts:1351](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1351)
 
 ### `server._getLedgerEntries(keys)`
 
@@ -225,7 +225,7 @@ _getLedgerEntries(...keys: LedgerKey[]): Promise<RawGetLedgerEntriesResponse>;
 
 - **`...keys`** — `LedgerKey[]` (required)
 
-**Source:** [src/rpc/server.ts:1020](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1020)
+**Source:** [src/rpc/server.ts:1045](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1045)
 
 ### `server._getLedgers(request)`
 
@@ -237,7 +237,7 @@ _getLedgers(request: GetLedgersRequest): Promise<RawGetLedgersResponse>;
 
 - **`request`** — `GetLedgersRequest` (required)
 
-**Source:** [src/rpc/server.ts:1944](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1944)
+**Source:** [src/rpc/server.ts:1968](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1968)
 
 ### `server._getTransaction(hash)`
 
@@ -249,7 +249,7 @@ _getTransaction(hash: string): Promise<RawGetTransactionResponse>;
 
 - **`hash`** — `string` (required)
 
-**Source:** [src/rpc/server.ts:1143](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1143)
+**Source:** [src/rpc/server.ts:1168](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1168)
 
 ### `server._getTransactions(request)`
 
@@ -261,7 +261,7 @@ _getTransactions(request: GetTransactionsRequest): Promise<RawGetTransactionsRes
 
 - **`request`** — `GetTransactionsRequest` (required)
 
-**Source:** [src/rpc/server.ts:1194](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1194)
+**Source:** [src/rpc/server.ts:1219](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1219)
 
 ### `server._sendTransaction(transaction)`
 
@@ -273,7 +273,7 @@ _sendTransaction(transaction: Transaction | FeeBumpTransaction): Promise<RawSend
 
 - **`transaction`** — `Transaction | FeeBumpTransaction` (required)
 
-**Source:** [src/rpc/server.ts:1583](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1583)
+**Source:** [src/rpc/server.ts:1608](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1608)
 
 ### `server._simulateTransaction(transaction, addlResources, authMode, useUpgradedAuth)`
 
@@ -288,7 +288,7 @@ _simulateTransaction(transaction: Transaction | FeeBumpTransaction, addlResource
 - **`authMode`** — `SimulationAuthMode` (optional)
 - **`useUpgradedAuth`** — `boolean` (optional) (default: `true`)
 
-**Source:** [src/rpc/server.ts:1412](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1412)
+**Source:** [src/rpc/server.ts:1437](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1437)
 
 ### `server.fundAddress(address, friendbotUrl)`
 
@@ -341,7 +341,7 @@ console.log("Contract funded! Hash:", tx.txHash);
 
 - `Friendbot docs`
 
-**Source:** [src/rpc/server.ts:1703](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1703)
+**Source:** [src/rpc/server.ts:1727](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1727)
 
 ### `server.getAccount(address)`
 
@@ -376,7 +376,7 @@ server.getAccount(accountId).then((account) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:240](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L240)
+**Source:** [src/rpc/server.ts:265](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L265)
 
 ### `server.getAccountEntry(address)`
 
@@ -408,7 +408,7 @@ server.getAccountEntry(accountId).then((account) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:263](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L263)
+**Source:** [src/rpc/server.ts:288](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L288)
 
 ### `server.getAssetBalance(address, asset, networkPassphrase)`
 
@@ -454,7 +454,7 @@ const balance = await server.getAssetBalance("GD...", usdc);
 console.log(balance.balanceEntry?.amount);
 ```
 
-**Source:** [src/rpc/server.ts:424](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L424)
+**Source:** [src/rpc/server.ts:449](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L449)
 
 ### `server.getClaimableBalance(id)`
 
@@ -490,7 +490,7 @@ server.getClaimableBalance(id).then((entry) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:355](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L355)
+**Source:** [src/rpc/server.ts:380](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L380)
 
 ### `server.getContractData(contract, key, durability)`
 
@@ -538,7 +538,7 @@ server.getContractData(contractId, key, Durability.Temporary).then(data => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:525](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L525)
+**Source:** [src/rpc/server.ts:550](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L550)
 
 ### `server.getContractInstance(contractId)`
 
@@ -572,7 +572,7 @@ const instance = await server.getContractInstance(
 console.log(instance.executable.type);
 ```
 
-**Source:** [src/rpc/server.ts:594](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L594)
+**Source:** [src/rpc/server.ts:619](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L619)
 
 ### `server.getContractMethods(contractId, networkPassphrase)`
 
@@ -617,7 +617,7 @@ const methods = await server.getContractMethods(
 // ]
 ```
 
-**Source:** [src/rpc/server.ts:943](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L943)
+**Source:** [src/rpc/server.ts:968](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L968)
 
 ### `server.getContractWasmByContractId(contractId)`
 
@@ -662,7 +662,7 @@ server.getContractWasmByContractId(contractId).then(wasmBytes => {
 });
 ```
 
-**Source:** [src/rpc/server.ts:720](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L720)
+**Source:** [src/rpc/server.ts:745](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L745)
 
 ### `server.getContractWasmByHash(wasmHash, format)`
 
@@ -702,7 +702,7 @@ server.getContractWasmByHash(wasmHash).then(wasmBytes => {
 });
 ```
 
-**Source:** [src/rpc/server.ts:775](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L775)
+**Source:** [src/rpc/server.ts:800](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L800)
 
 ### `server.getEvents(request)`
 
@@ -760,7 +760,7 @@ server.getEvents({
 
 - `getEvents docs`
 
-**Source:** [src/rpc/server.ts:1249](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1249)
+**Source:** [src/rpc/server.ts:1274](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1274)
 
 ### `server.getExternalRefWasmHash(ref)`
 
@@ -802,7 +802,7 @@ if (instance.executable.type === "contractExecutableExternalRef") {
 }
 ```
 
-**Source:** [src/rpc/server.ts:649](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L649)
+**Source:** [src/rpc/server.ts:674](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L674)
 
 ### `server.getFeeStats()`
 
@@ -821,7 +821,7 @@ the fee stats
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getFeeStats
 
-**Source:** [src/rpc/server.ts:1749](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1749)
+**Source:** [src/rpc/server.ts:1773](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1773)
 
 ### `server.getHealth()`
 
@@ -849,7 +849,7 @@ server.getHealth().then((health) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:483](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L483)
+**Source:** [src/rpc/server.ts:508](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L508)
 
 ### `server.getLatestLedger()`
 
@@ -879,7 +879,7 @@ server.getLatestLedger().then((response) => {
 
 - `getLatestLedger docs`
 
-**Source:** [src/rpc/server.ts:1322](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1322)
+**Source:** [src/rpc/server.ts:1347](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1347)
 
 ### `server.getLedgerEntries(keys)`
 
@@ -929,7 +929,7 @@ server.getLedgerEntries([key]).then(response => {
 - - `getLedgerEntries docs`
  - RpcServer._getLedgerEntries
 
-**Source:** [src/rpc/server.ts:1016](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1016)
+**Source:** [src/rpc/server.ts:1041](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1041)
 
 ### `server.getLedgerEntry(key)`
 
@@ -941,7 +941,7 @@ getLedgerEntry(key: LedgerKey): Promise<LedgerEntryResult>;
 
 - **`key`** — `LedgerKey` (required)
 
-**Source:** [src/rpc/server.ts:1031](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1031)
+**Source:** [src/rpc/server.ts:1056](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1056)
 
 ### `server.getLedgers(request)`
 
@@ -1007,7 +1007,7 @@ const nextPage = await server.getLedgers({
 
 - `getLedgers docs`
 
-**Source:** [src/rpc/server.ts:1928](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1928)
+**Source:** [src/rpc/server.ts:1952](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1952)
 
 ### `server.getNetwork()`
 
@@ -1036,7 +1036,7 @@ server.getNetwork().then((network) => {
 
 - `getNetwork docs`
 
-**Source:** [src/rpc/server.ts:1296](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1296)
+**Source:** [src/rpc/server.ts:1321](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1321)
 
 ### `server.getSACBalance(address, sac, networkPassphrase)`
 
@@ -1095,7 +1095,7 @@ console.log(
 - - getLedgerEntries
  - https://developers.stellar.org/docs/tokens/stellar-asset-contract
 
-**Source:** [src/rpc/server.ts:1813](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1813)
+**Source:** [src/rpc/server.ts:1837](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1837)
 
 ### `server.getTransaction(hash)`
 
@@ -1133,7 +1133,7 @@ server.getTransaction(transactionHash).then((tx) => {
 
 - `getTransaction docs`
 
-**Source:** [src/rpc/server.ts:1116](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1116)
+**Source:** [src/rpc/server.ts:1141](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1141)
 
 ### `server.getTransactions(request)`
 
@@ -1169,7 +1169,7 @@ server.getTransactions({
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getTransactions
 
-**Source:** [src/rpc/server.ts:1176](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1176)
+**Source:** [src/rpc/server.ts:1201](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1201)
 
 ### `server.getTrustline(account, asset)`
 
@@ -1208,7 +1208,7 @@ server.getTrustline(accountId, asset).then((entry) => {
 
 - `getLedgerEntries docs`
 
-**Source:** [src/rpc/server.ts:307](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L307)
+**Source:** [src/rpc/server.ts:332](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L332)
 
 ### `server.getVersionInfo()`
 
@@ -1226,7 +1226,7 @@ the version info
 
 - https://developers.stellar.org/docs/data/rpc/api-reference/methods/getVersionInfo
 
-**Source:** [src/rpc/server.ts:1763](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1763)
+**Source:** [src/rpc/server.ts:1787](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1787)
 
 ### `server.pollTransaction(hash, opts)`
 
@@ -1266,7 +1266,7 @@ const txStatus = await server.pollTransaction(h, {
 }); // this will take 5,050 seconds to complete
 ```
 
-**Source:** [src/rpc/server.ts:1069](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1069)
+**Source:** [src/rpc/server.ts:1094](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1094)
 
 ### `server.prepareTransaction(tx, useUpgradedAuth)`
 
@@ -1363,7 +1363,7 @@ server.sendTransaction(transaction).then(result => {
 - - module:rpc.assembleTransaction
  - `simulateTransaction docs`
 
-**Source:** [src/rpc/server.ts:1514](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1514)
+**Source:** [src/rpc/server.ts:1539](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1539)
 
 ### `server.queryContract(contractId, method, args, networkPassphrase)`
 
@@ -1421,7 +1421,7 @@ const { result: balance } = await server.queryContract<bigint>(
 );
 ```
 
-**Source:** [src/rpc/server.ts:858](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L858)
+**Source:** [src/rpc/server.ts:883](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L883)
 
 ### `server.requestAirdrop(address, friendbotUrl)`
 
@@ -1471,7 +1471,7 @@ server
 - - `Friendbot docs`
  - [`Friendbot.Api.Response`](/reference/network-friendbot/#friendbotapiresponse)
 
-**Source:** [src/rpc/server.ts:1628](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1628)
+**Source:** [src/rpc/server.ts:1653](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1653)
 
 ### `server.sendTransaction(transaction)`
 
@@ -1532,7 +1532,7 @@ server.sendTransaction(transaction).then((result) => {
 - - `transaction docs`
  - `sendTransaction docs`
 
-**Source:** [src/rpc/server.ts:1577](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1577)
+**Source:** [src/rpc/server.ts:1602](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1602)
 
 ### `server.simulateTransaction(tx, addlResources, authMode, useUpgradedAuth)`
 
@@ -1606,7 +1606,7 @@ server.simulateTransaction(transaction).then((sim) => {
  - module:rpc.Server#prepareTransaction
  - module:rpc.assembleTransaction
 
-**Source:** [src/rpc/server.ts:1398](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1398)
+**Source:** [src/rpc/server.ts:1423](https://github.com/stellar/js-stellar-sdk/blob/main/src/rpc/server.ts#L1423)
 
 ## rpc.assembleTransaction
 

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -164,6 +164,31 @@ function findCreatedAccountSequenceInTransactionMeta(
  * `scSpecTypeU32` becomes `U32` and `scSpecTypeAddress` becomes `Address`.
  * User-defined types (structs/enums/unions) are shown by their declared name.
  */
+/**
+ * Whether a Friendbot 400 means "this account already has funds".
+ *
+ * Friendbot answers a request for an already-funded account with a
+ * human-readable `detail`, currently `"account already funded to starting
+ * balance"`. It does not return `createAccountAlreadyExist`: that is the name
+ * of the XDR `CreateAccountResultCode` enum member, which never reaches the
+ * HTTP body.
+ *
+ * The match is deliberately loose because the wording is Friendbot's, not part
+ * of any spec, and it has changed before. Matching the shape of the phrase
+ * rather than one exact string keeps this working when the wording shifts
+ * again. The legacy enum name stays accepted so any caller or fixture still
+ * producing it keeps working.
+ */
+function isAlreadyFundedDetail(detail: unknown): boolean {
+  if (typeof detail !== "string") {
+    return false;
+  }
+  return (
+    /already\s+(funded|exists?)/i.test(detail) ||
+    detail.includes("createAccountAlreadyExist")
+  );
+}
+
 function contractSpecTypeName(td: ScSpecTypeDef): string {
   if (td.type === "scSpecTypeUdt") {
     return td.value.name.toString();
@@ -1654,13 +1679,12 @@ export class RpcServer {
       const sequence = findCreatedAccountSequenceInTransactionMeta(meta);
       return new Account(account, sequence);
     } catch (error: any) {
-      if (error.response?.status === 400) {
-        if (
-          error.response.data?.detail?.includes("createAccountAlreadyExist")
-        ) {
-          // Account already exists, load the sequence number
-          return this.getAccount(account);
-        }
+      if (
+        error.response?.status === 400 &&
+        isAlreadyFundedDetail(error.response.data?.detail)
+      ) {
+        // Account already exists, load the sequence number
+        return this.getAccount(account);
       }
       throw error;
     }

--- a/test/unit/server/soroban/request_airdrop.test.ts
+++ b/test/unit/server/soroban/request_airdrop.test.ts
@@ -146,7 +146,11 @@ describe("Server#requestAirdrop", () => {
     const friendbotError = {
       response: {
         status: 400,
-        data: { detail: "createAccountAlreadyExist" },
+        // El detail real que devuelve friendbot. El valor anterior de este
+        // fixture era "createAccountAlreadyExist", el nombre del enum XDR, que
+        // friendbot no emite nunca: el test le daba al codigo exactamente el
+        // string que el codigo buscaba, asi que pasaba sin probar nada.
+        data: { detail: "account already funded to starting balance" },
       },
     };
 
@@ -195,6 +199,102 @@ describe("Server#requestAirdrop", () => {
       params: { keys: [ledgerKey.toXdr("base64")] },
     });
     expect(mockPost).toHaveBeenCalledTimes(3);
+  });
+
+  // Friendbot's `detail` is prose, not a spec'd value, so the guard matches the
+  // shape of the phrase rather than one exact string. These pin both the real
+  // wording and the legacy enum name, so neither can regress silently.
+  it.each([
+    [
+      "the current friendbot wording",
+      "account already funded to starting balance",
+    ],
+    ["a shorter variant", "account already funded"],
+    ["the legacy XDR enum name", "createAccountAlreadyExist"],
+    ["op_already_exists style wording", "account already exists"],
+  ])("returns the existing account for %s", async (_label, detail) => {
+    const friendbotUrl = "https://friendbot.stellar.org";
+    const accountId =
+      "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
+
+    const networkResponse = {
+      data: {
+        result: {
+          friendbotUrl,
+          passphrase: Networks.FUTURENET,
+          protocolVersion: 20,
+        },
+      },
+    };
+
+    const friendbotError = {
+      response: { status: 400, data: { detail } },
+    };
+
+    const accountEntry = accountLedgerEntryData();
+    const ledgerKey = xdr.LedgerKey.account(
+      new xdr.LedgerKeyAccount({
+        accountId: Keypair.fromPublicKey(accountId).xdrPublicKey(),
+      }),
+    );
+    const ledgerEntryResponse = {
+      data: {
+        result: {
+          latestLedger: 0,
+          entries: [
+            {
+              key: ledgerKey.toXdr("base64"),
+              xdr: accountEntry.toXdr("base64"),
+            },
+          ],
+        },
+      },
+    };
+
+    mockPost
+      .mockResolvedValueOnce(networkResponse)
+      .mockRejectedValueOnce(friendbotError)
+      .mockResolvedValueOnce(ledgerEntryResponse);
+
+    const result = await server.requestAirdrop(accountId);
+    expect(result).toBeInstanceOf(Account);
+    expect(result.accountId()).toBe(accountId);
+  });
+
+  // The guard must stay narrow: a 400 that is not about existing funds has to
+  // keep propagating, or a real failure gets silently turned into a lookup.
+  it.each([
+    ["a malformed address", "invalid address format"],
+    ["a rate limit", "too many requests from this IP"],
+    ["an empty detail", ""],
+    ["a missing detail", undefined],
+    ["a non-string detail", { code: "createAccountAlreadyExist" }],
+  ])("rethrows a 400 caused by %s", async (_label, detail) => {
+    const friendbotUrl = "https://friendbot.stellar.org";
+    const accountId =
+      "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPV6LY4UV2GL6VJGIQRXFDNMADI";
+
+    const networkResponse = {
+      data: {
+        result: {
+          friendbotUrl,
+          passphrase: Networks.FUTURENET,
+          protocolVersion: 20,
+        },
+      },
+    };
+
+    const friendbotError = {
+      response: { status: 400, data: { detail } },
+    };
+
+    mockPost
+      .mockResolvedValueOnce(networkResponse)
+      .mockRejectedValueOnce(friendbotError);
+
+    await expect(server.requestAirdrop(accountId)).rejects.toBe(friendbotError);
+    // Sin llamada a getLedgerEntries: getNetwork y friendbot, y nada mas.
+    expect(mockPost).toHaveBeenCalledTimes(2);
   });
 
   it("throws an error if friendbot is not available", async () => {


### PR DESCRIPTION
Closes #1645

## The bug

`requestAirdrop` has a branch to return the existing account when Friendbot reports it is already funded. It matches on `"createAccountAlreadyExist"`, which is the name of the XDR `CreateAccountResultCode` enum member. Friendbot never puts that in the HTTP body: it returns prose, currently `"account already funded to starting balance"`.

So the branch has never been reachable. The method throws a bare `AxiosError` reading `Request failed with status code 400`, and the code that exists to handle the case reads as "this is handled" to anyone auditing the source.

## Why CI never caught it

This is the part I think matters most, so I want to state it plainly.

The existing test at `test/unit/server/soroban/request_airdrop.test.ts` mocked the Friendbot 400 like this:

```ts
data: { detail: "createAccountAlreadyExist" },
```

The fixture fed the code **exactly the string the code was looking for**. The test asserted that `requestAirdrop` returns an `Account`, it passed, and it proved nothing about Friendbot's real behaviour. A test built from the implementation instead of from the wire format cannot fail when the implementation is wrong about the wire format.

I changed that fixture to the real `detail`. That change alone makes the pre-existing test fail against the old code, which is the point.

## The fix

`src/rpc/server.ts`. The guard now goes through a small named helper:

```ts
function isAlreadyFundedDetail(detail: unknown): boolean {
  if (typeof detail !== "string") {
    return false;
  }
  return (
    /already\s+(funded|exists?)/i.test(detail) ||
    detail.includes("createAccountAlreadyExist")
  );
}
```

Three deliberate decisions:

**The match is loose.** Friendbot's `detail` is prose, not a spec'd value, and the wording has changed before. Pinning one exact string just moves the same bug to the next rewording. Matching the shape of the phrase survives that.

**The legacy enum name stays accepted.** Anyone with a fixture or a proxy still producing it keeps working. It costs one clause.

**The type guard is not decoration.** The old code called `detail?.includes(...)` on whatever arrived. If `detail` is an object (`{ code: "createAccountAlreadyExist" }`, which is a plausible shape for a proxy or a future Friendbot), `.includes` is `undefined` and calling it throws a `TypeError` that **replaces the original error**. So the caller loses the 400 entirely and gets a confusing type error instead. That is a second, smaller bug, not mentioned in the issue, and the `typeof` check closes it. There is a regression test for it.

## Tests

Nine new cases in the existing file, as two tables.

**Four that must return the existing account:** the current Friendbot wording, a shorter variant, `"account already exists"`, and the legacy enum name.

**Five that must keep throwing:** a malformed address, a rate limit, an empty `detail`, a missing `detail`, and a non-string `detail`. These matter as much as the first group: a guard that is too wide turns a real failure into a silent account lookup. Each also asserts `getLedgerEntries` was never called, so a widened guard cannot pass by accident.

## Verification

I checked that the tests actually detect the bug, rather than only passing alongside the fix. Reverting `server.ts` and keeping the new tests:

```
Tests  5 failed | 18 passed (23)

FAIL  returns false if the account already exists          <- the pre-existing test, with the real fixture
FAIL  returns the existing account for the current friendbot wording
FAIL  returns the existing account for a shorter variant
FAIL  returns the existing account for op_already_exists style wording
FAIL  rethrows a 400 caused by a non-string detail
```

With the fix restored, 23 of 23 pass.

Full unit suite, unchanged otherwise:

```
Test Files  130 passed (130)
     Tests  6667 passed | 4 skipped | 9 todo (6680)
```

`tsc -p tsconfig.json --noEmit` is clean.

## Note on `fundAddress`

`requestAirdrop` is deprecated in favour of `fundAddress`, so I checked whether the replacement carries the same bug. It does not, and I did not touch it. `fundAddress` converts a 400 into `new Error(detail)`, which at least surfaces the reason instead of a bare `AxiosError`. It still throws for an already-funded address, but that is defensible: it returns a transaction response, and for an account that needs no funding there is no transaction to return. Different contract, different correct answer.

## Out of scope

The `stellar` CLI already handles this case correctly (`already funded error ignored because account is funded`). Aligning the two implementations beyond this fix is a larger conversation and I did not attempt it here.

## The second commit

`docs/reference/network-rpc.md` is regenerated output, and the `pre-push` hook blocks a push that leaves it stale. The diff is **only line-number shifts** in `**Source:**` links, because the helper added 25 lines above the class. No documentation text changed. I kept it as a separate commit so the fix stays readable on its own.
