### PR TITLE
docs: fix optional-null rewrite guidance and add Jest CJS note

### DIFF
--- a/docs/guides/00-migration.md
+++ b/docs/guides/00-migration.md
@@ -42,8 +42,11 @@ at all**:
 - `Buffer` methods on a `Uint8Array` fail silently. `.toString("hex")` returns
   comma-joined decimals (`"185,77,39,…"`), and `.toString("utf8")` returns
   `"104,105"`. Nothing throws, so the wrong string is used downstream.
-- Absent optional XDR fields decode to `null` instead of `undefined`, so
-  `=== undefined` checks stop matching. Prefer `== null`.
+- Absent optional fields on raw `xdr.*` values decode to `null` instead of
+  `undefined`, so `=== undefined` checks stop matching there. Prefer `== null`
+  on the raw XDR layer. Parsed operation records from
+  `Operation.fromXdrObject` still normalize absent optionals to `undefined` —
+  do not rewrite those call sites.
 - `scValToNative` can now return a `Uint8Array` for a `scvString` or `scvSymbol`
   whose contents aren't valid UTF-8, where it always returned a string before.
 
@@ -59,6 +62,37 @@ from 22.12.0 — on 22.0–22.11 `require("@stellar/stellar-sdk")` fails with
 warning instead of a package that cannot be required
 ([#1664](https://github.com/stellar/js-stellar-sdk/issues/1664)). ESM consumers
 were never affected. Upgrade Node, or use the ESM entry point.
+
+### Test runners and bundlers: Jest cannot load the CJS build as-is
+
+Node 22.12+ can `require()` the ESM-only dependencies that the CJS build pulls
+in. **Jest's CJS module registry cannot.** It hands those files to babel, which
+sees a bare `import` and fails. In a 17.0.0 install the ESM-only packages that
+commonly trip this are `@exodus/bytes`, `smol-toml`, `uint8array-extras`, and
+`eventsource`.
+
+Tell Jest to transform them (and the SDK itself if you resolve through
+`node_modules`) via `transformIgnorePatterns`. Freighter's fix was two entries
+in `jest.config.js`:
+
+```js
+const esModules = [
+  "@stellar/stellar-sdk",
+  "@exodus/bytes",
+  "smol-toml",
+  "uint8array-extras",
+  "eventsource",
+  // plus any other ESM-only deps your suite already transforms
+];
+
+module.exports = {
+  transformIgnorePatterns: [`/node_modules/(?!${esModules.join("|")})`],
+};
+```
+
+If you already maintain an allowlist like this for `@noble/*` / `js-xdr`, add the
+four packages above. Bundlers that already handle ESM in `node_modules` do not
+need this change; the gap is specific to Jest's default CJS transform skip list.
 
 ### Auth: CAP-71 v2 address credentials are now the default
 

--- a/docs/migration/xdr-migration.md
+++ b/docs/migration/xdr-migration.md
@@ -675,7 +675,9 @@ i128.size, i128.unsigned     →   (no longer exposed — pick the right class)
 scInt.int / xli.int          →   scInt.value / xli.value  (bigint) — `.int` is gone
 
 // ============== OPTIONALS (§ 14) ==============
-x === undefined              →   x == null    // decoded absent = null now
+x === undefined (raw xdr.*)  →   x == null    // raw decoded absent = null;
+                                              // Operation.fromXdrObject still
+                                              // uses undefined — leave those
 
 // ============== REMOVED (§ 13) ==============
 xdr.scvSortedMap(entries)    →   scvSortedMap(entries)   // top-level export
@@ -997,24 +999,31 @@ runtime for legacy code, install it under an alias:
 
 ---
 
-## 14. Optional fields: `null`, not `undefined`
+## 14. Optional fields on raw `xdr.*`: `null`, not `undefined`
 
-An absent optional (`T*` in the XDR) now decodes to **`null`**. The legacy layer
-used `undefined`:
+An absent optional (`T*` in the XDR) on a **raw `xdr.*` value** now decodes to
+**`null`**. The legacy XDR layer used `undefined`:
 
 ```ts
 // Legacy: an unset optional read back as undefined
 tx.cond().v2().timeBounds(); // undefined
 
-// Now: null
+// Now: null on the raw layer
 xdr.PreconditionsV2.fromXdr(bytes).timeBounds; // null
 ```
 
-This is a **silent** change. The shape of the check is what breaks, not the
-type:
+This does **not** apply to parsed operation records. `Operation.fromXdrObject`
+still normalizes absent optionals to `undefined` (for example
+`parsed.homeDomain`, `parsed.inflationDest`, `parsed.lowThreshold` on a
+`setOptions` operation). Leave `=== undefined` checks on those records alone —
+rewriting them to `== null` can invent phantom "cleared" rows for fields the
+transaction never touched.
+
+On the raw XDR layer this is a **silent** change. The shape of the check is what
+breaks, not the type:
 
 ```ts
-// ⚠ Compiles, never matches any more
+// ⚠ Compiles, never matches any more (raw xdr.*)
 if (v2.timeBounds === undefined) { … }
 
 // ⚠ Worse: the guard passes for null, then the access throws
@@ -1022,7 +1031,7 @@ if (v2.timeBounds !== undefined) {
   v2.timeBounds.minTime; // TypeError: … of null
 }
 
-// ✅ Covers both
+// ✅ Covers both on the raw layer
 if (v2.timeBounds == null) { … }
 if (!v2.timeBounds) { … }
 ```
@@ -1040,8 +1049,9 @@ though where it does so depends on the field's type:
   coerce their input in the constructor, so they throw a `TypeError` right
   there — `new xdr.SetOptionsOp({})` never reaches an encode call.
 
-Decoded values are always `null`. Prefer `== null` / falsy checks over
-`=== undefined` everywhere.
+On raw `xdr.*` values, decoded optionals are always `null`. Prefer `== null` /
+falsy checks over `=== undefined` there. Do not apply that rewrite to parsed
+operation records from `Operation.fromXdrObject`.
 
 In JSON output an unset optional is `null` too (§ 12).
 


### PR DESCRIPTION
## Summary

Two Freighter v17 migration docs gaps, both in the migration guides.

### Optional fields (`Fixes #1685`)

The guides told readers to rewrite `=== undefined` to `== null` without saying that only applies to raw `xdr.*` values. `Operation.fromXdrObject` still normalizes absent optionals to `undefined`, so a literal rewrite invents phantom "cleared" rows (for example a Home Domain cleared row on every setOptions that never touched home domain).

Scoped the claim in:

- the silent-failure bullet in `docs/guides/00-migration.md`
- the rewrite-table entry and §14 in `docs/migration/xdr-migration.md`

§14 examples were already raw-layer; the over-general title and "everywhere" wording were the problem.

### Jest / CJS (`Fixes #1686`)

The Node 22.12 floor section explains why `require()` of the CJS build needs that Node version, but never connects it to test runners. Jest's CJS registry still cannot load the ESM-only deps (`@exodus/bytes`, `smol-toml`, `uint8array-extras`, `eventsource`) and fails with a bare `import` SyntaxError.

Added a short "Test runners and bundlers" subsection next to the Node floor section with a `transformIgnorePatterns` snippet matching Freighter's workaround.

## Test plan

- [ ] Skim the new Jest subsection against a local Jest suite that `require`s `@stellar/stellar-sdk` 17.x
- [ ] Confirm §14 still reads correctly for raw `xdr.*` call sites
- [ ] Confirm parsed-op wording matches `Operation.fromXdrObject` behavior on a setOptions tx with unset homeDomain

Fixes #1685
Fixes #1686