### PR TITLE
fix(asset): preserve alphanum12 discriminant on XDR round-trip

### DIFF
--- a/docs/reference/core-assets.md
+++ b/docs/reference/core-assets.md
@@ -38,7 +38,7 @@ class Asset {
 }
 ```
 
-**Source:** [src/base/asset.ts:67](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L67)
+**Source:** [src/base/asset.ts:69](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L69)
 
 ### `new Asset(code, issuer)`
 
@@ -51,7 +51,7 @@ constructor(code: string, issuer?: string);
 - **`code`** — `string` (required) — The asset code.
 - **`issuer`** — `string` (optional) — The account ID of the issuer.
 
-**Source:** [src/base/asset.ts:77](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L77)
+**Source:** [src/base/asset.ts:79](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L79)
 
 ### `Asset.compare(assetA, assetB)`
 
@@ -70,7 +70,7 @@ static compare(assetA: Asset, assetB: Asset): -1 | 0 | 1;
 - **`assetA`** — `Asset` (required) — the first asset
 - **`assetB`** — `Asset` (required) — the second asset
 
-**Source:** [src/base/asset.ts:337](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L337)
+**Source:** [src/base/asset.ts:354](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L354)
 
 ### `Asset.fromOperation(assetXdr)`
 
@@ -84,7 +84,7 @@ static fromOperation(assetXdr: Asset): Asset;
 
 - **`assetXdr`** — `Asset` (required) — The asset xdr object.
 
-**Source:** [src/base/asset.ts:111](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L111)
+**Source:** [src/base/asset.ts:113](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L113)
 
 ### `Asset.native()`
 
@@ -94,7 +94,7 @@ Returns an asset object for the native asset.
 static native(): Asset;
 ```
 
-**Source:** [src/base/asset.ts:103](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L103)
+**Source:** [src/base/asset.ts:105](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L105)
 
 ### `asset.code`
 
@@ -104,7 +104,7 @@ The asset code.
 readonly code: string;
 ```
 
-**Source:** [src/base/asset.ts:69](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L69)
+**Source:** [src/base/asset.ts:71](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L71)
 
 ### `asset.issuer`
 
@@ -114,7 +114,7 @@ The account ID of the issuer. Undefined for the native asset.
 readonly issuer: string | undefined;
 ```
 
-**Source:** [src/base/asset.ts:71](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L71)
+**Source:** [src/base/asset.ts:73](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L73)
 
 ### `asset.contractId(networkPassphrase)`
 
@@ -131,7 +131,7 @@ contractId(networkPassphrase: string): string;
      ID should refer to, since every network will have a unique ID for the
      same contract (see [`Networks`](/reference/core-transactions/#networks) for options)
 
-**Source:** [src/base/asset.ts:196](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L196)
+**Source:** [src/base/asset.ts:201](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L201)
 
 ### `asset.equals(asset)`
 
@@ -145,7 +145,7 @@ equals(asset: Asset): boolean;
 
 - **`asset`** — `Asset` (required) — Asset to compare
 
-**Source:** [src/base/asset.ts:310](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L310)
+**Source:** [src/base/asset.ts:323](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L323)
 
 ### `asset.getAssetType()`
 
@@ -166,7 +166,7 @@ Returns the asset type. Can be one of following types:
  - `credit_alphanum4`,
  - `credit_alphanum12`
 
-**Source:** [src/base/asset.ts:267](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L267)
+**Source:** [src/base/asset.ts:275](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L275)
 
 ### `asset.getCode()`
 
@@ -176,7 +176,7 @@ Returns the asset code
 getCode(): string;
 ```
 
-**Source:** [src/base/asset.ts:244](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L244)
+**Source:** [src/base/asset.ts:252](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L252)
 
 ### `asset.getIssuer()`
 
@@ -186,7 +186,7 @@ Returns the asset issuer
 getIssuer(): string | undefined;
 ```
 
-**Source:** [src/base/asset.ts:251](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L251)
+**Source:** [src/base/asset.ts:259](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L259)
 
 ### `asset.getRawAssetType()`
 
@@ -196,7 +196,7 @@ Returns the raw XDR representation of the asset type
 getRawAssetType(): AssetType;
 ```
 
-**Source:** [src/base/asset.ts:286](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L286)
+**Source:** [src/base/asset.ts:294](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L294)
 
 ### `asset.isNative()`
 
@@ -206,7 +206,7 @@ Returns true if this asset object is the native asset.
 isNative(): boolean;
 ```
 
-**Source:** [src/base/asset.ts:301](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L301)
+**Source:** [src/base/asset.ts:314](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L314)
 
 ### `asset.toChangeTrustXdrObject()`
 
@@ -216,7 +216,7 @@ Returns the xdr.ChangeTrustAsset object for this asset.
 toChangeTrustXdrObject(): ChangeTrustAsset;
 ```
 
-**Source:** [src/base/asset.ts:150](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L150)
+**Source:** [src/base/asset.ts:155](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L155)
 
 ### `asset.toChangeTrustXDRObject()`
 
@@ -227,7 +227,7 @@ Deprecated in version v17.0.0
 toChangeTrustXDRObject(): ChangeTrustAsset;
 ```
 
-**Source:** [src/base/asset.ts:173](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L173)
+**Source:** [src/base/asset.ts:178](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L178)
 
 ### `asset.toString()`
 
@@ -239,7 +239,7 @@ Native assets return `"native"`. Non-native assets return `"code:issuer"`.
 toString(): string;
 ```
 
-**Source:** [src/base/asset.ts:319](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L319)
+**Source:** [src/base/asset.ts:336](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L336)
 
 ### `asset.toTrustLineXdrObject()`
 
@@ -249,7 +249,7 @@ Returns the xdr.TrustLineAsset object for this asset.
 toTrustLineXdrObject(): TrustLineAsset;
 ```
 
-**Source:** [src/base/asset.ts:157](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L157)
+**Source:** [src/base/asset.ts:162](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L162)
 
 ### `asset.toTrustLineXDRObject()`
 
@@ -260,7 +260,7 @@ Deprecated in version v17.0.0
 toTrustLineXDRObject(): TrustLineAsset;
 ```
 
-**Source:** [src/base/asset.ts:181](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L181)
+**Source:** [src/base/asset.ts:186](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L186)
 
 ### `asset.toXdrObject()`
 
@@ -270,7 +270,7 @@ Returns the xdr.Asset object for this asset.
 toXdrObject(): Asset;
 ```
 
-**Source:** [src/base/asset.ts:143](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L143)
+**Source:** [src/base/asset.ts:148](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L148)
 
 ### `asset.toXDRObject()`
 
@@ -281,7 +281,7 @@ Deprecated in version v17.0.0
 toXDRObject(): Asset;
 ```
 
-**Source:** [src/base/asset.ts:165](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L165)
+**Source:** [src/base/asset.ts:170](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L170)
 
 ## AssetType
 

--- a/src/base/asset.ts
+++ b/src/base/asset.ts
@@ -36,6 +36,8 @@ export namespace AssetType {
   export type liquidityPoolShares = "liquidity_pool_shares";
 }
 
+const decodedAssetTypes = new WeakMap<Asset, XdrAssetType>();
+
 interface XdrAssetConstructor<TNative, TAlpha4, TAlpha12> {
   assetTypeNative(): TNative;
   assetTypeCreditAlphanum4(value: AlphaNum4): TAlpha4;
@@ -123,14 +125,17 @@ export class Asset {
           "\0",
         ) as string;
         return new this(code, issuer);
-      case "assetTypeCreditAlphanum12":
+      case "assetTypeCreditAlphanum12": {
         anum = assetXdr.alphaNum12;
         issuer = StrKey.encodeEd25519PublicKey(anum.issuer.ed25519.toBytes());
         code = trimEnd(
           uint8ArrayToString(anum.assetCode.toBytes()),
           "\0",
         ) as string;
-        return new this(code, issuer);
+        const asset = new this(code, issuer);
+        decodedAssetTypes.set(asset, XdrAssetType.assetTypeCreditAlphanum12);
+        return asset;
+      }
       default:
         // @ts-expect-error this should be unreachable if the XDR types are correct, but we throw just in case
         throw new Error("Invalid asset type received: " + assetXdr.type);
@@ -223,7 +228,10 @@ export class Asset {
       throw new Error("Issuer cannot be null for non-native asset");
     }
 
-    if (this.code.length <= 4) {
+    if (
+      this.getRawAssetType().value ===
+      XdrAssetType.assetTypeCreditAlphanum4.value
+    ) {
       const assetType = new AlphaNum4({
         assetCode: stringToUint8Array(this.code.padEnd(4, "\0")),
         issuer: Keypair.fromPublicKey(this.issuer).xdrAccountId(),
@@ -288,6 +296,11 @@ export class Asset {
       return XdrAssetType.assetTypeNative;
     }
 
+    const decodedAssetType = decodedAssetTypes.get(this);
+    if (decodedAssetType) {
+      return decodedAssetType;
+    }
+
     if (this.code.length <= 4) {
       return XdrAssetType.assetTypeCreditAlphanum4;
     }
@@ -308,7 +321,11 @@ export class Asset {
    * @param asset - Asset to compare
    */
   equals(asset: Asset): boolean {
-    return this.code === asset.getCode() && this.issuer === asset.getIssuer();
+    return (
+      this.code === asset.getCode() &&
+      this.issuer === asset.getIssuer() &&
+      this.getRawAssetType().value === asset.getRawAssetType().value
+    );
   }
 
   /**

--- a/test/unit/base/asset.test.ts
+++ b/test/unit/base/asset.test.ts
@@ -282,6 +282,21 @@ describe("Asset", () => {
       expect(asset.getCode()).toBe(assetCode);
       expect(asset.getIssuer()).toBe(ISSUER);
     });
+
+    it("preserves an alphanum12 arm when the decoded code is short", () => {
+      const assetCode = "USD";
+      const assetType = new xdr.AlphaNum12({
+        assetCode: stringToUint8Array(assetCode.padEnd(12, "\0")),
+        issuer: Keypair.fromPublicKey(ISSUER).xdrAccountId(),
+      });
+      const assetXdr = xdr.Asset.assetTypeCreditAlphanum12(assetType);
+
+      const asset = Asset.fromOperation(assetXdr);
+
+      expect(asset.getCode()).toBe(assetCode);
+      expect(asset.getAssetType()).toBe("credit_alphanum12");
+      expect(asset.toXdrObject().toXdr()).toEqual(assetXdr.toXdr());
+    });
   });
 
   describe("toString()", () => {
@@ -369,6 +384,21 @@ describe("Asset", () => {
       const lower = new Asset("a", issuer);
 
       expect(Asset.compare(upper, lower)).toBe(-1);
+    });
+
+    it("distinguishes a short alphanum12 asset from an alphanum4 asset", () => {
+      const assetType = new xdr.AlphaNum12({
+        assetCode: stringToUint8Array("USD".padEnd(12, "\0")),
+        issuer: Keypair.fromPublicKey(ISSUER).xdrAccountId(),
+      });
+      const alphanum12 = Asset.fromOperation(
+        xdr.Asset.assetTypeCreditAlphanum12(assetType),
+      );
+      const alphanum4 = new Asset("USD", ISSUER);
+
+      expect(alphanum12.equals(alphanum4)).toBe(false);
+      expect(Asset.compare(alphanum4, alphanum12)).toBe(-1);
+      expect(Asset.compare(alphanum12, alphanum4)).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary

- preserve the decoded `assetTypeCreditAlphanum12` discriminant even when its trimmed code is four characters or shorter
- use the preserved type for XDR encoding, equality, and ordering while keeping the public asset code trimmed
- add regression coverage and refresh generated Asset reference source links

## Problem

`Asset.fromOperation` trimmed trailing NUL bytes and discarded the XDR union arm. Later code inferred the asset type only from `code.length`, so a hand-crafted alphanum12 asset carrying a short code was re-encoded as alphanum4. That also changed the reported type, derived contract ID, equality, and ordering semantics.

The fix records the decoded arm in internal weak state. User-constructed assets continue to derive their type from code length, and `getCode()` / `toString()` do not expose padding bytes.

## Validation

RED before the fix:

- the round-trip test reported `credit_alphanum4` instead of `credit_alphanum12`
- the identity test reported a short alphanum12 asset equal to the matching alphanum4 asset

GREEN after the fix:

- `pnpm exec vitest run test/unit/base/asset.test.ts --config config/vitest.config.ts` — 46/46 passed
- `pnpm run test:node` — 132 files passed; 6725 tests passed, 4 skipped, 9 todo
- `pnpm exec eslint src/base/asset.ts test/unit/base/asset.test.ts`
- `pnpm exec prettier --check src/base/asset.ts test/unit/base/asset.test.ts`
- `pnpm run build:types`
- `pnpm run typecheck:tests`
- `pnpm run build`
- repository pre-push generated-doc and link checks passed

## Risk and compatibility

This only changes the type retained by assets decoded from non-canonical short-code alphanum12 XDR. Publicly constructed assets and valid on-network asset codes keep their existing behavior. The public code remains trimmed; no NUL padding is exposed.

Fixes #1584

## AI assistance

OpenAI Codex assisted with investigation, test drafting, and implementation. I reviewed the complete diff and ran the validation above locally.
