### PR TITLE
fix(rpc): coerce getTransaction/sendTransaction close times to number

### DIFF
--- a/src/rpc/api.ts
+++ b/src/rpc/api.ts
@@ -143,16 +143,17 @@ export namespace Api {
   export interface RawGetTransactionResponse {
     status: GetTransactionStatus;
     latestLedger: number;
-    latestLedgerCloseTime: number;
+    // RPC may return these as JSON strings; parsers coerce to number.
+    latestLedgerCloseTime: number | string;
     oldestLedger: number;
-    oldestLedgerCloseTime: number;
+    oldestLedgerCloseTime: number | string;
     txHash: string;
 
     // the fields below are set if status is SUCCESS
     applicationOrder?: number;
     feeBump?: boolean;
     ledger?: number;
-    createdAt?: number;
+    createdAt?: number | string;
 
     envelopeXdr?: string;
     resultXdr?: string;
@@ -373,7 +374,10 @@ export namespace Api {
     diagnosticEvents?: DiagnosticEvent[];
   }
 
-  export interface RawSendTransactionResponse extends BaseSendTransactionResponse {
+  export interface RawSendTransactionResponse
+    extends Omit<BaseSendTransactionResponse, "latestLedgerCloseTime"> {
+    // RPC may return this as a JSON string; parsers coerce to number.
+    latestLedgerCloseTime: number | string;
     /**
      * This is a base64-encoded instance of {@link TransactionResult}, set
      * only when `status` is `"ERROR"`.

--- a/src/rpc/parsers.ts
+++ b/src/rpc/parsers.ts
@@ -33,9 +33,12 @@ export function parseRawSendTransaction(
   delete raw.errorResultXdr;
   delete raw.diagnosticEventsXdr;
 
+  const latestLedgerCloseTime = Number(raw.latestLedgerCloseTime);
+
   if (errorResultXdr) {
     return {
       ...raw,
+      latestLedgerCloseTime,
       ...(diagnosticEventsXdr !== undefined &&
         diagnosticEventsXdr.length > 0 && {
           diagnosticEvents: diagnosticEventsXdr.map((evt) =>
@@ -46,7 +49,10 @@ export function parseRawSendTransaction(
     };
   }
 
-  return { ...raw } as Api.BaseSendTransactionResponse;
+  return {
+    ...raw,
+    latestLedgerCloseTime,
+  } as Api.BaseSendTransactionResponse;
 }
 
 export function parseTransactionInfo(
@@ -55,7 +61,7 @@ export function parseTransactionInfo(
   const meta = TransactionMeta.fromXdr(raw.resultMetaXdr!, "base64");
   const info: Omit<Api.TransactionInfo, "status" | "txHash"> = {
     ledger: raw.ledger!,
-    createdAt: raw.createdAt!,
+    createdAt: Number(raw.createdAt),
     applicationOrder: raw.applicationOrder!,
     feeBump: raw.feeBump!,
     envelopeXdr: TransactionEnvelope.fromXdr(raw.envelopeXdr!, "base64"),

--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -1140,9 +1140,9 @@ export class RpcServer {
         status: raw.status,
         txHash: hash,
         latestLedger: raw.latestLedger,
-        latestLedgerCloseTime: raw.latestLedgerCloseTime,
+        latestLedgerCloseTime: Number(raw.latestLedgerCloseTime),
         oldestLedger: raw.oldestLedger,
-        oldestLedgerCloseTime: raw.oldestLedgerCloseTime,
+        oldestLedgerCloseTime: Number(raw.oldestLedgerCloseTime),
         ...foundInfo,
       };
 


### PR DESCRIPTION
## Summary

`getTransaction` and `sendTransaction` declare unix timestamps as `number`, but the RPC returns JSON strings for those fields. The SDK copied them through unchanged, so callers saw `typeof === "string"` while TypeScript still believed they were numbers.

`getTransactions` (plural) already returns numeric `createdAt`, so the mismatch also made the singular and plural methods disagree.

## Changes

- Coerce `createdAt` with `Number()` in `parseTransactionInfo`.
- Coerce `latestLedgerCloseTime` / `oldestLedgerCloseTime` in `getTransaction`.
- Coerce `latestLedgerCloseTime` in `parseRawSendTransaction`.
- Widen the corresponding `Raw*` fields to `number | string` so the wire shape is honest before parsing.

## Why

Option 2 from #1644: keep the public `number` types and fix the values at the parse boundary, so arithmetic and `getTransactions` stay consistent.

## Test plan

- [ ] Existing RPC unit tests in CI
- [ ] Manual check against testnet `getTransaction`: `typeof createdAt === "number"` after parse

Fixes #1644