### PR TITLE
fix(test): run call_builders in the browser suite

### DIFF
--- a/config/vitest.config.browser.ts
+++ b/config/vitest.config.browser.ts
@@ -75,7 +75,7 @@ export default defineConfig({
     // Run all unit tests in browser
     include: ["test/unit/**/*.test.ts"],
     exclude: [
-      "test/unit/call_builders.test.ts",
+      // Node-only: `msw/node` loads @mswjs/interceptors, which needs node:http.
       "test/unit/server/horizon/server.test.ts",
       // Node-only class-XDR tests: they read corpus/fixture files from disk
       // via `node:fs`, which isn't available in the browser environment.


### PR DESCRIPTION
## Summary

Fixes #1708.

`config/vitest.config.browser.ts` was excluding `test/unit/call_builders.test.ts` from the jsdom/browser run with no comment. That file only imports `vitest` and `src/`, and it already passes under chromium and firefox, so the exclude was obsolete. New cases added there would not show up in the browser suite count.

This drops that exclude and keeps `test/unit/server/horizon/server.test.ts` out of the browser run, with a short comment that `msw/node` needs `node:http`.

## Test plan

- [ ] Browser suite still passes
- [ ] `call_builders.test.ts` is included in the browser run