### PR TITLE
fix(horizon): pass CallBuilder base URL into expandUriTemplate

### DIFF
--- a/src/horizon/call_builder.ts
+++ b/src/horizon/call_builder.ts
@@ -334,7 +334,7 @@ export class CallBuilder<
       let uri;
 
       if (link.templated) {
-        uri = new URL(expandUriTemplate(link.href, opts), this.url);
+        uri = new URL(expandUriTemplate(link.href, opts, this.url));
       } else {
         uri = new URL(link.href, this.url);
       }

--- a/test/unit/call_builders.test.ts
+++ b/test/unit/call_builders.test.ts
@@ -56,6 +56,34 @@ describe("CallBuilder functions", () => {
     );
   });
 
+  it("resolves relative templated Horizon links against the CallBuilder base URL", async () => {
+    const mockHttpClient = {
+      defaults: {},
+      get: vi.fn().mockResolvedValue({ data: { value: "ok" } }),
+    } as any;
+    const builder = new CallBuilder(
+      new URL("https://proxy.example.com"),
+      mockHttpClient,
+    );
+    const response = builder["_parseResponse"]({
+      _links: {
+        data: {
+          href: "/accounts/{account_id}/data/{key}",
+          templated: true,
+        },
+      },
+    });
+
+    await response.data({
+      account_id: "GABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCD",
+      key: "config",
+    });
+
+    expect(mockHttpClient.get).toHaveBeenCalledWith(
+      "https://proxy.example.com/accounts/GABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCD/data/config",
+    );
+  });
+
   it("uses the configured Horizon authority for absolute page links", async () => {
     const mockHttpClient = {
       defaults: {},

--- a/test/unit/utils/url.test.ts
+++ b/test/unit/utils/url.test.ts
@@ -127,4 +127,26 @@ describe("expandUriTemplate", () => {
 
     expect(expanded).toBe("https://horizon.stellar.org/accounts/GA");
   });
+
+  it("requires a base URL when the template is a relative path", () => {
+    expect(() =>
+      expandUriTemplate("/accounts/{account_id}/data/{key}", {
+        account_id: "GA",
+        key: "config",
+      }),
+    ).toThrow(/Invalid URL/);
+
+    const expanded = expandUriTemplate(
+      "/accounts/{account_id}/data/{key}",
+      {
+        account_id: "GA",
+        key: "config",
+      },
+      "https://horizon.example.com",
+    );
+
+    expect(expanded).toBe(
+      "https://horizon.example.com/accounts/GA/data/config",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1717.

`CallBuilder._requestFnForLink` was calling `expandUriTemplate(link.href, opts)` without a base URL. For relative templated `_links` hrefs (for example `/accounts/.../data/{key}` on Horizon account records), that means `new URL(expanded)` throws `Invalid URL` before the request is sent. Absolute templates and non-templated relative links already worked because they either need no base or resolve with `new URL(link.href, this.url)`.

This passes `this.url` as the third argument so `expandUriTemplate` can resolve the template the same way the non-templated branch already does.

## Tests

- CallBuilder: relative templated `data` link resolves against the builder base URL
- `expandUriTemplate`: relative path without a base throws; with a base it expands cleanly

## Notes for reviewers

Happy to adjust the test fixtures if you would rather hang this off an existing account-records case instead of the small CallBuilder mock. Thanks for maintaining the SDK.