### PR TITLE
fix(asset): preserve alphanum12 discriminant on XDR round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ A breaking change will get clearly marked in this log.
 
 ## Unreleased
 
+### Fixed
+* `Asset.fromOperation` preserves the `assetTypeCreditAlphanum12` union arm even when the decoded code is four characters or shorter, instead of re-deriving the arm from code length. Such an asset now re-encodes to the same XDR bytes it was decoded from, and its `getAssetType()`, `contractId()`, `equals()`, and `Asset.compare()` results reflect the alphanum12 arm. `equals()` now also compares the asset type, so a decoded short-code alphanum12 asset is no longer equal to the alphanum4 asset with the same code and issuer. User-constructed assets are unaffected: `new Asset(code, issuer)` still derives the type from code length ([#1584](https://github.com/stellar/js-stellar-sdk/issues/1584)).
+
 ## [v17.0.1](https://github.com/stellar/js-stellar-sdk/compare/v17.0.0...v17.0.1)
 
 ### Added

--- a/docs/reference/core-assets.md
+++ b/docs/reference/core-assets.md
@@ -51,7 +51,7 @@ constructor(code: string, issuer?: string);
 - **`code`** — `string` (required) — The asset code.
 - **`issuer`** — `string` (optional) — The account ID of the issuer.
 
-**Source:** [src/base/asset.ts:77](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L77)
+**Source:** [src/base/asset.ts:83](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L83)
 
 ### `Asset.compare(assetA, assetB)`
 
@@ -70,7 +70,7 @@ static compare(assetA: Asset, assetB: Asset): -1 | 0 | 1;
 - **`assetA`** — `Asset` (required) — the first asset
 - **`assetB`** — `Asset` (required) — the second asset
 
-**Source:** [src/base/asset.ts:337](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L337)
+**Source:** [src/base/asset.ts:367](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L367)
 
 ### `Asset.fromOperation(assetXdr)`
 
@@ -84,7 +84,7 @@ static fromOperation(assetXdr: Asset): Asset;
 
 - **`assetXdr`** — `Asset` (required) — The asset xdr object.
 
-**Source:** [src/base/asset.ts:111](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L111)
+**Source:** [src/base/asset.ts:130](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L130)
 
 ### `Asset.native()`
 
@@ -94,7 +94,7 @@ Returns an asset object for the native asset.
 static native(): Asset;
 ```
 
-**Source:** [src/base/asset.ts:103](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L103)
+**Source:** [src/base/asset.ts:122](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L122)
 
 ### `asset.code`
 
@@ -131,7 +131,7 @@ contractId(networkPassphrase: string): string;
      ID should refer to, since every network will have a unique ID for the
      same contract (see [`Networks`](/reference/core-transactions/#networks) for options)
 
-**Source:** [src/base/asset.ts:196](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L196)
+**Source:** [src/base/asset.ts:220](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L220)
 
 ### `asset.equals(asset)`
 
@@ -145,7 +145,7 @@ equals(asset: Asset): boolean;
 
 - **`asset`** — `Asset` (required) — Asset to compare
 
-**Source:** [src/base/asset.ts:310](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L310)
+**Source:** [src/base/asset.ts:336](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L336)
 
 ### `asset.getAssetType()`
 
@@ -166,7 +166,7 @@ Returns the asset type. Can be one of following types:
  - `credit_alphanum4`,
  - `credit_alphanum12`
 
-**Source:** [src/base/asset.ts:267](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L267)
+**Source:** [src/base/asset.ts:294](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L294)
 
 ### `asset.getCode()`
 
@@ -176,7 +176,7 @@ Returns the asset code
 getCode(): string;
 ```
 
-**Source:** [src/base/asset.ts:244](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L244)
+**Source:** [src/base/asset.ts:271](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L271)
 
 ### `asset.getIssuer()`
 
@@ -186,7 +186,7 @@ Returns the asset issuer
 getIssuer(): string | undefined;
 ```
 
-**Source:** [src/base/asset.ts:251](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L251)
+**Source:** [src/base/asset.ts:278](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L278)
 
 ### `asset.getRawAssetType()`
 
@@ -196,7 +196,7 @@ Returns the raw XDR representation of the asset type
 getRawAssetType(): AssetType;
 ```
 
-**Source:** [src/base/asset.ts:286](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L286)
+**Source:** [src/base/asset.ts:313](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L313)
 
 ### `asset.isNative()`
 
@@ -206,7 +206,7 @@ Returns true if this asset object is the native asset.
 isNative(): boolean;
 ```
 
-**Source:** [src/base/asset.ts:301](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L301)
+**Source:** [src/base/asset.ts:327](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L327)
 
 ### `asset.toChangeTrustXdrObject()`
 
@@ -216,7 +216,7 @@ Returns the xdr.ChangeTrustAsset object for this asset.
 toChangeTrustXdrObject(): ChangeTrustAsset;
 ```
 
-**Source:** [src/base/asset.ts:150](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L150)
+**Source:** [src/base/asset.ts:174](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L174)
 
 ### `asset.toChangeTrustXDRObject()`
 
@@ -227,7 +227,7 @@ Deprecated in version v17.0.0
 toChangeTrustXDRObject(): ChangeTrustAsset;
 ```
 
-**Source:** [src/base/asset.ts:173](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L173)
+**Source:** [src/base/asset.ts:197](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L197)
 
 ### `asset.toString()`
 
@@ -239,7 +239,7 @@ Native assets return `"native"`. Non-native assets return `"code:issuer"`.
 toString(): string;
 ```
 
-**Source:** [src/base/asset.ts:319](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L319)
+**Source:** [src/base/asset.ts:349](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L349)
 
 ### `asset.toTrustLineXdrObject()`
 
@@ -249,7 +249,7 @@ Returns the xdr.TrustLineAsset object for this asset.
 toTrustLineXdrObject(): TrustLineAsset;
 ```
 
-**Source:** [src/base/asset.ts:157](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L157)
+**Source:** [src/base/asset.ts:181](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L181)
 
 ### `asset.toTrustLineXDRObject()`
 
@@ -260,7 +260,7 @@ Deprecated in version v17.0.0
 toTrustLineXDRObject(): TrustLineAsset;
 ```
 
-**Source:** [src/base/asset.ts:181](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L181)
+**Source:** [src/base/asset.ts:205](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L205)
 
 ### `asset.toXdrObject()`
 
@@ -270,7 +270,7 @@ Returns the xdr.Asset object for this asset.
 toXdrObject(): Asset;
 ```
 
-**Source:** [src/base/asset.ts:143](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L143)
+**Source:** [src/base/asset.ts:167](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L167)
 
 ### `asset.toXDRObject()`
 
@@ -281,7 +281,7 @@ Deprecated in version v17.0.0
 toXDRObject(): Asset;
 ```
 
-**Source:** [src/base/asset.ts:165](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L165)
+**Source:** [src/base/asset.ts:189](https://github.com/stellar/js-stellar-sdk/blob/main/src/base/asset.ts#L189)
 
 ## AssetType
 

--- a/src/base/asset.ts
+++ b/src/base/asset.ts
@@ -71,6 +71,12 @@ export class Asset {
   readonly issuer: string | undefined;
 
   /**
+   * The XDR union arm this asset encodes to. A private field so the object's
+   * JSON/spread shape keeps only the code and issuer.
+   */
+  #rawAssetType: XdrAssetType;
+
+  /**
    * @param code - The asset code.
    * @param issuer - The account ID of the issuer.
    */
@@ -95,6 +101,19 @@ export class Asset {
     }
 
     this.issuer = issuer;
+    this.#rawAssetType = Asset.#deriveRawAssetType(this.code, issuer);
+  }
+
+  static #deriveRawAssetType(
+    code: string,
+    issuer: string | undefined,
+  ): XdrAssetType {
+    if (!issuer) {
+      return XdrAssetType.assetTypeNative;
+    }
+    return code.length <= 4
+      ? XdrAssetType.assetTypeCreditAlphanum4
+      : XdrAssetType.assetTypeCreditAlphanum12;
   }
 
   /**
@@ -123,14 +142,19 @@ export class Asset {
           "\0",
         ) as string;
         return new this(code, issuer);
-      case "assetTypeCreditAlphanum12":
+      case "assetTypeCreditAlphanum12": {
         anum = assetXdr.alphaNum12;
         issuer = StrKey.encodeEd25519PublicKey(anum.issuer.ed25519.toBytes());
         code = trimEnd(
           uint8ArrayToString(anum.assetCode.toBytes()),
           "\0",
         ) as string;
-        return new this(code, issuer);
+        // Preserve the decoded arm: a short code inferred from length alone
+        // would re-encode as alphanum4.
+        const asset = new this(code, issuer);
+        asset.#rawAssetType = XdrAssetType.assetTypeCreditAlphanum12;
+        return asset;
+      }
       default:
         // @ts-expect-error this should be unreachable if the XDR types are correct, but we throw just in case
         throw new Error("Invalid asset type received: " + assetXdr.type);
@@ -223,7 +247,10 @@ export class Asset {
       throw new Error("Issuer cannot be null for non-native asset");
     }
 
-    if (this.code.length <= 4) {
+    if (
+      this.getRawAssetType().value ===
+      XdrAssetType.assetTypeCreditAlphanum4.value
+    ) {
       const assetType = new AlphaNum4({
         assetCode: stringToUint8Array(this.code.padEnd(4, "\0")),
         issuer: Keypair.fromPublicKey(this.issuer).xdrAccountId(),
@@ -284,15 +311,14 @@ export class Asset {
    * Returns the raw XDR representation of the asset type
    */
   getRawAssetType(): XdrAssetType {
-    if (this.isNative()) {
-      return XdrAssetType.assetTypeNative;
+    // An object that never ran the constructor (a structural clone or a
+    // JSON-rehydrated instance) lacks the private field; derive the arm from
+    // code and issuer as before v17.1.
+    const { code, issuer } = this;
+    if (#rawAssetType in this) {
+      return this.#rawAssetType;
     }
-
-    if (this.code.length <= 4) {
-      return XdrAssetType.assetTypeCreditAlphanum4;
-    }
-
-    return XdrAssetType.assetTypeCreditAlphanum12;
+    return Asset.#deriveRawAssetType(code, issuer);
   }
 
   /**
@@ -308,7 +334,11 @@ export class Asset {
    * @param asset - Asset to compare
    */
   equals(asset: Asset): boolean {
-    return this.code === asset.getCode() && this.issuer === asset.getIssuer();
+    return (
+      this.code === asset.getCode() &&
+      this.issuer === asset.getIssuer() &&
+      this.getRawAssetType().value === asset.getRawAssetType().value
+    );
   }
 
   /**

--- a/test/unit/base/asset.test.ts
+++ b/test/unit/base/asset.test.ts
@@ -282,6 +282,21 @@ describe("Asset", () => {
       expect(asset.getCode()).toBe(assetCode);
       expect(asset.getIssuer()).toBe(ISSUER);
     });
+
+    it("preserves an alphanum12 arm when the decoded code is short", () => {
+      const assetCode = "USD";
+      const assetType = new xdr.AlphaNum12({
+        assetCode: stringToUint8Array(assetCode.padEnd(12, "\0")),
+        issuer: Keypair.fromPublicKey(ISSUER).xdrAccountId(),
+      });
+      const assetXdr = xdr.Asset.assetTypeCreditAlphanum12(assetType);
+
+      const asset = Asset.fromOperation(assetXdr);
+
+      expect(asset.getCode()).toBe(assetCode);
+      expect(asset.getAssetType()).toBe("credit_alphanum12");
+      expect(asset.toXdrObject().toXdr()).toEqual(assetXdr.toXdr());
+    });
   });
 
   describe("toString()", () => {
@@ -410,6 +425,33 @@ describe("Asset", () => {
       expect(asset.isNative()).toBe(true);
       expect(asset.getIssuer()).toBeUndefined();
     });
+
+    it("keeps the JSON shape to code and issuer", () => {
+      expect(JSON.parse(JSON.stringify(new Asset("USD", ISSUER)))).toEqual({
+        code: "USD",
+        issuer: ISSUER,
+      });
+    });
+
+    it("derives the asset type on a rehydrated instance", () => {
+      const rehydrate = (asset: Asset): Asset =>
+        Object.assign(
+          Object.create(Asset.prototype),
+          JSON.parse(JSON.stringify(asset)),
+        );
+
+      const credit4 = rehydrate(new Asset("USD", ISSUER));
+      expect(credit4.getAssetType()).toBe("credit_alphanum4");
+      expect(credit4.equals(new Asset("USD", ISSUER))).toBe(true);
+      expect(credit4.toXdrObject().toXdr()).toEqual(
+        new Asset("USD", ISSUER).toXdrObject().toXdr(),
+      );
+
+      const credit12 = rehydrate(new Asset("LONGCODE", ISSUER));
+      expect(credit12.getAssetType()).toBe("credit_alphanum12");
+
+      expect(rehydrate(Asset.native()).getAssetType()).toBe("native");
+    });
   });
 
   describe("isNative()", () => {
@@ -443,6 +485,21 @@ describe("Asset", () => {
 
     it("returns true for two native assets", () => {
       expect(Asset.native().equals(Asset.native())).toBe(true);
+    });
+
+    it("distinguishes a short alphanum12 asset from an alphanum4 asset", () => {
+      const assetType = new xdr.AlphaNum12({
+        assetCode: stringToUint8Array("USD".padEnd(12, "\0")),
+        issuer: Keypair.fromPublicKey(ISSUER).xdrAccountId(),
+      });
+      const alphanum12 = Asset.fromOperation(
+        xdr.Asset.assetTypeCreditAlphanum12(assetType),
+      );
+      const alphanum4 = new Asset("USD", ISSUER);
+
+      expect(alphanum12.equals(alphanum4)).toBe(false);
+      expect(Asset.compare(alphanum4, alphanum12)).toBe(-1);
+      expect(Asset.compare(alphanum12, alphanum4)).toBe(1);
     });
   });
 


### PR DESCRIPTION
## What

`Asset.fromOperation` now remembers which XDR union arm it decoded. An `AlphaNum12` asset with a short code (e.g. `USD` padded with NULs) used to re-encode as `AlphaNum4`, since the arm was re-inferred from code length. The decoded arm is stored in a private field, `getRawAssetType()`/`getAssetType()` report it, and `equals()`/`compare()` include it. Instances that never ran the constructor (clones, JSON-rehydrated objects) fall back to deriving the arm from code and issuer, as before.

## Why

Re-inferring the arm from code length changes the encoded bytes: round-tripping such an asset through the SDK produced different XDR, a different transaction hash, and a different SAC contract ID than the original, with no error. Preserving the decoded discriminant keeps round-trips byte-exact.