### PR TITLE
fix(xdr): honor declared encoding in byte wrappers' toString()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 A breaking change will get clearly marked in this log.
 
+## Unreleased
+
+### Fixed
+* Named byte aliases (`Hash`, `Signature`, `AssetCode4`, `AssetCode12`, `PoolId`, `ContractId`, …) now honor their declared string encoding in `toString()`, matching what the constructor accepts: hex classes return hex, and the asset-code classes return the code as text (`new xdr.AssetCode4("KHL1").toString()` is now `"KHL1"`, was the base64 `"S0hMMQ=="`). Previously every wrapper inherited the base-class behavior and returned base64 regardless of its declared encoding, so a `Hash` built from a hex string handed back base64 with no error. Code that relied on the base64 output should use `.toXdr("base64")` ([#1687](https://github.com/stellar/js-stellar-sdk/issues/1687)).
+
 ## [v17.0.0](https://github.com/stellar/js-stellar-sdk/compare/v16.2.0...v17.0.0)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ A breaking change will get clearly marked in this log.
 ## Unreleased
 
 ### Fixed
-* Named byte aliases (`Hash`, `Signature`, `AssetCode4`, `AssetCode12`, `PoolId`, `ContractId`, …) now honor their declared string encoding in `toString()`, matching what the constructor accepts: hex classes return hex, and the asset-code classes return the code as text (`new xdr.AssetCode4("KHL1").toString()` is now `"KHL1"`, was the base64 `"S0hMMQ=="`). Previously every wrapper inherited the base-class behavior and returned base64 regardless of its declared encoding, so a `Hash` built from a hex string handed back base64 with no error. Code that relied on the base64 output should use `.toXdr("base64")` ([#1687](https://github.com/stellar/js-stellar-sdk/issues/1687)).
+* `BytesValue#toString()` on the named byte aliases (`Hash`, `Signature`, `AssetCode4`, `AssetCode12`, `PoolId`, `ContractId`, …) now returns the class's declared encoding instead of base64 for every wrapper: `new xdr.AssetCode4("KHL1").toString()` is now `"KHL1"`, was `"S0hMMQ=="`. Use `.toXdr("base64")` for the wire form ([#1689](https://github.com/stellar/js-stellar-sdk/pull/1689)).
 
 ## [v17.0.0](https://github.com/stellar/js-stellar-sdk/compare/v16.2.0...v17.0.0)
 

--- a/src/xdr/values/bytes-value.ts
+++ b/src/xdr/values/bytes-value.ts
@@ -1,6 +1,6 @@
-import { stringToUint8Array } from "uint8array-extras";
+import { stringToUint8Array, uint8ArrayToString } from "uint8array-extras";
 import { XdrError } from "@stellar/js-xdr";
-import { XdrValue, decodeBytes } from "./xdr-value.js";
+import { XdrValue, decodeBytes, encodeBytes } from "./xdr-value.js";
 
 export type BytesEncoding = "hex" | "base64" | "ascii";
 
@@ -11,6 +11,11 @@ function decodeBytesInput(
   if (input instanceof Uint8Array) return input;
   if (encoding === "ascii") return stringToUint8Array(input);
   return decodeBytes(input, encoding);
+}
+
+function encodeBytesOutput(bytes: Uint8Array, encoding: BytesEncoding): string {
+  if (encoding === "ascii") return uint8ArrayToString(bytes);
+  return encodeBytes(bytes, encoding);
 }
 
 /**
@@ -53,6 +58,13 @@ export abstract class BytesValue<Tag extends string = string> extends XdrValue {
       );
     }
     this.value = bytes;
+  }
+
+  toString(): string {
+    const ctor = this.constructor as typeof BytesValue & {
+      readonly encoding: BytesEncoding;
+    };
+    return encodeBytesOutput(this.value, ctor.encoding);
   }
 
   toXdrObject(): Uint8Array {

--- a/src/xdr/values/bytes-value.ts
+++ b/src/xdr/values/bytes-value.ts
@@ -60,6 +60,12 @@ export abstract class BytesValue<Tag extends string = string> extends XdrValue {
     this.value = bytes;
   }
 
+  /**
+   * Render the bytes in the class's declared `encoding`.
+   *
+   * For the XDR wire form regardless of the declared encoding, use
+   * {@link XdrValue.toXdr | `toXdr("base64")`}.
+   */
   toString(): string {
     const ctor = this.constructor as typeof BytesValue & {
       readonly encoding: BytesEncoding;

--- a/test/unit/xdr/bytes_value.test.ts
+++ b/test/unit/xdr/bytes_value.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  AssetCode4,
+  AssetCode12,
+  BytesValue,
+  Hash,
+  Signature,
+} from "../../../src/xdr/index.js";
+import { opaque } from "@stellar/js-xdr";
+
+describe("BytesValue#toString", () => {
+  it("renders hex-encoded aliases as hex", () => {
+    const hex = "ab".repeat(32);
+    expect(new Hash(hex).toString()).toBe(hex);
+    expect(new Hash(new Uint8Array(32).fill(0xab)).toString()).toBe(hex);
+  });
+
+  it("round-trips through the constructor", () => {
+    const sig = new Signature(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+    expect(new Signature(sig.toString()).value).toEqual(sig.value);
+  });
+
+  it("renders ascii-encoded aliases as text", () => {
+    expect(
+      new AssetCode4(new Uint8Array([0x55, 0x53, 0x44, 0x43])).toString(),
+    ).toBe("USDC");
+  });
+
+  it("keeps the zero padding a short asset code gained", () => {
+    expect(new AssetCode4("USD").toString()).toBe("USD\0");
+    expect(new AssetCode12("LONGCODE").toString()).toBe("LONGCODE\0\0\0\0");
+  });
+
+  it("renders base64-encoded subclasses as base64", () => {
+    class B64Bytes extends BytesValue<"B64Bytes"> {
+      static readonly encoding = "base64" as const;
+
+      static readonly schema = opaque(4, "B64Bytes");
+    }
+    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    expect(new B64Bytes(bytes).toString()).toBe("3q2+7w==");
+    expect(new B64Bytes("3q2+7w==").value).toEqual(bytes);
+  });
+
+  it("returns a plain string usable in interpolation", () => {
+    const hash = new Hash("00".repeat(32));
+    expect(`${hash}`).toBe("00".repeat(32));
+    expect(String(hash)).toBe("00".repeat(32));
+  });
+});


### PR DESCRIPTION
## What

`BytesValue` (the base for the named byte aliases: `Hash`, `Signature`, `AssetCode4`, `AssetCode12`, `PoolId`, `ContractId`, …) now overrides `toString()` to use the class's declared `static encoding`, the same one the constructor uses to decode string input. Hex classes return hex, base64 classes return base64, and the ascii asset-code classes return the code as text. Adds `test/unit/xdr/bytes_value.test.ts` covering all three branches, round-trips through the constructor, the preserved zero padding on short asset codes, and string interpolation.

## Why

Fixes #1687. Each wrapper declares an encoding and honors it on input only: `new xdr.AssetCode4("KHL1")` accepts ascii, but `toString()` fell through to the base class and base64-encoded, so `.toString()` returned `"S0hMMQ=="`. Same story for `Hash`: hex in, base64 out. The failure is silent and reads identically to `XdrString.toString()`, which does return real text — Freighter hit exactly that during its v17 migration (stellar/freighter#2977). Output now matches what the class advertises; callers that want the wire form still have `.toXdr("base64")`.