### PR TITLE
fix(xdr): throw on an unusable type argument at the call site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Fixed
-* The type-generic `xdr` helpers — `encodeArray`, `decodeArray`, `decodeStream` and the `fromXdr` / `validateXdr` / `fromJson` statics — now throw a `TypeError` naming the helper and the argument when it has no static schema, such as an `Int64`/`Uint32` shim or an abstract base ([#1680](https://github.com/stellar/js-stellar-sdk/issues/1680)). `xdr.encodeArray(xdr.Uint32, [1])` previously threw `TypeError: v.toXdrObject is not a function`, and on an empty list returned a valid-looking 4-byte count. Valid types are unaffected.
+* The type-generic `xdr` helpers — `encodeArray`, `decodeArray`, `decodeStream` and the `fromXdr` / `validateXdr` / `fromJson` statics — now throw a `TypeError` naming the helper and the argument when it has no static schema, such as an `Int64`/`Uint32` shim or an abstract base ([#1682](https://github.com/stellar/js-stellar-sdk/pull/1682)). `xdr.encodeArray(xdr.Uint32, [1])` previously threw `TypeError: v.toXdrObject is not a function`, and on an empty list returned a valid-looking 4-byte count. The four decode paths also name a missing `static fromXdrObject`, which only they need. Valid types are unaffected.
 * `xdr.Int32`, `xdr.Uint32`, `xdr.Int64` and `xdr.Uint64` report their XDR type name from `.name`, instead of the internal `"Shim"`.
 
 ## [v17.0.0](https://github.com/stellar/js-stellar-sdk/compare/v16.2.0...v17.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 A breaking change will get clearly marked in this log.
 
+## Unreleased
+
+### Fixed
+* The type-generic `xdr` helpers — `encodeArray`, `decodeArray`, `decodeStream` and the `fromXdr` / `validateXdr` / `fromJson` statics — now throw a `TypeError` naming the helper and the argument when it has no static schema, such as an `Int64`/`Uint32` shim or an abstract base ([#1680](https://github.com/stellar/js-stellar-sdk/issues/1680)). `xdr.encodeArray(xdr.Uint32, [1])` previously threw `TypeError: v.toXdrObject is not a function`, and on an empty list returned a valid-looking 4-byte count. Valid types are unaffected.
+* `xdr.Int32`, `xdr.Uint32`, `xdr.Int64` and `xdr.Uint64` report their XDR type name from `.name`, instead of the internal `"Shim"`.
+
 ## [v17.0.0](https://github.com/stellar/js-stellar-sdk/compare/v16.2.0...v17.0.0)
 
 ### Breaking Changes

--- a/docs/migration/xdr-migration.md
+++ b/docs/migration/xdr-migration.md
@@ -114,12 +114,15 @@ The one runtime use the array typedefs had was encoding or decoding a whole
 list as a single length-prefixed blob (e.g.
 `xdr.LedgerEntryChanges.fromXDR(feeMetaXdr, "base64")` on Horizon's
 `fee_meta_xdr`). That job moved to the generic `encodeArray` / `decodeArray`
-helpers, which work with any XDR class:
+helpers, which work with any generated XDR class:
 
 ```js
 const changes = xdr.decodeArray(xdr.LedgerEntryChange, feeMetaXdr, "base64");
 const blob = xdr.encodeArray(xdr.LedgerEntryChange, changes, "base64");
 ```
+
+Both throw a `TypeError` naming the argument if it has no static schema: the
+integer shims (§ 4) and the abstract base classes are not usable here.
 
 This is only for the bare typedef wire format. Lists exchanged as one base64
 string per element (RPC simulation auth entries, `operation.auth`) still use

--- a/src/xdr/index.ts
+++ b/src/xdr/index.ts
@@ -133,6 +133,9 @@ function makeBigIntShim(signed: boolean, bits: 64) {
   };
   Shim.MAX_VALUE = max;
   Shim.MIN_VALUE = min;
+  // Both factories declare `function Shim`, so without this every message that
+  // interpolates the type name reads "Shim".
+  Object.defineProperty(Shim, "name", { value: name });
   return new Proxy(Shim, {
     construct(_target, args) {
       // A construct trap must return an object, and a boxed bigint fails the
@@ -180,6 +183,9 @@ function makeIntShim(signed: boolean, bits: 32) {
   };
   Shim.MAX_VALUE = max;
   Shim.MIN_VALUE = min;
+  // Both factories declare `function Shim`, so without this every message that
+  // interpolates the type name reads "Shim".
+  Object.defineProperty(Shim, "name", { value: name });
   return new Proxy(Shim, {
     construct(_target, args) {
       // Without this trap, `new` would discard the primitive return value

--- a/src/xdr/values/xdr-value.ts
+++ b/src/xdr/values/xdr-value.ts
@@ -109,7 +109,7 @@ export abstract class XdrValue {
     input: Uint8Array | string,
     format?: "hex" | "base64",
   ): Instance {
-    assertXdrType(this, "fromXdr");
+    assertXdrType(this, "fromXdr", true);
     const bytes = decodeBytes(input, format);
     return this.fromXdrObject(this.schema.decode(bytes));
   }
@@ -152,7 +152,7 @@ export abstract class XdrValue {
     this: XdrValueConstructor<Wire, Instance>,
     json: JsonValue,
   ): Instance {
-    assertXdrType(this, "fromJson");
+    assertXdrType(this, "fromJson", true);
     return this.fromXdrObject(walkFromJson(json, this.schema) as Wire);
   }
 }
@@ -162,7 +162,8 @@ export abstract class XdrValue {
  * back-to-back (e.g. a contract spec's `ScSpecEntry` stream). Throws
  * `XdrError` if the buffer ends mid-value.
  *
- * @throws a `TypeError` when `type` carries no static schema
+ * @throws a `TypeError` when `type` carries no static schema, or no static
+ * `fromXdrObject` to build values with
  */
 export function decodeStream<Wire, Instance extends XdrValue>(
   type: XdrValueConstructor<Wire, Instance>,
@@ -178,7 +179,7 @@ export function decodeStream<Wire, Instance extends XdrValue>(
   input: Uint8Array | string,
   format?: "hex" | "base64",
 ): Instance[] {
-  assertXdrType(type, "decodeStream");
+  assertXdrType(type, "decodeStream", true);
   const reader = new Reader(decodeBytes(input, format));
   const path = type.schema.name ?? type.name;
   const out: Instance[] = [];
@@ -257,7 +258,8 @@ export function encodeArray<Wire, Instance extends XdrValue>(
  * the payload. For a buffer of values concatenated with no length prefix, use
  * {@link decodeStream}.
  *
- * @throws a `TypeError` when `type` carries no static schema
+ * @throws a `TypeError` when `type` carries no static schema, or no static
+ * `fromXdrObject` to build values with
  */
 export function decodeArray<Wire, Instance extends XdrValue>(
   type: XdrValueConstructor<Wire, Instance>,
@@ -277,7 +279,7 @@ export function decodeArray<Wire, Instance extends XdrValue>(
   maybeOptions?: XdrArrayOptions,
 ): Instance[] {
   const [format, options] = splitArrayArgs(formatOrOptions, maybeOptions);
-  assertXdrType(type, "decodeArray");
+  assertXdrType(type, "decodeArray", true);
   const codec = array(type.schema, options.maxLength ?? UNBOUNDED_MAX_LENGTH);
   const wires = codec.decode(
     decodeBytes(input, format as "hex" | "base64" | undefined),
@@ -294,6 +296,7 @@ export function decodeArray<Wire, Instance extends XdrValue>(
 interface UncheckedXdrType {
   readonly schema?: unknown;
   readonly name?: string;
+  readonly fromXdrObject?: unknown;
 }
 
 /**
@@ -303,7 +306,11 @@ interface UncheckedXdrType {
  * and a null-prototype object throws on `String()`.
  */
 function describeType(type: unknown): string {
-  if (typeof type === "function") return type.name || "an anonymous class";
+  // `typeof` cannot tell a class from an ordinary or arrow function, and an
+  // unnamed one of any kind lands here, so the wording covers both.
+  if (typeof type === "function") {
+    return type.name || "an anonymous function or class";
+  }
   if (type === null || type === undefined) return String(type);
   if (typeof type === "object") {
     return `an instance of ${type.constructor?.name || "an anonymous object"}`;
@@ -323,17 +330,31 @@ function describeType(type: unknown): string {
  * Only a bad *type* throws here. Thin or malformed *data* keeps its existing
  * behaviour, so an empty list still round-trips and `validateXdr` still
  * returns `false` rather than throwing.
+ *
+ * The requirement differs by direction, so `needsFromXdrObject` is set only by
+ * the decode paths. `encodeArray` and `validateXdr` never call
+ * `fromXdrObject`, and a class that declares a schema without one encodes
+ * correctly — requiring it there would reject a type that works.
  */
 function assertXdrType(
   type: UncheckedXdrType | null | undefined,
   fn: string,
+  needsFromXdrObject = false,
 ): void {
-  if (type?.schema) return;
-  throw new TypeError(
-    `${fn}: ${describeType(type)} has no static schema, so it is not a ` +
-      `usable XDR type. Pass a generated class such as xdr.ScVal, or ` +
-      "declare `static readonly schema` on a class of your own.",
-  );
+  if (!type?.schema) {
+    throw new TypeError(
+      `${fn}: ${describeType(type)} has no static schema, so it is not a ` +
+        `usable XDR type. Pass a generated class such as xdr.ScVal, or ` +
+        "declare `static readonly schema` on a class of your own.",
+    );
+  }
+  if (needsFromXdrObject && typeof type.fromXdrObject !== "function") {
+    throw new TypeError(
+      `${fn}: ${describeType(type)} has a static schema but no static ` +
+        "fromXdrObject, so it can encode but not decode. Declare " +
+        "`static fromXdrObject(wire)` on it.",
+    );
+  }
 }
 
 /**

--- a/src/xdr/values/xdr-value.ts
+++ b/src/xdr/values/xdr-value.ts
@@ -109,6 +109,7 @@ export abstract class XdrValue {
     input: Uint8Array | string,
     format?: "hex" | "base64",
   ): Instance {
+    assertXdrType(this, "fromXdr");
     const bytes = decodeBytes(input, format);
     return this.fromXdrObject(this.schema.decode(bytes));
   }
@@ -118,6 +119,10 @@ export abstract class XdrValue {
    * without the throw. Returns `false` on any failure (bad hex/base64, wrong
    * shape, trailing bytes) and discards the error detail; decode directly
    * when you need the reason.
+   *
+   * @throws a `TypeError` when the type itself carries no static schema. Only
+   * invalid *data* returns `false`; a type that cannot decode is a caller
+   * mistake and is not reported as a validation failure.
    */
   static validateXdr<Wire, Instance extends XdrValue>(
     this: XdrValueConstructor<Wire, Instance>,
@@ -133,6 +138,7 @@ export abstract class XdrValue {
     input: Uint8Array | string,
     format?: "hex" | "base64",
   ): boolean {
+    assertXdrType(this, "validateXdr");
     let bytes: Uint8Array;
     try {
       bytes = decodeBytes(input, format);
@@ -146,6 +152,7 @@ export abstract class XdrValue {
     this: XdrValueConstructor<Wire, Instance>,
     json: JsonValue,
   ): Instance {
+    assertXdrType(this, "fromJson");
     return this.fromXdrObject(walkFromJson(json, this.schema) as Wire);
   }
 }
@@ -154,6 +161,8 @@ export abstract class XdrValue {
  * Decode a buffer containing several XDR values of one type, concatenated
  * back-to-back (e.g. a contract spec's `ScSpecEntry` stream). Throws
  * `XdrError` if the buffer ends mid-value.
+ *
+ * @throws a `TypeError` when `type` carries no static schema
  */
 export function decodeStream<Wire, Instance extends XdrValue>(
   type: XdrValueConstructor<Wire, Instance>,
@@ -169,6 +178,7 @@ export function decodeStream<Wire, Instance extends XdrValue>(
   input: Uint8Array | string,
   format?: "hex" | "base64",
 ): Instance[] {
+  assertXdrType(type, "decodeStream");
   const reader = new Reader(decodeBytes(input, format));
   const path = type.schema.name ?? type.name;
   const out: Instance[] = [];
@@ -204,6 +214,8 @@ export interface XdrArrayOptions {
  * list as one blob, such as Horizon's `fee_meta_xdr`. For lists exchanged as
  * one string per element, encode each element with `value.toXdr(format)`
  * instead.
+ *
+ * @throws a `TypeError` when `type` carries no static schema
  */
 export function encodeArray<Wire, Instance extends XdrValue>(
   type: XdrValueConstructor<Wire, Instance>,
@@ -229,6 +241,7 @@ export function encodeArray<Wire, Instance extends XdrValue>(
   maybeOptions?: XdrArrayOptions,
 ): Uint8Array | string {
   const [format, options] = splitArrayArgs(formatOrOptions, maybeOptions);
+  assertXdrType(type, "encodeArray");
   const codec = array(type.schema, options.maxLength ?? UNBOUNDED_MAX_LENGTH);
   const bytes = codec.encode(
     values.map((v) => v.toXdrObject() as Wire),
@@ -243,6 +256,8 @@ export function encodeArray<Wire, Instance extends XdrValue>(
  * `XdrError` on a short buffer, trailing bytes, or a count that doesn't match
  * the payload. For a buffer of values concatenated with no length prefix, use
  * {@link decodeStream}.
+ *
+ * @throws a `TypeError` when `type` carries no static schema
  */
 export function decodeArray<Wire, Instance extends XdrValue>(
   type: XdrValueConstructor<Wire, Instance>,
@@ -262,12 +277,63 @@ export function decodeArray<Wire, Instance extends XdrValue>(
   maybeOptions?: XdrArrayOptions,
 ): Instance[] {
   const [format, options] = splitArrayArgs(formatOrOptions, maybeOptions);
+  assertXdrType(type, "decodeArray");
   const codec = array(type.schema, options.maxLength ?? UNBOUNDED_MAX_LENGTH);
   const wires = codec.decode(
     decodeBytes(input, format as "hex" | "base64" | undefined),
     { maxDepth: options.maxDepth },
   );
   return wires.map((w) => type.fromXdrObject(w));
+}
+
+/**
+ * A `type` argument before it has been checked. The generated classes satisfy
+ * {@link XdrValueConstructor}, but nothing stops a plain-JS caller passing a
+ * primitive shim, an abstract base, or something that is not a type at all.
+ */
+interface UncheckedXdrType {
+  readonly schema?: unknown;
+  readonly name?: string;
+}
+
+/**
+ * Name an unchecked `type` for an error message. Reading `.name` alone is not
+ * enough: an instance stringifies to its own base64, an enum singleton's
+ * `.name` getter shadows the class name, a string prints as the class it names,
+ * and a null-prototype object throws on `String()`.
+ */
+function describeType(type: unknown): string {
+  if (typeof type === "function") return type.name || "an anonymous class";
+  if (type === null || type === undefined) return String(type);
+  if (typeof type === "object") {
+    return `an instance of ${type.constructor?.name || "an anonymous object"}`;
+  }
+  return typeof type === "string"
+    ? `the string "${type}"`
+    : `the ${typeof type} ${String(type)}`;
+}
+
+/**
+ * Reject a `type` that cannot encode or decode, naming the helper and the
+ * argument. Runs before any codec work, because otherwise the mistake surfaces
+ * as an internal `TypeError` about an undefined property — or not at all:
+ * `array()` accepts an `undefined` element schema and reads it only once per
+ * element, so an empty list encoded as a valid-looking 4-byte count.
+ *
+ * Only a bad *type* throws here. Thin or malformed *data* keeps its existing
+ * behaviour, so an empty list still round-trips and `validateXdr` still
+ * returns `false` rather than throwing.
+ */
+function assertXdrType(
+  type: UncheckedXdrType | null | undefined,
+  fn: string,
+): void {
+  if (type?.schema) return;
+  throw new TypeError(
+    `${fn}: ${describeType(type)} has no static schema, so it is not a ` +
+      `usable XDR type. Pass a generated class such as xdr.ScVal, or ` +
+      "declare `static readonly schema` on a class of your own.",
+  );
 }
 
 /**

--- a/test/unit/xdr/type_guard.test.ts
+++ b/test/unit/xdr/type_guard.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  BigIntValue,
+  BytesValue,
+  ContractDataDurability,
+  decodeArray,
+  decodeStream,
+  encodeArray,
+  EnumValue,
+  Hash,
+  Int32,
+  Int64,
+  ScVal,
+  Uint32,
+  Uint64,
+  XdrString,
+  XdrValue,
+} from "../../../src/xdr/index.js";
+
+/** The message a call throws, for asserting on wording rather than on class. */
+const messageFrom = (fn: () => unknown): string => {
+  try {
+    fn();
+    return "(did not throw)";
+  } catch (e) {
+    return (e as Error).message;
+  }
+};
+
+// Every `xdr` export a caller might mistake for a generated XDR class: the four
+// primitive shims wrap native number/bigint values, and the bases are abstract.
+// None of them carries a static schema, so none can encode or decode.
+const WITHOUT_SCHEMA: [string, unknown][] = [
+  ["Int32", Int32],
+  ["Uint32", Uint32],
+  ["Int64", Int64],
+  ["Uint64", Uint64],
+  ["XdrValue", XdrValue],
+  ["BytesValue", BytesValue],
+  ["EnumValue", EnumValue],
+  ["BigIntValue", BigIntValue],
+  ["XdrString", XdrString],
+];
+
+// Only the `XdrValue` bases carry the statics; `XdrString` is not an
+// `XdrValue` and has no `fromXdr`/`validateXdr` at all.
+const ABSTRACT_BASES: [string, unknown][] = [
+  ["XdrValue", XdrValue],
+  ["BytesValue", BytesValue],
+  ["EnumValue", EnumValue],
+  ["BigIntValue", BigIntValue],
+];
+
+describe("array helpers reject a type with no schema", () => {
+  for (const [name, type] of WITHOUT_SCHEMA) {
+    describe(name, () => {
+      // The element schema is only read per element, so an empty list used to
+      // encode as a valid-looking 4-byte count with no error at all.
+      it("encodeArray names the helper and the type, empty list included", () => {
+        const values = [ScVal.scvU32(1)];
+        expect(() => encodeArray(type as any, values)).toThrow(TypeError);
+        expect(() => encodeArray(type as any, values)).toThrow(
+          new RegExp(`encodeArray.*${name}`),
+        );
+        expect(() => encodeArray(type as any, [])).toThrow(
+          new RegExp(`encodeArray.*${name}`),
+        );
+      });
+
+      it("decodeArray names the helper and the type", () => {
+        const buf = new Uint8Array([0, 0, 0, 1, 0, 0, 0, 7]);
+        expect(() => decodeArray(type as any, buf)).toThrow(TypeError);
+        expect(() => decodeArray(type as any, buf)).toThrow(
+          new RegExp(`decodeArray.*${name}`),
+        );
+      });
+
+      // A zero count decoded to `[]`, and a count that left bytes over blamed
+      // the buffer ("trailing 4 byte(s)") for what is a type mistake.
+      it("decodeArray rejects a zero-count and a trailing-byte buffer", () => {
+        expect(() =>
+          decodeArray(type as any, new Uint8Array([0, 0, 0, 0])),
+        ).toThrow(new RegExp(`decodeArray.*${name}`));
+        expect(() => decodeArray(type as any, new Uint8Array(8))).toThrow(
+          new RegExp(`decodeArray.*${name}`),
+        );
+      });
+
+      it("decodeStream names the helper and the type, empty buffer included", () => {
+        const buf = new Uint8Array([0, 0, 0, 7]);
+        expect(() => decodeStream(type as any, buf)).toThrow(TypeError);
+        expect(() => decodeStream(type as any, buf)).toThrow(
+          new RegExp(`decodeStream.*${name}`),
+        );
+        expect(() => decodeStream(type as any, new Uint8Array(0))).toThrow(
+          new RegExp(`decodeStream.*${name}`),
+        );
+      });
+    });
+  }
+
+  it("names the helper for a first argument that is not a type at all", () => {
+    expect(() => encodeArray({} as any, [])).toThrow(TypeError);
+    expect(() => encodeArray({} as any, [])).toThrow(/encodeArray/);
+    expect(() => encodeArray(undefined as any, [])).toThrow(
+      /encodeArray.*undefined/,
+    );
+    expect(() =>
+      decodeArray(undefined as any, new Uint8Array([0, 0, 0, 0])),
+    ).toThrow(/decodeArray.*undefined/);
+  });
+});
+
+describe("statics reject a base class with no schema", () => {
+  for (const [name, base] of ABSTRACT_BASES) {
+    it(`${name} rejects fromXdr, validateXdr, and fromJson`, () => {
+      expect(() => (base as any).fromXdr(new Uint8Array(4))).toThrow(
+        new RegExp(`fromXdr.*${name}`),
+      );
+      expect(() => (base as any).validateXdr(new Uint8Array(4))).toThrow(
+        new RegExp(`validateXdr.*${name}`),
+      );
+      expect(() => (base as any).fromJson(1)).toThrow(
+        new RegExp(`fromJson.*${name}`),
+      );
+    });
+  }
+});
+
+// Every guard message above interpolates `type.name`. Both shim factories
+// declare `function Shim`, so without an explicit name all four read "Shim".
+describe("primitive shims report their XDR type name", () => {
+  it("names each shim after its XDR type", () => {
+    expect(Int32.name).toBe("Int32");
+    expect(Uint32.name).toBe("Uint32");
+    expect(Int64.name).toBe("Int64");
+    expect(Uint64.name).toBe("Uint64");
+  });
+});
+
+// Controls: the guard must not reject a type that works today.
+describe("generated classes are unaffected", () => {
+  const values = [ScVal.scvU32(1), ScVal.scvSymbol("hi")];
+
+  it("round-trips through the array helpers", () => {
+    expect(decodeArray(ScVal, encodeArray(ScVal, values))).toHaveLength(2);
+    expect(encodeArray(ScVal, [])).toEqual(new Uint8Array([0, 0, 0, 0]));
+    expect(decodeArray(ScVal, new Uint8Array([0, 0, 0, 0]))).toEqual([]);
+    expect(decodeStream(ScVal, new Uint8Array(0))).toEqual([]);
+  });
+
+  it("round-trips through the statics", () => {
+    const v = ScVal.scvU32(1);
+    expect(ScVal.fromXdr(v.toXdr()).equals(v)).toBe(true);
+    expect(ScVal.validateXdr(v.toXdr())).toBe(true);
+    expect(ScVal.fromJson(v.toJson()).equals(v)).toBe(true);
+  });
+
+  // The guard reads `schema` through the prototype chain, so a subclass that
+  // inherits one is accepted. Tightening the check to an own-property test
+  // (`Object.hasOwn`) would break every consumer subclass while leaving the
+  // rest of this file green, so it is asserted here rather than assumed.
+  it("accepts a subclass that inherits its schema", () => {
+    // `Hash`, not `ScVal`: the union bases are abstract, so extending one
+    // without implementing `type`/`toXdrObject` does not compile.
+    class Sub extends Hash {}
+    const bytes = new Uint8Array(32).fill(3);
+    expect(Sub.fromXdr(bytes).toBytes()).toEqual(bytes);
+    expect(Sub.validateXdr(bytes)).toBe(true);
+    expect(encodeArray(Sub, [])).toEqual(new Uint8Array([0, 0, 0, 0]));
+    expect(decodeArray(Sub, new Uint8Array([0, 0, 0, 0]))).toEqual([]);
+  });
+
+  // A static pulled off its class loses `this`, which used to surface as
+  // `Cannot read properties of undefined (reading 'decode')`. TypeScript
+  // rejects the detached call outright, so this is a plain-JS-only path.
+  it("names the helper when a static is called detached", () => {
+    const { fromXdr } = ScVal as any;
+    expect(() => fromXdr(ScVal.scvU32(1).toXdr())).toThrow(
+      /fromXdr.*undefined has no static schema/,
+    );
+  });
+});
+
+// A returned empty value is not a failure the guard should convert into a
+// throw: an empty XDR array is a real value, and `validateXdr` is documented
+// as `fromXdr` without the throw so a caller can branch on a boolean instead
+// of a try/catch. The guard fires on an unusable *type*, never on thin data.
+describe("intentional non-throwing paths are preserved", () => {
+  it("encodes and decodes an empty list without throwing", () => {
+    expect(encodeArray(ScVal, [])).toEqual(new Uint8Array([0, 0, 0, 0]));
+    expect(decodeArray(ScVal, new Uint8Array([0, 0, 0, 0]))).toEqual([]);
+    expect(decodeStream(ScVal, new Uint8Array(0))).toEqual([]);
+  });
+
+  it("returns false from validateXdr for every flavour of bad data", () => {
+    const good = ScVal.scvU32(1).toXdr();
+    expect(ScVal.validateXdr(good)).toBe(true);
+    expect(ScVal.validateXdr(new Uint8Array([9, 9, 9, 9]))).toBe(false);
+    expect(ScVal.validateXdr(good.slice(0, -1))).toBe(false);
+    expect(ScVal.validateXdr(new Uint8Array([...good, 0, 0, 0, 0]))).toBe(
+      false,
+    );
+    expect(ScVal.validateXdr("!!not base64!!", "base64")).toBe(false);
+  });
+});
+
+// The boundary: bad *data* is a value the caller checks, bad *type* is a
+// programming error. Reporting a type mistake as `false` would send someone
+// looking at their bytes.
+describe("a type mistake is not reported as invalid data", () => {
+  it("throws from validateXdr rather than returning false", () => {
+    expect(() => (XdrValue as any).validateXdr(new Uint8Array(4))).toThrow(
+      /validateXdr.*XdrValue/,
+    );
+    expect(() => (BytesValue as any).validateXdr(new Uint8Array(4))).toThrow(
+      /validateXdr.*BytesValue/,
+    );
+  });
+});
+
+// Regression cover for the label: `type?.name || String(type)` printed base64
+// for an instance, dumped class source text for an anonymous class, threw on a
+// null-prototype object, and named a real class for inputs that were not it.
+describe("the message names the argument accurately", () => {
+  it("marks a string as a string, not as the class of that name", () => {
+    const msg = messageFrom(() => encodeArray("ScVal" as any, []));
+    expect(msg).toContain('the string "ScVal"');
+    expect(msg).not.toMatch(/^encodeArray: ScVal has no/);
+  });
+
+  it("marks a raw schema object as an instance, not as its schema name", () => {
+    const msg = messageFrom(() => encodeArray(ScVal.schema as any, []));
+    expect(msg).toContain("an instance of");
+    expect(msg).not.toMatch(/^encodeArray: ScVal has no/);
+  });
+
+  it("survives a null-prototype object instead of throwing on String()", () => {
+    expect(() => encodeArray(Object.create(null) as any, [])).toThrow(
+      /encodeArray.*has no static schema/,
+    );
+  });
+
+  it("marks an instance passed where a class belongs", () => {
+    expect(
+      messageFrom(() => encodeArray(ScVal.scvU32(42) as any, [])),
+    ).toContain("an instance of");
+    expect(
+      messageFrom(() =>
+        encodeArray(ContractDataDurability.persistent as any, []),
+      ),
+    ).toContain("an instance of ContractDataDurability");
+  });
+
+  it("names an anonymous class without dumping its source", () => {
+    const Anon = (() => class extends BytesValue {})();
+    const msg = messageFrom(() => encodeArray(Anon as any, []));
+    expect(msg).toContain("an anonymous class");
+    expect(msg).not.toContain("extends");
+  });
+});
+
+// Consumer-defined XDR classes on the SDK bases are a supported pattern, so
+// the guard has to reject an incomplete one by name without rejecting a
+// complete one.
+describe("consumer-defined XDR classes", () => {
+  class NoSchema extends BytesValue {}
+  class SchemaOnly extends BytesValue {
+    static readonly schema = Hash.schema;
+  }
+  class Complete extends BytesValue {
+    static readonly schema = Hash.schema;
+    static fromXdrObject(wire: Uint8Array): Complete {
+      return new Complete(wire);
+    }
+  }
+
+  it("rejects a subclass that never declared a schema, by name", () => {
+    expect(() => encodeArray(NoSchema as any, [])).toThrow(
+      /encodeArray.*NoSchema.*static readonly schema/s,
+    );
+    expect(() => decodeArray(NoSchema as any, new Uint8Array(4))).toThrow(
+      /decodeArray.*NoSchema/,
+    );
+    expect(() => decodeStream(NoSchema as any, new Uint8Array(4))).toThrow(
+      /decodeStream.*NoSchema/,
+    );
+    expect(() => (NoSchema as any).fromXdr(new Uint8Array(4))).toThrow(
+      /fromXdr.*NoSchema/,
+    );
+  });
+
+  it("rejects a subclass whose schema is null", () => {
+    class NullSchema extends BytesValue {
+      static readonly schema = null as never;
+    }
+    expect(() => encodeArray(NullSchema as any, [])).toThrow(
+      /encodeArray.*NullSchema/,
+    );
+  });
+
+  it("leaves a complete subclass working", () => {
+    const bytes = new Uint8Array(32).fill(7);
+    expect(Complete.fromXdr(bytes).toBytes()).toEqual(bytes);
+    expect(
+      decodeArray(Complete, encodeArray(Complete, [new Complete(bytes)])),
+    ).toHaveLength(1);
+  });
+
+  // Accepted residual: the guard checks `schema` only, so a subclass that
+  // declares one but no `fromXdrObject` reaches the decode path and fails
+  // there. That message already names the missing member.
+  it("reports a missing fromXdrObject from the decode path", () => {
+    expect(() => (SchemaOnly as any).fromXdr(new Uint8Array(32))).toThrow(
+      /fromXdrObject/,
+    );
+  });
+});

--- a/test/unit/xdr/type_guard.test.ts
+++ b/test/unit/xdr/type_guard.test.ts
@@ -253,11 +253,18 @@ describe("the message names the argument accurately", () => {
     ).toContain("an instance of ContractDataDurability");
   });
 
-  it("names an anonymous class without dumping its source", () => {
-    const Anon = (() => class extends BytesValue {})();
-    const msg = messageFrom(() => encodeArray(Anon as any, []));
-    expect(msg).toContain("an anonymous class");
-    expect(msg).not.toContain("extends");
+  it("names an unnamed callable without dumping its source", () => {
+    // Anonymous classes and anonymous functions share this branch, since
+    // `typeof` cannot separate them, so the wording must fit both.
+    // Declared inline: a function assigned to a `const` would inherit that
+    // name, which would skip the branch under test.
+    const AnonClass = (() => class extends BytesValue {})();
+    for (const value of [AnonClass, () => undefined]) {
+      const msg = messageFrom(() => encodeArray(value as any, []));
+      expect(msg).toContain("an anonymous function or class");
+      expect(msg).not.toContain("extends");
+      expect(msg).not.toContain("=>");
+    }
   });
 });
 
@@ -308,12 +315,33 @@ describe("consumer-defined XDR classes", () => {
     ).toHaveLength(1);
   });
 
-  // Accepted residual: the guard checks `schema` only, so a subclass that
-  // declares one but no `fromXdrObject` reaches the decode path and fails
-  // there. That message already names the missing member.
-  it("reports a missing fromXdrObject from the decode path", () => {
-    expect(() => (SchemaOnly as any).fromXdr(new Uint8Array(32))).toThrow(
-      /fromXdrObject/,
-    );
+  // A schema without a `fromXdrObject` can encode but not decode, so the
+  // requirement is checked per direction: the decode paths name the missing
+  // member at the call site, and the encode paths must not reject the type.
+  it("names the missing fromXdrObject on every decode path", () => {
+    const bytes = new Uint8Array(32).fill(9);
+    const arr = new Uint8Array([0, 0, 0, 1, ...bytes]);
+    for (const [fn, call] of [
+      ["fromXdr", () => (SchemaOnly as any).fromXdr(bytes)],
+      ["fromJson", () => (SchemaOnly as any).fromJson("09".repeat(32))],
+      ["decodeArray", () => decodeArray(SchemaOnly as any, arr)],
+      ["decodeStream", () => decodeStream(SchemaOnly as any, bytes)],
+    ] as [string, () => unknown][]) {
+      expect(call).toThrow(TypeError);
+      expect(call).toThrow(
+        new RegExp(`${fn}: SchemaOnly has a static schema but no static`),
+      );
+      expect(call).toThrow(/fromXdrObject/);
+    }
+  });
+
+  it("still encodes a schema-only subclass, which needs no fromXdrObject", () => {
+    const bytes = new Uint8Array(32).fill(9);
+    const encoded = encodeArray(SchemaOnly as any, [new SchemaOnly(bytes)]);
+    expect(encoded).toHaveLength(36);
+    expect(Array.from(encoded.subarray(0, 4))).toEqual([0, 0, 0, 1]);
+    // `as any`: the `XdrValueConstructor` type requires `fromXdrObject` for
+    // both directions, so tsc rejects this call even though it works.
+    expect((SchemaOnly as any).validateXdr(bytes)).toBe(true);
   });
 });


### PR DESCRIPTION
- Fixed the type-generic `xdr` helpers accepting a first argument that cannot encode or decode: `encodeArray`, `decodeArray`, `decodeStream` and the `fromXdr` / `validateXdr` / `fromJson` statics now throw a `TypeError` naming the helper and the argument
- Added a per-direction check for `fromXdrObject` — the four decode paths name it when it is missing, while `encodeArray` and `validateXdr` deliberately do not require it, since a class that declares a schema without one encodes correctly
- Fixed the same calls appearing to succeed on an empty list — `xdr.encodeArray(xdr.Uint32, [])` returned a valid-looking 4-byte count and `xdr.decodeArray(xdr.Uint32, <4 zero bytes>)` returned `[]`, because the element schema is only read once per element
- Added `describeType` to keep the message accurate for arguments that are not classes — an instance no longer prints as its own base64, nor the string `"ScVal"` as though the real class lacked a schema
- Fixed `xdr.Int32`, `xdr.Uint32`, `xdr.Int64` and `xdr.Uint64` reporting `"Shim"` from `.name`, which every guard message would otherwise have quoted
- Preserved the deliberately non-throwing paths: an empty list still round-trips, and `validateXdr` still returns `false` for malformed data instead of throwing
- Corrected the claim in `xdr-migration.md` that the array helpers "work with any XDR class", and added `@throws` to the four entry points that carry a doc block

Before:

```
xdr.encodeArray(xdr.Uint32, [1])       TypeError: v.toXdrObject is not a function
xdr.encodeArray(xdr.Uint32, [])        no error — returns Uint8Array [0, 0, 0, 0]
xdr.decodeArray(xdr.Uint32, buf)       TypeError: Cannot read properties of undefined (reading '_read')
xdr.decodeStream(xdr.XdrValue, buf)    TypeError: Cannot read properties of undefined (reading 'name')
xdr.XdrValue.fromXdr(buf)              TypeError: Cannot read properties of undefined (reading 'decode')
MyBytes.fromXdr(buf)                   TypeError: this.fromXdrObject is not a function
```

After, every one of them naming the helper and the argument:

```
TypeError: encodeArray: Uint32 has no static schema, so it is not a usable XDR type. Pass a generated class such as xdr.ScVal, or declare `static readonly schema` on a class of your own.
```

The four decode paths report a missing `fromXdrObject` separately, because only they need it:

```
TypeError: fromXdr: SchemaOnly has a static schema but no static fromXdrObject, so it can encode but not decode. Declare `static fromXdrObject(wire)` on it.
```

The argument is described rather than stringified, so the message stays true whatever gets passed:

```
encodeArray: MyBytes has no static schema, …                       (a subclass that forgot `static schema`)
encodeArray: the string "ScVal" has no static schema, …            (not the real class, which has one)
encodeArray: an instance of ScValU32 has no static schema, …       (an instance where a class belongs)
encodeArray: an anonymous function or class has no static schema, … (an unnamed callable)
decodeStream: XdrValue has no static schema, …                     (an abstract base)
```

Closes #1680