### PR TITLE
fix: deduplicate and anchor liquidity pool ID validation

### DIFF
--- a/src/base/liquidity_pool_id.ts
+++ b/src/base/liquidity_pool_id.ts
@@ -2,6 +2,15 @@ import { uint8ArrayToHex } from "uint8array-extras";
 import { PoolId, TrustLineAsset } from "../xdr/index.js";
 
 /**
+ * Returns whether a string is a valid hexadecimal liquidity pool ID.
+ *
+ * @param liquidityPoolId - The liquidity pool ID to validate.
+ */
+export function isValidLiquidityPoolId(liquidityPoolId: string): boolean {
+  return /^[a-fA-F0-9]{64}$/.test(liquidityPoolId);
+}
+
+/**
  * LiquidityPoolId class represents the asset referenced by a trustline to a
  * liquidity pool.
  */
@@ -15,7 +24,7 @@ export class LiquidityPoolId {
     if (!liquidityPoolId) {
       throw new Error("liquidityPoolId cannot be empty");
     }
-    if (!/^[a-f0-9]{64}$/.test(liquidityPoolId)) {
+    if (!isValidLiquidityPoolId(liquidityPoolId)) {
       throw new Error("Liquidity pool ID is not a valid hash");
     }
 

--- a/src/base/liquidity_pool_id.ts
+++ b/src/base/liquidity_pool_id.ts
@@ -28,7 +28,7 @@ export class LiquidityPoolId {
       throw new Error("Liquidity pool ID is not a valid hash");
     }
 
-    this.liquidityPoolId = liquidityPoolId;
+    this.liquidityPoolId = liquidityPoolId.toLowerCase();
   }
 
   /**

--- a/src/horizon/liquidity_pool_call_builder.ts
+++ b/src/horizon/liquidity_pool_call_builder.ts
@@ -1,4 +1,5 @@
 import { Asset } from "../base/index.js";
+import { isValidLiquidityPoolId } from "../base/liquidity_pool_id.js";
 
 import { CallBuilder } from "./call_builder.js";
 import { ServerApi } from "./server_api.js";
@@ -53,7 +54,7 @@ export class LiquidityPoolCallBuilder extends CallBuilder<
   public liquidityPoolId(
     id: string,
   ): CallBuilder<ServerApi.LiquidityPoolRecord> {
-    if (!id.match(/[a-fA-F0-9]{64}/)) {
+    if (!isValidLiquidityPoolId(id)) {
       throw new TypeError(`${id} does not look like a liquidity pool ID`);
     }
 

--- a/test/unit/base/liquidity_pool_id.test.ts
+++ b/test/unit/base/liquidity_pool_id.test.ts
@@ -35,9 +35,8 @@ describe("LiquidityPoolId", () => {
 
     it("accepts valid lowercase and mixed-case hashes", () => {
       expect(() => new LiquidityPoolId(POOL_ID)).not.toThrow();
-      expect(
-        () => new LiquidityPoolId(`DD7B1AB8${POOL_ID.slice(8)}`),
-      ).not.toThrow();
+      const asset = new LiquidityPoolId(`DD7B1AB8${POOL_ID.slice(8)}`);
+      expect(asset.getLiquidityPoolId()).toBe(POOL_ID);
     });
   });
 
@@ -135,6 +134,12 @@ describe("LiquidityPoolId", () => {
       expect(a.equals(b)).toBe(true);
     });
 
+    it("returns true when pool IDs differ only in case", () => {
+      const a = new LiquidityPoolId(POOL_ID);
+      const b = new LiquidityPoolId(POOL_ID.toUpperCase());
+      expect(a.equals(b)).toBe(true);
+    });
+
     it("returns false when pool IDs differ", () => {
       const a = new LiquidityPoolId(POOL_ID);
       const b = new LiquidityPoolId(
@@ -149,6 +154,13 @@ describe("LiquidityPoolId", () => {
       const original = new LiquidityPoolId(POOL_ID);
       const restored = LiquidityPoolId.fromOperation(original.toXdrObject());
       expect(original.equals(restored)).toBe(true);
+    });
+
+    it("round-trips uppercase input as a canonical lowercase ID", () => {
+      const original = new LiquidityPoolId(POOL_ID.toUpperCase());
+      const restored = LiquidityPoolId.fromOperation(original.toXdrObject());
+      expect(original.equals(restored)).toBe(true);
+      expect(restored.getLiquidityPoolId()).toBe(POOL_ID);
     });
   });
 });

--- a/test/unit/base/liquidity_pool_id.test.ts
+++ b/test/unit/base/liquidity_pool_id.test.ts
@@ -21,23 +21,23 @@ describe("LiquidityPoolId", () => {
       );
     });
 
-    it("throws an error when pool ID is not a valid hash", () => {
-      expect(() => new LiquidityPoolId("abc")).toThrow(
+    it.each([
+      ["fewer than 64 characters", POOL_ID.slice(1)],
+      ["more than 64 characters", `${POOL_ID}a`],
+      ["a prefix", `prefix-${POOL_ID}`],
+      ["a suffix", `${POOL_ID}-suffix`],
+      ["non-hexadecimal characters", `${POOL_ID.slice(0, -1)}g`],
+    ])("throws an error when pool ID has %s", (_description, invalidId) => {
+      expect(() => new LiquidityPoolId(invalidId)).toThrow(
         /Liquidity pool ID is not a valid hash/,
       );
     });
 
-    it("throws an error when pool ID is not all lowercase", () => {
-      expect(
-        () =>
-          new LiquidityPoolId(
-            "DD7b1ab831c273310ddbec6f97870aa83c2fbd78ce22aded37ecbf4f3380fac7",
-          ),
-      ).toThrow(/Liquidity pool ID is not a valid hash/);
-    });
-
-    it("does not throw an error when pool ID is a valid hash", () => {
+    it("accepts valid lowercase and mixed-case hashes", () => {
       expect(() => new LiquidityPoolId(POOL_ID)).not.toThrow();
+      expect(
+        () => new LiquidityPoolId(`DD7B1AB8${POOL_ID.slice(8)}`),
+      ).not.toThrow();
     });
   });
 

--- a/test/unit/liquidity_pool_endpoints.test.ts
+++ b/test/unit/liquidity_pool_endpoints.test.ts
@@ -182,11 +182,36 @@ describe("/liquidity_pools tests", () => {
     const lpId =
       "ae44a51f6191ce24414fbd1326e93ccb0ae656f07fc1e37602b11d0802f74b9a";
 
-    it("checks for valid IDs", () => {
-      expect(() =>
-        server.liquidityPools().liquidityPoolId("nonsense"),
-      ).toThrow();
+    it("accepts valid lowercase and mixed-case IDs", () => {
       expect(() => server.liquidityPools().liquidityPoolId(lpId)).not.toThrow();
+      expect(() =>
+        server.liquidityPools().liquidityPoolId(lpId.toUpperCase()),
+      ).not.toThrow();
+    });
+
+    it.each([
+      ["fewer than 64 characters", lpId.slice(1)],
+      ["more than 64 characters", `${lpId}a`],
+      ["a prefix", `prefix-${lpId}`],
+      ["a suffix", `${lpId}-suffix`],
+      ["non-hexadecimal characters", `${lpId.slice(0, -1)}g`],
+    ])("rejects an ID with %s", (_description, invalidId) => {
+      const getBuilder = () =>
+        server.liquidityPools().liquidityPoolId(invalidId);
+
+      expect(getBuilder).toThrow(TypeError);
+      expect(getBuilder).toThrow(
+        `${invalidId} does not look like a liquidity pool ID`,
+      );
+    });
+
+    it("normalizes mixed-case IDs to lowercase", async () => {
+      const mixedCaseId = `AE44A51F${lpId.slice(8)}`;
+      mockGet.mockResolvedValue({ data: {} });
+
+      await server.liquidityPools().liquidityPoolId(mixedCaseId).call();
+
+      expect(mockGet).toHaveBeenCalledWith(`${LP_URL}/${lpId}`);
     });
 
     it("filters by specific ID", async () => {


### PR DESCRIPTION
## Summary

- add a shared predicate for validating 64-character hexadecimal liquidity pool IDs
- use it from both `LiquidityPoolId` and the Horizon liquidity-pool call builder
- accept lowercase and uppercase hexadecimal characters
- reject prefixes, suffixes, incorrect lengths, and non-hexadecimal characters
- preserve the call builder's lowercase normalization and existing `TypeError`
- intentionally leave `L…` StrKey support out of scope

## Testing

- targeted liquidity-pool tests under fetch and Axios transports
- full Node unit suites under fetch and Axios transports
- source, Axios, test, and public API TypeScript checks
- Prettier and ESLint
- library build

Fixes #1703
