### PR TITLE
fix(horizon): declare transaction_attr and correct join() JSDoc

### DIFF
--- a/src/horizon/call_builder.ts
+++ b/src/horizon/call_builder.ts
@@ -269,9 +269,10 @@ export class CallBuilder<
    * Sets `join` parameter for the current call. The `join` parameter
    * includes the requested resource in the response. Currently, the
    * only valid value for the parameter is `transactions` and is only
-   * supported on the operations and payments endpoints. The response
-   * will include a `transaction` field for each operation in the
-   * response.
+   * supported on the operations and payments endpoints. For each
+   * operation in the response, the joined transaction is exposed as
+   * `transaction_attr`, and `transaction` remains a callable that
+   * resolves from the join when present.
    *
    * @param include - join Records to be included in the response.
    * @returns current CallBuilder instance.

--- a/src/horizon/server_api.ts
+++ b/src/horizon/server_api.ts
@@ -179,6 +179,7 @@ export namespace ServerApi {
     precedes: CallFunction<OperationRecord>;
     effects: CallCollectionFunction<EffectRecord>;
     transaction: CallFunction<TransactionRecord>;
+    transaction_attr?: TransactionRecord;
   }
   export interface CreateAccountOperationRecord
     extends

--- a/test/unit/server/horizon/join.test.ts
+++ b/test/unit/server/horizon/join.test.ts
@@ -160,8 +160,14 @@ describe("Server - CallBuilder#join", () => {
 
       const record = response.records[0];
       expect(record.transaction).toBeTypeOf("function");
+      expect(record.transaction_attr).toBeDefined();
+      expect(record.transaction_attr.hash).toEqual(
+        "de8ca055af7972f817e9d3f7c7a0b480de82593bc378f0e48f83b8e31985e4e5",
+      );
+      expect(record.transaction_attr.ledger_attr).toEqual(679846);
 
       const tx = await record.transaction();
+      expect(tx).toEqual(record.transaction_attr);
       expect(tx).toEqual(transaction);
     });
   });


### PR DESCRIPTION
## Summary

Fixes #1646.

When `.join("transactions")` is used, Horizon embeds the transaction object on each operation. The SDK then moves that object to `transaction_attr` (same `_attr` pattern as `ledger_attr` / `data_attr`) and replaces `transaction` with a callable that resolves from the join. Types never declared `transaction_attr`, and `join()`'s JSDoc still said the response included a `transaction` field.

This adds the missing optional field on `ServerApi.BaseOperationRecord` and updates the JSDoc to describe the runtime shape.

## Changes

- `transaction_attr?: TransactionRecord` on `BaseOperationRecord`
- `join()` JSDoc now points at `transaction_attr`, and notes that `transaction` stays callable
- Existing join unit test asserts `transaction_attr` is populated and matches `await record.transaction()`

## Test plan

- [x] `vitest run test/unit/server/horizon/join.test.ts`