### PR TITLE
fix(rpc): validate complete claimable balance hex IDs

### DIFF
--- a/src/rpc/server.ts
+++ b/src/rpc/server.ts
@@ -364,9 +364,9 @@ export class RpcServer {
       balanceId = ClaimableBalanceId.fromXdr(
         concatUint8Arrays([v, buffer.subarray(1)]),
       );
-    } else if (id.match(/[a-f0-9]{72}/i)) {
+    } else if (id.match(/^[a-f0-9]{72}$/i)) {
       balanceId = ClaimableBalanceId.fromXdr(id, "hex");
-    } else if (id.match(/[a-f0-9]{64}/i)) {
+    } else if (id.match(/^[a-f0-9]{64}$/i)) {
       balanceId = ClaimableBalanceId.fromXdr(id.padStart(72, "0"), "hex");
     } else {
       throw new TypeError(`expected 72-char hex ID or strkey, not ${id}`);

--- a/test/unit/server/soroban/get_classic_entries.test.ts
+++ b/test/unit/server/soroban/get_classic_entries.test.ts
@@ -302,15 +302,33 @@ describe("Server#getClaimableBalance", () => {
     concatUint8Arrays([Uint8Array.of(0), balanceId.v0.value]),
   );
 
-  it("returns the claimable balance entry when found", () =>
+  it.each([
+    ["strkey", balanceIdStrKey],
+    ["72-character hex", balanceIdHex],
+    ["64-character hex", balanceIdHex.slice(8)],
+    ["uppercase hex", balanceIdHex.toUpperCase()],
+  ])("returns the claimable balance entry for a %s ID", (_, id) =>
     expectLedgerEntryFound(
       mockPost,
       ledgerKeyXDR,
       ledgerEntryXDR,
-      () => server.getClaimableBalance(balanceIdStrKey),
+      () => server.getClaimableBalance(id),
       xdr.ClaimableBalanceEntry,
       claimableBalanceEntry.toXdr("base64"),
-    ));
+    ),
+  );
+
+  it.each([
+    ["a prefix before 64 hex characters", `x${balanceIdHex.slice(8)}`],
+    ["a suffix after 64 hex characters", `${balanceIdHex.slice(8)}x`],
+    ["a prefix before 72 hex characters", `x${balanceIdHex}`],
+    ["a suffix after 72 hex characters", `${balanceIdHex}x`],
+    ["an extra hex byte", `${balanceIdHex}00`],
+    ["a trailing newline", `${balanceIdHex}\n`],
+  ])("rejects an ID with %s before making an RPC request", async (_, id) => {
+    await expect(server.getClaimableBalance(id)).rejects.toThrow(TypeError);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
 
   it("throws an error when the claimable balance does not exist", () =>
     expectLedgerEntryNotFound(


### PR DESCRIPTION
## What and why

`getClaimableBalance()` accepts 64-character hash hex, 72-character XDR hex, and claimable-balance StrKeys. Its unanchored hex patterns also matched malformed inputs that only contained a valid-length substring. Those inputs reached the XDR decoder and raised `XdrError` instead of the argument-validation `TypeError`.

Anchor both hex patterns. Add six malformed-input regression cases (prefixes, suffixes, an extra hex byte, and a trailing newline), and expand success coverage for 64/72-character hex and uppercase hex alongside StrKey. Invalid inputs are rejected before an RPC request.

Fixes #1707.

## Validation

- RED: the six new malformed-input cases failed on upstream `63c85fe`, receiving `XdrError` instead of `TypeError`.
- Focused `get_classic_entries.test.ts`: 17 passed.
- `pnpm run test:node` and `pnpm run test:node:axios`: each 132 files, 6,741 tests passed; 4 skipped and 9 todo.
- Browser unit suite in Chromium and Firefox, for both fetch and axios: each transport 250 files passed, 2 skipped; 5,776 tests passed, 6 skipped, 18 todo.
- ESLint, changed-file Prettier, `test:types`, `typecheck:tests`, `docs:snippets:check`, `build:prod`, generated docs checks, and the documentation site build passed.
- `vitest run test/integration --config config/vitest.config.ts --coverage --coverage.reportsDirectory=<isolated-directory> --maxWorkers=1`: all 4 files / 122 tests passed, without retries or skips. Earlier default parallel runs had intermittent Apiary HTTPS socket resets and one coverage temp-directory error; the single-worker run used unchanged tests and assertions.

## Compatibility

Valid ID decoding and RPC payloads are unchanged. The intentional observable change is the error class for malformed hex-like strings; it now follows the existing invalid-argument branch. This does not change authorization, transaction construction, or XDR decoding rules.

## AI assistance

Implemented, tested, and reviewed with OpenAI Codex assistance.
